### PR TITLE
feat(gcs): object holds, retention policy, batch API, and notification configs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -12,7 +12,7 @@ Its goal is full GCP SDK and gcloud CLI compatibility through real GCP wire prot
 
 floci-gcp acts as an open-source alternative to the GCP-provided emulators, unified under a single port.
 
-- Port: 4578
+- Port: 4588
 - Stack:
   - Java 25
   - Quarkus 3.34.6
@@ -107,7 +107,7 @@ floci-gcp must implement real GCP wire protocols.
 
 ### Single-port design
 
-Both gRPC and REST are served on port **4578** via ALPN negotiation:
+Both gRPC and REST are served on port **4588** via ALPN negotiation:
 - `quarkus.http.http2=true`
 - `quarkus.grpc.server.use-separate-server=false`
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -91,6 +91,7 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <argLine>-Dsun.net.http.allowRestrictedHeaders=true</argLine>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsBatchTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsBatchTest.java
@@ -1,0 +1,128 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GcsBatchTest {
+
+    private static final String BUCKET_NAME = TestFixtures.uniqueName("batch-bucket");
+    private static final String OBJ1 = "batch/object1.txt";
+    private static final String OBJ2 = "batch/object2.txt";
+    private static final String OBJ3 = "batch/object3.txt";
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        for (String obj : List.of(OBJ1, OBJ2, OBJ3)) {
+            try { storage.delete(BlobId.of(BUCKET_NAME, obj)); } catch (Exception ignored) {}
+        }
+        try { storage.get(BUCKET_NAME).delete(); } catch (Exception ignored) {}
+        if (storage instanceof AutoCloseable closeable) closeable.close();
+    }
+
+    @Test
+    @Order(1)
+    void createBucketAndObjects() {
+        storage.create(BucketInfo.of(BUCKET_NAME));
+
+        for (String obj : List.of(OBJ1, OBJ2, OBJ3)) {
+            BlobInfo info = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, obj))
+                    .setContentType("text/plain")
+                    .build();
+            storage.create(info, ("content of " + obj).getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertThat(storage.get(BUCKET_NAME)).isNotNull();
+        assertThat(storage.get(BlobId.of(BUCKET_NAME, OBJ1))).isNotNull();
+    }
+
+    @Test
+    @Order(2)
+    void batchGetMetadata() {
+        StorageBatch batch = storage.batch();
+
+        StorageBatchResult<Blob> r1 = batch.get(BlobId.of(BUCKET_NAME, OBJ1));
+        StorageBatchResult<Blob> r2 = batch.get(BlobId.of(BUCKET_NAME, OBJ2));
+        StorageBatchResult<Blob> r3 = batch.get(BlobId.of(BUCKET_NAME, OBJ3));
+
+        batch.submit();
+
+        assertThat(r1.get()).isNotNull();
+        assertThat(r1.get().getName()).isEqualTo(OBJ1);
+        assertThat(r2.get()).isNotNull();
+        assertThat(r2.get().getName()).isEqualTo(OBJ2);
+        assertThat(r3.get()).isNotNull();
+        assertThat(r3.get().getName()).isEqualTo(OBJ3);
+    }
+
+    @Test
+    @Order(3)
+    void batchGetNonExistentReturnsNull() {
+        StorageBatch batch = storage.batch();
+
+        StorageBatchResult<Blob> existing = batch.get(BlobId.of(BUCKET_NAME, OBJ1));
+        StorageBatchResult<Blob> missing = batch.get(BlobId.of(BUCKET_NAME, "batch/does-not-exist.txt"));
+
+        batch.submit();
+
+        assertThat(existing.get()).isNotNull();
+        assertThat(missing.get()).isNull();
+    }
+
+    @Test
+    @Order(4)
+    void batchDeleteObjects() {
+        StorageBatch batch = storage.batch();
+
+        List<StorageBatchResult<Boolean>> results = new ArrayList<>();
+        results.add(batch.delete(BlobId.of(BUCKET_NAME, OBJ1)));
+        results.add(batch.delete(BlobId.of(BUCKET_NAME, OBJ2)));
+        results.add(batch.delete(BlobId.of(BUCKET_NAME, OBJ3)));
+
+        batch.submit();
+
+        for (StorageBatchResult<Boolean> result : results) {
+            assertThat(result.get()).isTrue();
+        }
+
+        assertThat(storage.get(BlobId.of(BUCKET_NAME, OBJ1))).isNull();
+        assertThat(storage.get(BlobId.of(BUCKET_NAME, OBJ2))).isNull();
+        assertThat(storage.get(BlobId.of(BUCKET_NAME, OBJ3))).isNull();
+    }
+
+    @Test
+    @Order(5)
+    void batchDeleteNonExistentReturnsFalse() {
+        StorageBatch batch = storage.batch();
+
+        StorageBatchResult<Boolean> result = batch.delete(BlobId.of(BUCKET_NAME, "batch/ghost.txt"));
+
+        batch.submit();
+
+        assertThat(result.get()).isFalse();
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsCorsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsCorsTest.java
@@ -1,0 +1,129 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Cors;
+import com.google.cloud.storage.HttpMethod;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GcsCorsTest {
+
+    private static final String BUCKET_NAME = TestFixtures.uniqueName("cors-bucket");
+    private static final String OBJECT_NAME = "cors/test.txt";
+    private static final String ORIGIN = "http://example.com";
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        try {
+            storage.delete(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+        } catch (Exception ignored) {}
+        try {
+            storage.get(BUCKET_NAME).delete();
+        } catch (Exception ignored) {}
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createBucketWithCorsConfig() {
+        Cors corsRule = Cors.newBuilder()
+                .setOrigins(List.of(Cors.Origin.of(ORIGIN)))
+                .setMethods(List.of(HttpMethod.GET, HttpMethod.PUT))
+                .setResponseHeaders(List.of("Content-Type", "Authorization"))
+                .setMaxAgeSeconds(3600)
+                .build();
+
+        storage.create(BucketInfo.newBuilder(BUCKET_NAME)
+                .setCors(List.of(corsRule))
+                .build());
+
+        var bucket = storage.get(BUCKET_NAME);
+        assertThat(bucket.getCors()).isNotEmpty();
+        assertThat(bucket.getCors().get(0).getOrigins())
+                .contains(Cors.Origin.of(ORIGIN));
+    }
+
+    @Test
+    @Order(2)
+    void uploadObjectForCorsTest() {
+        BlobInfo info = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME))
+                .setContentType("text/plain")
+                .build();
+        Blob blob = storage.create(info, "cors test content".getBytes(StandardCharsets.UTF_8));
+        assertThat(blob).isNotNull();
+    }
+
+    @Test
+    @Order(3)
+    void getObjectResponseIncludesCorsHeader() throws Exception {
+        String endpoint = TestFixtures.endpoint();
+        URL url = new URL(endpoint + "/storage/v1/b/" + BUCKET_NAME + "/o/" + OBJECT_NAME);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Origin", ORIGIN);
+        int status = conn.getResponseCode();
+        assertThat(status).isEqualTo(200);
+        String corsHeader = conn.getHeaderField("Access-Control-Allow-Origin");
+        assertThat(corsHeader).isEqualTo(ORIGIN);
+    }
+
+    @Test
+    @Order(4)
+    void optionsPreflightReturnsCorsHeaders() throws Exception {
+        String endpoint = TestFixtures.endpoint();
+        URL url = new URL(endpoint + "/storage/v1/b/" + BUCKET_NAME + "/o/" + OBJECT_NAME);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("OPTIONS");
+        conn.setRequestProperty("Origin", ORIGIN);
+        conn.setRequestProperty("Access-Control-Request-Method", "PUT");
+        conn.setRequestProperty("Access-Control-Request-Headers", "Content-Type");
+        int status = conn.getResponseCode();
+        assertThat(status).isEqualTo(200);
+        String allowOrigin = conn.getHeaderField("Access-Control-Allow-Origin");
+        assertThat(allowOrigin).isEqualTo(ORIGIN);
+        String allowMethods = conn.getHeaderField("Access-Control-Allow-Methods");
+        assertThat(allowMethods).isNotNull();
+    }
+
+    @Test
+    @Order(5)
+    void updateCorsConfigOnBucket() {
+        Cors newRule = Cors.newBuilder()
+                .setOrigins(List.of(Cors.Origin.of("*")))
+                .setMethods(List.of(HttpMethod.GET))
+                .build();
+
+        var bucket = storage.get(BUCKET_NAME);
+        bucket.toBuilder().setCors(List.of(newRule)).build().update();
+
+        var updated = storage.get(BUCKET_NAME);
+        assertThat(updated.getCors()).isNotEmpty();
+        assertThat(updated.getCors().get(0).getOrigins())
+                .contains(Cors.Origin.of("*"));
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsHoldLockTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsHoldLockTest.java
@@ -1,0 +1,197 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import static com.google.cloud.storage.Storage.BucketTargetOption.metagenerationMatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GcsHoldLockTest {
+
+    private static final String CONTENT = "hold-lock-test-content";
+    private static final byte[] BYTES = CONTENT.getBytes(StandardCharsets.UTF_8);
+
+    private Storage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable c) c.close();
+    }
+
+    // ── temporaryHold ─────────────────────────────────────────────────────────
+
+    @Test
+    void temporaryHoldBlocksDelete() {
+        String bucket = TestFixtures.uniqueName("hold-tmp");
+        String obj = "obj.txt";
+        try {
+            storage.create(BucketInfo.of(bucket));
+            Blob blob = storage.create(BlobInfo.newBuilder(bucket, obj).build(), BYTES);
+
+            blob.toBuilder().setTemporaryHold(true).build().update();
+
+            Blob held = storage.get(BlobId.of(bucket, obj));
+            assertThat(held.getTemporaryHold()).isTrue();
+
+            assertThatThrownBy(() -> storage.delete(BlobId.of(bucket, obj)))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("temporary hold");
+
+            held.toBuilder().setTemporaryHold(false).build().update();
+            boolean deleted = storage.delete(BlobId.of(bucket, obj));
+            assertThat(deleted).isTrue();
+        } finally {
+            cleanup(bucket, obj);
+        }
+    }
+
+    @Test
+    void temporaryHoldBlocksOverwrite() {
+        String bucket = TestFixtures.uniqueName("hold-tmp-ow");
+        String obj = "obj.txt";
+        try {
+            storage.create(BucketInfo.of(bucket));
+            Blob blob = storage.create(BlobInfo.newBuilder(bucket, obj).build(), BYTES);
+            blob.toBuilder().setTemporaryHold(true).build().update();
+
+            assertThatThrownBy(() ->
+                    storage.create(BlobInfo.newBuilder(bucket, obj).build(), "new".getBytes(StandardCharsets.UTF_8)))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("temporary hold");
+
+            storage.get(BlobId.of(bucket, obj)).toBuilder().setTemporaryHold(false).build().update();
+        } finally {
+            cleanup(bucket, obj);
+        }
+    }
+
+    // ── eventBasedHold ────────────────────────────────────────────────────────
+
+    @Test
+    void eventBasedHoldBlocksDelete() {
+        String bucket = TestFixtures.uniqueName("hold-evt");
+        String obj = "obj.txt";
+        try {
+            storage.create(BucketInfo.of(bucket));
+            Blob blob = storage.create(BlobInfo.newBuilder(bucket, obj).build(), BYTES);
+
+            blob.toBuilder().setEventBasedHold(true).build().update();
+
+            Blob held = storage.get(BlobId.of(bucket, obj));
+            assertThat(held.getEventBasedHold()).isTrue();
+
+            assertThatThrownBy(() -> storage.delete(BlobId.of(bucket, obj)))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("event-based hold");
+
+            held.toBuilder().setEventBasedHold(false).build().update();
+            boolean deleted = storage.delete(BlobId.of(bucket, obj));
+            assertThat(deleted).isTrue();
+        } finally {
+            cleanup(bucket, obj);
+        }
+    }
+
+    @Test
+    void defaultEventBasedHoldInheritedByNewObjects() {
+        String bucket = TestFixtures.uniqueName("hold-def-evt");
+        String obj = "obj.txt";
+        try {
+            storage.create(BucketInfo.newBuilder(bucket)
+                    .setDefaultEventBasedHold(true)
+                    .build());
+
+            Blob blob = storage.create(BlobInfo.newBuilder(bucket, obj).build(), BYTES);
+            assertThat(blob.getEventBasedHold()).isTrue();
+
+            assertThatThrownBy(() -> storage.delete(BlobId.of(bucket, obj)))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("event-based hold");
+
+            storage.get(BlobId.of(bucket, obj)).toBuilder().setEventBasedHold(false).build().update();
+            assertThat(storage.delete(BlobId.of(bucket, obj))).isTrue();
+        } finally {
+            cleanup(bucket, obj);
+        }
+    }
+
+    // ── Bucket retention policy ───────────────────────────────────────────────
+
+    @Test
+    void retentionPolicyBlocksDeleteBeforeExpiry() throws Exception {
+        String bucket = TestFixtures.uniqueName("hold-ret");
+        String obj = "obj.txt";
+        try {
+            // 3-second retention period
+            storage.create(BucketInfo.newBuilder(bucket)
+                    .setRetentionPeriod(3L)
+                    .build());
+
+            Blob blob = storage.create(BlobInfo.newBuilder(bucket, obj).build(), BYTES);
+            assertThat(blob.getRetentionExpirationTime()).isNotNull();
+
+            assertThatThrownBy(() -> storage.delete(BlobId.of(bucket, obj)))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("retention policy");
+
+            Thread.sleep(4000);
+            assertThat(storage.delete(BlobId.of(bucket, obj))).isTrue();
+        } finally {
+            cleanup(bucket, obj);
+        }
+    }
+
+    @Test
+    void lockRetentionPolicyIsReflectedOnBucket() {
+        String bucket = TestFixtures.uniqueName("hold-lock");
+        try {
+            storage.create(BucketInfo.newBuilder(bucket)
+                    .setRetentionPeriod(86400L)
+                    .build());
+
+            Bucket b = storage.get(bucket);
+            Bucket locked = b.lockRetentionPolicy(metagenerationMatch());
+
+            assertThat(locked.retentionPolicyIsLocked()).isTrue();
+            assertThat(locked.getRetentionPeriod()).isEqualTo(86400L);
+        } finally {
+            cleanup(bucket, null);
+        }
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    private void cleanup(String bucket, String obj) {
+        try {
+            if (obj != null) {
+                Blob b = storage.get(BlobId.of(bucket, obj));
+                if (b != null) {
+                    if (Boolean.TRUE.equals(b.getTemporaryHold())) {
+                        b.toBuilder().setTemporaryHold(false).build().update();
+                    }
+                    if (Boolean.TRUE.equals(b.getEventBasedHold())) {
+                        b.toBuilder().setEventBasedHold(false).build().update();
+                    }
+                    storage.delete(BlobId.of(bucket, obj));
+                }
+            }
+        } catch (Exception ignored) {}
+        try { storage.delete(bucket); } catch (Exception ignored) {}
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsNotificationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsNotificationTest.java
@@ -1,0 +1,232 @@
+package io.floci.gcp.test;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Notification;
+import com.google.cloud.storage.NotificationInfo;
+import com.google.cloud.storage.Storage;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.ReceivedMessage;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.Topic;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GcsNotificationTest {
+
+    private static final String PROJECT_ID = TestFixtures.projectId();
+    private static final String BUCKET_NAME = TestFixtures.uniqueName("notif-bucket");
+    private static final String TOPIC_ID = TestFixtures.uniqueName("gcs-notif-topic");
+    private static final String SUBSCRIPTION_ID = TestFixtures.uniqueName("gcs-notif-sub");
+    private static final String OBJECT_NAME = "notification/trigger.txt";
+
+    private static Storage storage;
+    private static ManagedChannel channel;
+    private static TransportChannelProvider channelProvider;
+    private static NoCredentialsProvider credentialsProvider;
+    private static TopicAdminClient topicAdminClient;
+    private static SubscriptionAdminClient subscriptionAdminClient;
+
+    private static String notificationId;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        storage = TestFixtures.storageClient();
+
+        String emulatorHost = System.getenv().getOrDefault("PUBSUB_EMULATOR_HOST", "localhost:4588");
+        channel = ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
+        channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+        credentialsProvider = NoCredentialsProvider.create();
+
+        topicAdminClient = TopicAdminClient.create(
+                TopicAdminSettings.newBuilder()
+                        .setTransportChannelProvider(channelProvider)
+                        .setCredentialsProvider(credentialsProvider)
+                        .build());
+
+        subscriptionAdminClient = SubscriptionAdminClient.create(
+                SubscriptionAdminSettings.newBuilder()
+                        .setTransportChannelProvider(channelProvider)
+                        .setCredentialsProvider(credentialsProvider)
+                        .build());
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        try { storage.delete(BlobId.of(BUCKET_NAME, OBJECT_NAME)); } catch (Exception ignored) {}
+        try { storage.get(BUCKET_NAME).delete(); } catch (Exception ignored) {}
+        try { subscriptionAdminClient.deleteSubscription(ProjectSubscriptionName.of(PROJECT_ID, SUBSCRIPTION_ID)); } catch (Exception ignored) {}
+        try { topicAdminClient.deleteTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID)); } catch (Exception ignored) {}
+        if (subscriptionAdminClient != null) subscriptionAdminClient.close();
+        if (topicAdminClient != null) topicAdminClient.close();
+        if (channel != null) {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (storage instanceof AutoCloseable closeable) closeable.close();
+    }
+
+    @Test
+    @Order(1)
+    void createTopicAndSubscription() {
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, TOPIC_ID);
+        Topic topic = topicAdminClient.createTopic(topicName);
+        assertThat(topic.getName()).isEqualTo(topicName.toString());
+
+        Subscription sub = subscriptionAdminClient.createSubscription(
+                ProjectSubscriptionName.of(PROJECT_ID, SUBSCRIPTION_ID),
+                topicName,
+                PushConfig.getDefaultInstance(),
+                10);
+        assertThat(sub.getName()).contains(SUBSCRIPTION_ID);
+    }
+
+    @Test
+    @Order(2)
+    void createBucketAndNotification() {
+        storage.create(BucketInfo.of(BUCKET_NAME));
+
+        String topicName = ProjectTopicName.of(PROJECT_ID, TOPIC_ID).toString();
+        NotificationInfo notifInfo = NotificationInfo.newBuilder(topicName)
+                .setEventTypes(NotificationInfo.EventType.OBJECT_FINALIZE,
+                        NotificationInfo.EventType.OBJECT_DELETE)
+                .setPayloadFormat(NotificationInfo.PayloadFormat.JSON_API_V1)
+                .build();
+
+        Notification notification = storage.createNotification(BUCKET_NAME, notifInfo);
+        assertThat(notification).isNotNull();
+        assertThat(notification.getTopic()).isEqualTo(topicName);
+        notificationId = notification.getNotificationId();
+        assertThat(notificationId).isNotBlank();
+    }
+
+    @Test
+    @Order(3)
+    void listNotificationsReturnCreated() {
+        List<Notification> notifications = storage.listNotifications(BUCKET_NAME);
+        assertThat(notifications).isNotEmpty();
+        assertThat(notifications.stream().anyMatch(n -> notificationId.equals(n.getNotificationId()))).isTrue();
+    }
+
+    @Test
+    @Order(4)
+    void getNotificationById() {
+        Notification notification = storage.getNotification(BUCKET_NAME, notificationId);
+        assertThat(notification).isNotNull();
+        assertThat(notification.getNotificationId()).isEqualTo(notificationId);
+    }
+
+    @Test
+    @Order(5)
+    void uploadObjectTriggersNotification() throws IOException {
+        BlobInfo info = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME))
+                .setContentType("text/plain")
+                .build();
+        storage.create(info, "trigger event".getBytes(StandardCharsets.UTF_8));
+
+        SubscriberStubSettings subscriberSettings = SubscriberStubSettings.newBuilder()
+                .setTransportChannelProvider(channelProvider)
+                .setCredentialsProvider(credentialsProvider)
+                .build();
+
+        try (GrpcSubscriberStub subscriberStub = GrpcSubscriberStub.create(subscriberSettings)) {
+            PullResponse response = subscriberStub.pullCallable().call(
+                    PullRequest.newBuilder()
+                            .setSubscription(ProjectSubscriptionName.of(PROJECT_ID, SUBSCRIPTION_ID).toString())
+                            .setMaxMessages(10)
+                            .build());
+
+            List<ReceivedMessage> messages = response.getReceivedMessagesList();
+            assertThat(messages).isNotEmpty();
+
+            boolean hasFinalize = messages.stream().anyMatch(m ->
+                    "OBJECT_FINALIZE".equals(m.getMessage().getAttributesOrDefault("eventType", "")));
+            assertThat(hasFinalize).isTrue();
+
+            boolean hasBucket = messages.stream().anyMatch(m ->
+                    BUCKET_NAME.equals(m.getMessage().getAttributesOrDefault("bucketId", "")));
+            assertThat(hasBucket).isTrue();
+
+            List<String> ackIds = messages.stream().map(ReceivedMessage::getAckId).toList();
+            subscriberStub.acknowledgeCallable().call(
+                    AcknowledgeRequest.newBuilder()
+                            .setSubscription(ProjectSubscriptionName.of(PROJECT_ID, SUBSCRIPTION_ID).toString())
+                            .addAllAckIds(ackIds)
+                            .build());
+        }
+    }
+
+    @Test
+    @Order(6)
+    void deleteObjectTriggersNotification() throws IOException {
+        storage.delete(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+
+        SubscriberStubSettings subscriberSettings = SubscriberStubSettings.newBuilder()
+                .setTransportChannelProvider(channelProvider)
+                .setCredentialsProvider(credentialsProvider)
+                .build();
+
+        try (GrpcSubscriberStub subscriberStub = GrpcSubscriberStub.create(subscriberSettings)) {
+            PullResponse response = subscriberStub.pullCallable().call(
+                    PullRequest.newBuilder()
+                            .setSubscription(ProjectSubscriptionName.of(PROJECT_ID, SUBSCRIPTION_ID).toString())
+                            .setMaxMessages(10)
+                            .build());
+
+            List<ReceivedMessage> messages = response.getReceivedMessagesList();
+            assertThat(messages).isNotEmpty();
+
+            boolean hasDelete = messages.stream().anyMatch(m ->
+                    "OBJECT_DELETE".equals(m.getMessage().getAttributesOrDefault("eventType", "")));
+            assertThat(hasDelete).isTrue();
+
+            List<String> ackIds = messages.stream().map(ReceivedMessage::getAckId).toList();
+            subscriberStub.acknowledgeCallable().call(
+                    AcknowledgeRequest.newBuilder()
+                            .setSubscription(ProjectSubscriptionName.of(PROJECT_ID, SUBSCRIPTION_ID).toString())
+                            .addAllAckIds(ackIds)
+                            .build());
+        }
+    }
+
+    @Test
+    @Order(7)
+    void deleteNotificationConfig() {
+        storage.deleteNotification(BUCKET_NAME, notificationId);
+
+        List<Notification> remaining = storage.listNotifications(BUCKET_NAME);
+        boolean stillPresent = remaining.stream()
+                .anyMatch(n -> notificationId.equals(n.getNotificationId()));
+        assertThat(stillPresent).isFalse();
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSignedUrlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSignedUrlTest.java
@@ -1,0 +1,157 @@
+package io.floci.gcp.test;
+
+import com.google.auth.ServiceAccountSigner;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.HttpMethod;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.SignUrlOption;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GcsSignedUrlTest {
+
+    private static final String BUCKET_NAME = TestFixtures.uniqueName("signed-url-bucket");
+    private static final String OBJECT_NAME = "test/signed-object.txt";
+    private static final String OBJECT_CONTENT = "content via signed URL";
+
+    private static Storage storage;
+    private static ServiceAccountSigner fakeSigner;
+    private static String emulatorHost;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET_NAME));
+
+        URI endpoint = URI.create(TestFixtures.endpoint());
+        int port = endpoint.getPort() > 0 ? endpoint.getPort() : 80;
+        emulatorHost = endpoint.getHost() + ":" + port;
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+        java.security.PrivateKey privateKey = kp.getPrivate();
+
+        fakeSigner = new ServiceAccountSigner() {
+            @Override
+            public String getAccount() {
+                return "test-signer@test-project.iam.gserviceaccount.com";
+            }
+
+            @Override
+            public byte[] sign(byte[] toSign) {
+                try {
+                    Signature sig = Signature.getInstance("SHA256withRSA");
+                    sig.initSign(privateKey);
+                    sig.update(toSign);
+                    return sig.sign();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME))
+                .setContentType("text/plain")
+                .build();
+        storage.create(blobInfo, OBJECT_CONTENT.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        try {
+            storage.delete(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+            storage.delete(BlobId.of(BUCKET_NAME, "test/signed-upload.txt"));
+        } catch (Exception ignored) {}
+        try {
+            storage.get(BUCKET_NAME).delete();
+        } catch (Exception ignored) {}
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void signedUrlDownloadReturnsObject() throws Exception {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME)).build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.HOURS,
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        assertThat(signed).isNotNull();
+        assertThat(signed.toString()).contains(BUCKET_NAME);
+
+        // SDK defaults to https:// — rewrite to http:// for the plaintext emulator
+        URL emulatorUrl = toHttp(signed);
+
+        HttpURLConnection conn = (HttpURLConnection) emulatorUrl.openConnection();
+        conn.setRequestMethod("GET");
+        assertThat(conn.getResponseCode()).isEqualTo(200);
+        try (InputStream is = conn.getInputStream()) {
+            String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(content).isEqualTo(OBJECT_CONTENT);
+        }
+    }
+
+    @Test
+    @Order(2)
+    void signedUrlUploadStoresObject() throws Exception {
+        String uploadObjectName = "test/signed-upload.txt";
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, uploadObjectName))
+                .setContentType("text/plain")
+                .build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.HOURS,
+                SignUrlOption.httpMethod(HttpMethod.PUT),
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        URL emulatorUrl = toHttp(signed);
+
+        byte[] body = "uploaded via signed url".getBytes(StandardCharsets.UTF_8);
+        HttpURLConnection conn = (HttpURLConnection) emulatorUrl.openConnection();
+        conn.setRequestMethod("PUT");
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "text/plain");
+        conn.setRequestProperty("Content-Length", String.valueOf(body.length));
+        conn.getOutputStream().write(body);
+
+        assertThat(conn.getResponseCode()).isEqualTo(200);
+
+        com.google.cloud.storage.Blob uploaded = storage.get(BlobId.of(BUCKET_NAME, uploadObjectName));
+        assertThat(uploaded).isNotNull();
+        String content = new String(uploaded.getContent(), StandardCharsets.UTF_8);
+        assertThat(content).isEqualTo("uploaded via signed url");
+    }
+
+    private static URL toHttp(URL url) throws Exception {
+        String s = url.toString();
+        if (s.startsWith("https://")) {
+            s = "http://" + s.substring("https://".length());
+        }
+        return new URL(s);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSignedUrlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSignedUrlTest.java
@@ -107,6 +107,8 @@ class GcsSignedUrlTest {
         URL emulatorUrl = toHttp(signed);
 
         HttpURLConnection conn = (HttpURLConnection) emulatorUrl.openConnection();
+        conn.setConnectTimeout(10_000);
+        conn.setReadTimeout(30_000);
         conn.setRequestMethod("GET");
         assertThat(conn.getResponseCode()).isEqualTo(200);
         try (InputStream is = conn.getInputStream()) {
@@ -133,6 +135,8 @@ class GcsSignedUrlTest {
 
         byte[] body = "uploaded via signed url".getBytes(StandardCharsets.UTF_8);
         HttpURLConnection conn = (HttpURLConnection) emulatorUrl.openConnection();
+        conn.setConnectTimeout(10_000);
+        conn.setReadTimeout(30_000);
         conn.setRequestMethod("PUT");
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "text/plain");

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsVersioningTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsVersioningTest.java
@@ -1,0 +1,165 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GcsVersioningTest {
+
+    private static final String BUCKET_NAME = TestFixtures.uniqueName("versioned-bucket");
+    private static final String OBJECT_NAME = "versioned/object.txt";
+    private static final String CONTENT_V1 = "version one content";
+    private static final String CONTENT_V2 = "version two content";
+
+    private static Storage storage;
+    private static Long v1Generation;
+    private static Long v2Generation;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createVersionedBucket() {
+        Bucket bucket = storage.create(
+                BucketInfo.newBuilder(BUCKET_NAME)
+                        .setVersioningEnabled(true)
+                        .build());
+        assertThat(bucket.getName()).isEqualTo(BUCKET_NAME);
+        assertThat(bucket.versioningEnabled()).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void uploadVersionOne() {
+        BlobInfo info = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME))
+                .setContentType("text/plain")
+                .build();
+        Blob blob = storage.create(info, CONTENT_V1.getBytes(StandardCharsets.UTF_8));
+        v1Generation = blob.getGeneration();
+        assertThat(v1Generation).isNotNull();
+        assertThat(blob.getName()).isEqualTo(OBJECT_NAME);
+    }
+
+    @Test
+    @Order(3)
+    void uploadVersionTwo() {
+        BlobInfo info = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME))
+                .setContentType("text/plain")
+                .build();
+        Blob blob = storage.create(info, CONTENT_V2.getBytes(StandardCharsets.UTF_8));
+        v2Generation = blob.getGeneration();
+        assertThat(v2Generation).isNotNull();
+        assertThat(v2Generation).isGreaterThan(v1Generation);
+    }
+
+    @Test
+    @Order(4)
+    void listVersionsShowsBothGenerations() {
+        List<Long> generations = new ArrayList<>();
+        storage.list(BUCKET_NAME, Storage.BlobListOption.versions(true))
+                .iterateAll()
+                .forEach(b -> {
+                    if (OBJECT_NAME.equals(b.getName())) {
+                        generations.add(b.getGeneration());
+                    }
+                });
+        assertThat(generations).hasSize(2);
+        assertThat(generations).contains(v1Generation, v2Generation);
+    }
+
+    @Test
+    @Order(5)
+    void readCurrentVersionReturnsV2() {
+        Blob current = storage.get(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+        assertThat(current).isNotNull();
+        String content = new String(current.getContent(), StandardCharsets.UTF_8);
+        assertThat(content).isEqualTo(CONTENT_V2);
+        assertThat(current.getGeneration()).isEqualTo(v2Generation);
+    }
+
+    @Test
+    @Order(6)
+    void readSpecificGenerationReturnsOldContent() {
+        Blob v1 = storage.get(BlobId.of(BUCKET_NAME, OBJECT_NAME, v1Generation));
+        assertThat(v1).isNotNull();
+        String content = new String(v1.getContent(), StandardCharsets.UTF_8);
+        assertThat(content).isEqualTo(CONTENT_V1);
+    }
+
+    @Test
+    @Order(7)
+    void deleteSpecificVersionRemovesOnlyThatVersion() {
+        storage.delete(BlobId.of(BUCKET_NAME, OBJECT_NAME, v1Generation));
+
+        List<Long> remaining = new ArrayList<>();
+        storage.list(BUCKET_NAME, Storage.BlobListOption.versions(true))
+                .iterateAll()
+                .forEach(b -> {
+                    if (OBJECT_NAME.equals(b.getName())) {
+                        remaining.add(b.getGeneration());
+                    }
+                });
+        assertThat(remaining).hasSize(1);
+        assertThat(remaining).contains(v2Generation);
+
+        Blob current = storage.get(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+        assertThat(current).isNotNull();
+        assertThat(current.getGeneration()).isEqualTo(v2Generation);
+    }
+
+    @Test
+    @Order(8)
+    void deleteCurrentObjectCreatesDeleteMarker() {
+        storage.delete(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+
+        Blob gone = storage.get(BlobId.of(BUCKET_NAME, OBJECT_NAME));
+        assertThat(gone).isNull();
+
+        List<Blob> allVersions = new ArrayList<>();
+        storage.list(BUCKET_NAME, Storage.BlobListOption.versions(true))
+                .iterateAll()
+                .forEach(b -> {
+                    if (OBJECT_NAME.equals(b.getName())) {
+                        allVersions.add(b);
+                    }
+                });
+        assertThat(allVersions).isNotEmpty();
+    }
+
+    @Test
+    @Order(9)
+    void cleanupVersionedBucket() {
+        storage.list(BUCKET_NAME, Storage.BlobListOption.versions(true))
+                .iterateAll()
+                .forEach(b -> storage.delete(BlobId.of(BUCKET_NAME, b.getName(), b.getGeneration())));
+        Bucket bucket = storage.get(BUCKET_NAME);
+        assertThat(bucket).isNotNull();
+        assertThat(bucket.delete()).isTrue();
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/resources/junit-platform.properties
+++ b/compatibility-tests/sdk-test-java/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+# Fail fast instead of hanging the whole CI job if a single test blocks
+# (e.g. on a non-responsive emulator request). A timed-out test reports a
+# stack trace pinpointing the blocked call instead of a silent 20m cancel.
+junit.jupiter.execution.timeout.test.method.default = 120s

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
@@ -1,0 +1,266 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.config.EmulatorConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+@Path("/batch/storage/v1")
+public class GcsBatchController {
+
+    private static final Logger LOG = Logger.getLogger(GcsBatchController.class);
+    private static final Pattern BOUNDARY_PATTERN = Pattern.compile("boundary=([^\\s;\"]+|\"[^\"]+\")");
+
+    private final EmulatorConfig config;
+    private final HttpClient httpClient;
+
+    @Inject
+    public GcsBatchController(EmulatorConfig config) {
+        this.config = config;
+        this.httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+    }
+
+    @POST
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.WILDCARD)
+    public Response batch(@HeaderParam("Content-Type") String contentType, byte[] body) {
+        String boundary = extractBoundary(contentType);
+        if (boundary == null) {
+            return Response.status(400).entity("Missing multipart boundary").build();
+        }
+
+        List<SubRequest> subRequests = parseMultipart(boundary, body);
+        LOG.debugf("batch: parsed %d sub-requests", subRequests.size());
+
+        String responseBoundary = "batch_" + UUID.randomUUID().toString().replace("-", "");
+        StringBuilder responseBody = new StringBuilder();
+
+        for (int i = 0; i < subRequests.size(); i++) {
+            SubRequest req = subRequests.get(i);
+            SubResponse resp = dispatch(req);
+            appendResponsePart(responseBody, responseBoundary, i, req.contentId(), resp);
+        }
+        responseBody.append("--").append(responseBoundary).append("--\r\n");
+
+        return Response.ok(responseBody.toString())
+                .type("multipart/mixed; boundary=" + responseBoundary)
+                .build();
+    }
+
+    private String extractBoundary(String contentType) {
+        if (contentType == null) return null;
+        Matcher m = BOUNDARY_PATTERN.matcher(contentType);
+        if (!m.find()) return null;
+        return m.group(1).replace("\"", "");
+    }
+
+    private List<SubRequest> parseMultipart(String boundary, byte[] bodyBytes) {
+        String body = new String(bodyBytes, StandardCharsets.UTF_8);
+        String delimiter = "--" + boundary;
+        List<SubRequest> requests = new ArrayList<>();
+
+        int pos = body.indexOf(delimiter);
+        while (pos >= 0) {
+            int partStart = pos + delimiter.length();
+            // Skip the closing boundary
+            if (partStart < body.length() && body.startsWith("--", partStart)) {
+                break;
+            }
+            // Skip line ending after boundary
+            if (partStart < body.length() && body.charAt(partStart) == '\r') partStart++;
+            if (partStart < body.length() && body.charAt(partStart) == '\n') partStart++;
+
+            int nextBoundary = body.indexOf("\r\n" + delimiter, partStart);
+            if (nextBoundary < 0) nextBoundary = body.indexOf("\n" + delimiter, partStart);
+            if (nextBoundary < 0) break;
+
+            String part = body.substring(partStart, nextBoundary);
+            SubRequest req = parsePart(part);
+            if (req != null) {
+                requests.add(req);
+            }
+            pos = nextBoundary + (body.startsWith("\r\n" + delimiter, nextBoundary) ? 2 : 1) + delimiter.length();
+            pos -= delimiter.length(); // will be re-added in next iteration
+            pos = body.indexOf(delimiter, nextBoundary + 1);
+        }
+        return requests;
+    }
+
+    private SubRequest parsePart(String part) {
+        // Find blank line separating MIME headers from the embedded HTTP request
+        int blankCrlf = part.indexOf("\r\n\r\n");
+        int blankLf = part.indexOf("\n\n");
+        int blankEnd;
+        if (blankCrlf >= 0 && (blankLf < 0 || blankCrlf <= blankLf)) {
+            blankEnd = blankCrlf + 4;
+        } else if (blankLf >= 0) {
+            blankEnd = blankLf + 2;
+        } else {
+            return null;
+        }
+
+        String mimeHeaders = part.substring(0, blankEnd);
+        String contentId = extractContentId(mimeHeaders);
+        String httpPart = part.substring(blankEnd).stripTrailing();
+
+        return parseHttpSubRequest(httpPart, contentId);
+    }
+
+    private String extractContentId(String mimeHeaders) {
+        for (String line : mimeHeaders.split("\r?\n")) {
+            if (line.toLowerCase().startsWith("content-id:")) {
+                return line.substring("content-id:".length()).trim();
+            }
+        }
+        return null;
+    }
+
+    private SubRequest parseHttpSubRequest(String httpText, String contentId) {
+        if (httpText == null || httpText.isBlank()) return null;
+        String[] lines = httpText.split("\r?\n", -1);
+        if (lines.length == 0 || lines[0].isBlank()) return null;
+
+        String[] requestLine = lines[0].trim().split(" ", 3);
+        if (requestLine.length < 2) return null;
+
+        String method = requestLine[0].trim();
+        String pathAndQuery = requestLine[1].trim();
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        int i = 1;
+        while (i < lines.length && !lines[i].isBlank()) {
+            int colon = lines[i].indexOf(':');
+            if (colon > 0) {
+                headers.put(lines[i].substring(0, colon).trim(),
+                        lines[i].substring(colon + 1).trim());
+            }
+            i++;
+        }
+        i++; // skip blank line
+
+        StringBuilder bodyBuilder = new StringBuilder();
+        while (i < lines.length) {
+            if (bodyBuilder.length() > 0) bodyBuilder.append("\n");
+            bodyBuilder.append(lines[i]);
+            i++;
+        }
+        String requestBody = bodyBuilder.toString().strip();
+        return new SubRequest(method, pathAndQuery, headers, requestBody, contentId);
+    }
+
+    private SubResponse dispatch(SubRequest req) {
+        try {
+            String path = req.path();
+            URI uri = path.startsWith("http://") || path.startsWith("https://")
+                    ? rewriteToLocalhost(URI.create(path))
+                    : URI.create("http://localhost:" + config.port() + path);
+
+            HttpRequest.BodyPublisher bodyPublisher = req.body().isEmpty()
+                    ? HttpRequest.BodyPublishers.noBody()
+                    : HttpRequest.BodyPublishers.ofString(req.body());
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .method(req.method(), bodyPublisher);
+
+            req.headers().forEach((k, v) -> {
+                if (!k.equalsIgnoreCase("host") && !k.equalsIgnoreCase("content-length")
+                        && !k.equalsIgnoreCase("transfer-encoding")) {
+                    try {
+                        builder.header(k, v);
+                    } catch (IllegalArgumentException ignored) {
+                        // skip restricted headers
+                    }
+                }
+            });
+            if (!req.body().isEmpty() && !req.headers().containsKey("Content-Type")) {
+                builder.header("Content-Type", "application/json");
+            }
+
+            HttpResponse<String> resp = httpClient.send(builder.build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            LOG.debugf("batch dispatch %s %s → %d", req.method(), req.path(), resp.statusCode());
+            return new SubResponse(resp.statusCode(), resp.body());
+        } catch (Exception e) {
+            LOG.errorf("batch dispatch error %s %s: %s", req.method(), req.path(), e.getMessage());
+            return new SubResponse(500,
+                    "{\"error\":{\"code\":500,\"message\":\"Internal batch error\"}}");
+        }
+    }
+
+    private URI rewriteToLocalhost(URI original) {
+        try {
+            return new URI("http", null, "localhost", config.port(),
+                    original.getRawPath(), original.getRawQuery(), null);
+        } catch (Exception e) {
+            return URI.create("http://localhost:" + config.port() + original.getRawPath()
+                    + (original.getRawQuery() != null ? "?" + original.getRawQuery() : ""));
+        }
+    }
+
+    private void appendResponsePart(StringBuilder sb, String boundary, int index,
+            String contentId, SubResponse resp) {
+        sb.append("--").append(boundary).append("\r\n");
+        sb.append("Content-Type: application/http\r\n");
+        String responseId = contentId != null
+                ? "<response-" + contentId.replaceAll("[<>]", "") + ">"
+                : "<response-" + index + ">";
+        sb.append("Content-ID: ").append(responseId).append("\r\n");
+        sb.append("\r\n");
+        sb.append("HTTP/1.1 ").append(resp.statusCode()).append(" ")
+                .append(statusText(resp.statusCode())).append("\r\n");
+        String body = resp.body();
+        if (body != null && !body.isBlank()) {
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            sb.append("Content-Type: application/json; charset=UTF-8\r\n");
+            sb.append("Content-Length: ").append(bodyBytes.length).append("\r\n");
+            sb.append("\r\n");
+            sb.append(body).append("\r\n");
+        } else {
+            sb.append("\r\n");
+        }
+    }
+
+    private static String statusText(int code) {
+        return switch (code) {
+            case 200 -> "OK";
+            case 201 -> "Created";
+            case 204 -> "No Content";
+            case 304 -> "Not Modified";
+            case 400 -> "Bad Request";
+            case 401 -> "Unauthorized";
+            case 403 -> "Forbidden";
+            case 404 -> "Not Found";
+            case 409 -> "Conflict";
+            case 412 -> "Precondition Failed";
+            case 429 -> "Too Many Requests";
+            case 500 -> "Internal Server Error";
+            default -> "Unknown";
+        };
+    }
+
+    record SubRequest(String method, String path, Map<String, String> headers,
+                      String body, String contentId) {}
+
+    record SubResponse(int statusCode, String body) {}
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
@@ -13,6 +13,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ public class GcsBatchController {
         this.config = config;
         this.httpClient = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(10))
                 .build();
     }
 
@@ -180,6 +182,7 @@ public class GcsBatchController {
 
             HttpRequest.Builder builder = HttpRequest.newBuilder()
                     .uri(uri)
+                    .timeout(Duration.ofSeconds(30))
                     .method(req.method(), bodyPublisher);
 
             req.headers().forEach((k, v) -> {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
@@ -37,6 +37,17 @@ public class GcsBucketController {
         this.iamService = iamService;
     }
 
+    @OPTIONS
+    public Response optionsRoot() {
+        return Response.ok().build();
+    }
+
+    @OPTIONS
+    @Path("/{anyPath: .*}")
+    public Response options() {
+        return Response.ok().build();
+    }
+
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public Response createBucket(@QueryParam("project") String project,
@@ -79,11 +90,30 @@ public class GcsBucketController {
         return Response.ok(service.updateBucket(bucket, body)).build();
     }
 
+    @POST
+    @Path("/{bucket}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response postBucketMethodOverride(@PathParam("bucket") String bucket,
+            @HeaderParam("X-HTTP-Method-Override") String methodOverride,
+            Map<String, Object> body) {
+        if ("PATCH".equalsIgnoreCase(methodOverride)) {
+            return Response.ok(service.updateBucket(bucket, body)).build();
+        }
+        throw GcpException.invalidArgument("unsupported method override: " + methodOverride);
+    }
+
     @DELETE
     @Path("/{bucket}")
     public Response deleteBucket(@PathParam("bucket") String bucket) {
         service.deleteBucket(bucket);
         return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/{bucket}/lockRetentionPolicy")
+    public Response lockRetentionPolicy(@PathParam("bucket") String bucket,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch) {
+        return Response.ok(service.lockRetentionPolicy(bucket, ifMetagenerationMatch)).build();
     }
 
     // ── Bucket IAM ────────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
@@ -1,0 +1,153 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.services.gcs.model.GcsBucket;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.List;
+import java.util.Map;
+
+@Provider
+@ApplicationScoped
+public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private final GcsService gcsService;
+
+    @Inject
+    public GcsCorsFilter(GcsService gcsService) {
+        this.gcsService = gcsService;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext req) {
+        if (!"OPTIONS".equals(req.getMethod())) {
+            return;
+        }
+        String origin = req.getHeaderString("Origin");
+        if (origin == null) {
+            return;
+        }
+        String bucket = extractBucket(req.getUriInfo().getRequestUri().getRawPath());
+        Map<String, Object> rule = matchCorsRule(bucket, origin);
+        Response.ResponseBuilder rb = Response.ok();
+        rb.header("Access-Control-Allow-Origin", origin);
+        rb.header("Vary", "Origin");
+        if (rule != null) {
+            appendMethodsHeader(rb, rule);
+            appendHeadersHeader(rb, rule);
+            appendMaxAge(rb, rule);
+        } else {
+            rb.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+            rb.header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Goog-*");
+        }
+        req.abortWith(rb.build());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext req, ContainerResponseContext resp) {
+        String origin = req.getHeaderString("Origin");
+        if (origin == null) {
+            return;
+        }
+        String bucket = extractBucket(req.getUriInfo().getRequestUri().getRawPath());
+        Map<String, Object> rule = matchCorsRule(bucket, origin);
+        if (rule == null && bucket == null) {
+            return;
+        }
+        resp.getHeaders().putSingle("Access-Control-Allow-Origin", origin);
+        resp.getHeaders().putSingle("Vary", "Origin");
+        if (rule != null) {
+            appendMethodsHeader(resp, rule);
+            appendHeadersHeader(resp, rule);
+            appendMaxAge(resp, rule);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> matchCorsRule(String bucketName, String origin) {
+        if (bucketName == null) {
+            return null;
+        }
+        GcsBucket bucket = gcsService.findBucket(bucketName).orElse(null);
+        if (bucket == null || bucket.getCors() == null) {
+            return null;
+        }
+        for (Map<String, Object> rule : bucket.getCors()) {
+            List<String> origins = (List<String>) rule.get("origin");
+            if (origins != null && (origins.contains("*") || origins.contains(origin))) {
+                return rule;
+            }
+        }
+        return null;
+    }
+
+    private static String extractBucket(String path) {
+        String[] prefixes = {
+                "/storage/v1/b/",
+                "/download/storage/v1/b/",
+                "/upload/storage/v1/b/"
+        };
+        for (String prefix : prefixes) {
+            if (path.startsWith(prefix)) {
+                String rest = path.substring(prefix.length());
+                int slash = rest.indexOf('/');
+                return slash >= 0 ? rest.substring(0, slash) : rest;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void appendMethodsHeader(Response.ResponseBuilder rb, Map<String, Object> rule) {
+        List<String> methods = (List<String>) rule.get("method");
+        if (methods != null && !methods.isEmpty()) {
+            rb.header("Access-Control-Allow-Methods", String.join(", ", methods));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void appendHeadersHeader(Response.ResponseBuilder rb, Map<String, Object> rule) {
+        List<String> headers = (List<String>) rule.get("responseHeader");
+        if (headers != null && !headers.isEmpty()) {
+            rb.header("Access-Control-Allow-Headers", String.join(", ", headers));
+            rb.header("Access-Control-Expose-Headers", String.join(", ", headers));
+        }
+    }
+
+    private static void appendMaxAge(Response.ResponseBuilder rb, Map<String, Object> rule) {
+        Object maxAge = rule.get("maxAgeSeconds");
+        if (maxAge != null) {
+            rb.header("Access-Control-Max-Age", maxAge.toString());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void appendMethodsHeader(ContainerResponseContext resp, Map<String, Object> rule) {
+        List<String> methods = (List<String>) rule.get("method");
+        if (methods != null && !methods.isEmpty()) {
+            resp.getHeaders().putSingle("Access-Control-Allow-Methods", String.join(", ", methods));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void appendHeadersHeader(ContainerResponseContext resp, Map<String, Object> rule) {
+        List<String> headers = (List<String>) rule.get("responseHeader");
+        if (headers != null && !headers.isEmpty()) {
+            resp.getHeaders().putSingle("Access-Control-Allow-Headers", String.join(", ", headers));
+            resp.getHeaders().putSingle("Access-Control-Expose-Headers", String.join(", ", headers));
+        }
+    }
+
+    private static void appendMaxAge(ContainerResponseContext resp, Map<String, Object> rule) {
+        Object maxAge = rule.get("maxAgeSeconds");
+        if (maxAge != null) {
+            resp.getHeaders().putSingle("Access-Control-Max-Age", maxAge.toString());
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 import java.net.URLDecoder;
@@ -26,8 +27,14 @@ public class GcsDownloadController {
     @Path("/{object: .+}")
     public Response download(
             @PathParam("bucket") String bucket,
-            @PathParam("object") String objectPath) {
+            @PathParam("object") String objectPath,
+            @QueryParam("generation") String generation) {
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
+        if (generation != null) {
+            byte[] data = service.getObjectData(bucket, objectName, generation);
+            GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
+            return Response.ok(data).type(meta.getContentType()).build();
+        }
         byte[] data = service.getObjectData(bucket, objectName);
         GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
         return Response.ok(data).type(meta.getContentType()).build();

--- a/src/main/java/io/floci/gcp/services/gcs/GcsNotificationController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsNotificationController.java
@@ -1,0 +1,51 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.services.gcs.model.StoredNotification;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+@Path("/storage/v1/b/{bucket}/notificationConfigs")
+@Produces(MediaType.APPLICATION_JSON)
+public class GcsNotificationController {
+
+    private final GcsService service;
+
+    @Inject
+    public GcsNotificationController(GcsService service) {
+        this.service = service;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response createNotification(@PathParam("bucket") String bucket, Map<String, Object> body) {
+        return Response.ok(service.createNotification(bucket, body)).build();
+    }
+
+    @GET
+    public Response listNotifications(@PathParam("bucket") String bucket) {
+        List<StoredNotification> items = service.listNotifications(bucket);
+        return Response.ok(Map.of("kind", "storage#notifications", "items", items)).build();
+    }
+
+    @GET
+    @Path("/{notification}")
+    public Response getNotification(@PathParam("bucket") String bucket,
+            @PathParam("notification") String notificationId) {
+        return Response.ok(service.getNotification(bucket, notificationId)).build();
+    }
+
+    @DELETE
+    @Path("/{notification}")
+    public Response deleteNotification(@PathParam("bucket") String bucket,
+            @PathParam("notification") String notificationId) {
+        service.deleteNotification(bucket, notificationId);
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -33,14 +33,23 @@ public class GcsObjectController {
         this.config = config;
     }
 
+    @OPTIONS
+    @Path("/{anyPath: .*}")
+    public Response options() {
+        return Response.ok().build();
+    }
+
     @GET
     public Response listObjects(@PathParam("bucket") String bucket,
             @QueryParam("maxResults") @DefaultValue("0") int maxResults,
             @QueryParam("pageToken") String pageToken,
             @QueryParam("prefix") String prefix,
-            @QueryParam("delimiter") String delimiter) {
-        List<GcsObjectMeta> all = service.listObjects(bucket);
-        if (prefix != null && !prefix.isBlank()) {
+            @QueryParam("delimiter") String delimiter,
+            @QueryParam("versions") @DefaultValue("false") boolean includeVersions) {
+        List<GcsObjectMeta> all = includeVersions
+                ? service.listObjectVersions(bucket, prefix)
+                : service.listObjects(bucket);
+        if (!includeVersions && prefix != null && !prefix.isBlank()) {
             all = all.stream().filter(o -> o.getName().startsWith(prefix)).toList();
         }
         PageToken.Page<GcsObjectMeta> page = PageToken.paginate(all, maxResults, pageToken);
@@ -111,8 +120,17 @@ public class GcsObjectController {
     @Path("/{object: .+}")
     public Response getObject(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
-            @QueryParam("alt") String alt) {
+            @QueryParam("alt") String alt,
+            @QueryParam("generation") String generation) {
         String objectName = decode(objectPath);
+        if (generation != null) {
+            if ("media".equals(alt)) {
+                byte[] data = service.getObjectData(bucket, objectName, generation);
+                GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
+                return Response.ok(data).type(meta.getContentType()).build();
+            }
+            return Response.ok(service.getObjectMeta(bucket, objectName, generation)).build();
+        }
         if ("media".equals(alt)) {
             byte[] data = service.getObjectData(bucket, objectName);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
@@ -130,11 +148,38 @@ public class GcsObjectController {
         return Response.ok(service.patchObject(bucket, objectName, body)).build();
     }
 
+    @PUT
+    @Path("/{object: .+}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateObject(@PathParam("bucket") String bucket,
+            @PathParam("object") String objectPath, Map<String, Object> body) {
+        String objectName = decode(objectPath);
+        return Response.ok(service.patchObject(bucket, objectName, body)).build();
+    }
+
+    @POST
+    @Path("/{object: .+}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response postObjectMethodOverride(@PathParam("bucket") String bucket,
+            @PathParam("object") String objectPath,
+            @HeaderParam("X-HTTP-Method-Override") String methodOverride,
+            Map<String, Object> body) {
+        if ("PATCH".equalsIgnoreCase(methodOverride)) {
+            return Response.ok(service.patchObject(bucket, decode(objectPath), body)).build();
+        }
+        throw GcpException.invalidArgument("Unsupported method override: " + methodOverride);
+    }
+
     @DELETE
     @Path("/{object: .+}")
     public Response deleteObject(@PathParam("bucket") String bucket,
-            @PathParam("object") String objectPath) {
+            @PathParam("object") String objectPath,
+            @QueryParam("generation") String generation) {
         String objectName = decode(objectPath);
+        if (generation != null) {
+            service.deleteObjectVersion(bucket, objectName, generation);
+            return Response.noContent().build();
+        }
         if (!service.deleteObject(bucket, objectName)) {
             throw GcpException.notFound("Object not found: " + objectName);
         }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -1,6 +1,9 @@
 package io.floci.gcp.services.gcs;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.ServiceDescriptor;
@@ -12,6 +15,8 @@ import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.ResumableUpload;
 import io.floci.gcp.services.gcs.model.StoredAcl;
+import io.floci.gcp.services.gcs.model.StoredNotification;
+import io.floci.gcp.services.pubsub.PubSubService;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -40,24 +45,32 @@ public class GcsService {
     private final StorageBackend<String, GcsBucket> bucketStore;
     private final StorageBackend<String, GcsObjectMeta> objectMetaStore;
     private final StorageBackend<String, StoredAcl> aclStore;
+    private final StorageBackend<String, StoredNotification> notificationStore;
     private final ConcurrentHashMap<String, byte[]> objectData = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ResumableUpload> resumableUploads = new ConcurrentHashMap<>();
 
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
     private final String defaultProjectId;
+    private final PubSubService pubSubService;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Inject
-    public GcsService(ServiceRegistry serviceRegistry, EmulatorConfig config, StorageFactory storageFactory) {
+    public GcsService(ServiceRegistry serviceRegistry, EmulatorConfig config,
+            StorageFactory storageFactory, PubSubService pubSubService) {
         this.serviceRegistry = serviceRegistry;
         this.config = config;
         this.defaultProjectId = config.defaultProjectId();
+        this.pubSubService = pubSubService;
         this.bucketStore = storageFactory.createGlobal("gcs-buckets", "gcs-buckets.json",
                 new TypeReference<Map<String, GcsBucket>>() {});
         this.objectMetaStore = storageFactory.createGlobal("gcs-objects", "gcs-objects.json",
                 new TypeReference<Map<String, GcsObjectMeta>>() {});
         this.aclStore = storageFactory.createGlobal("gcs-acls", "gcs-acls.json",
                 new TypeReference<Map<String, StoredAcl>>() {});
+        this.notificationStore = storageFactory.createGlobal("gcs-notifications", "gcs-notifications.json",
+                new TypeReference<Map<String, StoredNotification>>() {});
     }
 
     GcsService(StorageBackend<String, GcsBucket> bucketStore,
@@ -68,8 +81,10 @@ public class GcsService {
         this.objectMetaStore = objectMetaStore;
         this.aclStore = aclStore;
         this.defaultProjectId = defaultProjectId;
+        this.notificationStore = new io.floci.gcp.core.storage.InMemoryStorage<>();
         this.serviceRegistry = null;
         this.config = null;
+        this.pubSubService = null;
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -79,7 +94,8 @@ public class GcsService {
                 .protocol(ServiceProtocol.REST)
                 .resourceClasses(GcsBucketController.class, GcsObjectController.class,
                         GcsUploadController.class, GcsDownloadController.class,
-                        GcsXmlDownloadController.class)
+                        GcsXmlDownloadController.class, GcsNotificationController.class,
+                        GcsBatchController.class)
                 .build());
     }
 
@@ -123,6 +139,9 @@ public class GcsService {
             if (body.containsKey("retentionPolicy")) {
                 bucket.setRetentionPolicy((Map<String, Object>) body.get("retentionPolicy"));
             }
+            if (body.containsKey("defaultEventBasedHold")) {
+                bucket.setDefaultEventBasedHold((Boolean) body.get("defaultEventBasedHold"));
+            }
         }
         bucketStore.put(name, bucket);
         return bucket;
@@ -155,6 +174,9 @@ public class GcsService {
         }
         if (patch.containsKey("storageClass")) {
             bucket.setStorageClass((String) patch.get("storageClass"));
+        }
+        if (patch.containsKey("defaultEventBasedHold")) {
+            bucket.setDefaultEventBasedHold((Boolean) patch.get("defaultEventBasedHold"));
         }
         bucket.setUpdated(Instant.now().toString());
         bucketStore.put(name, bucket);
@@ -190,6 +212,24 @@ public class GcsService {
         String now = Instant.now().toString();
         String encodedName = urlEncode(objectName);
 
+        GcsObjectMeta existing = objectMetaStore.get(key).orElse(null);
+        if (existing != null && existing.getTimeDeleted() == null) {
+            checkObjectMutable(existing);
+        }
+
+        if (isVersioningEnabled(bucket)) {
+            if (existing != null) {
+                String archiveKey = key + "\0" + existing.getGeneration();
+                GcsObjectMeta archived = cloneMeta(existing);
+                archived.setIsLatest(false);
+                objectMetaStore.put(archiveKey, archived);
+                byte[] oldData = objectData.get(key);
+                if (oldData != null) {
+                    objectData.put(archiveKey, oldData);
+                }
+            }
+        }
+
         GcsObjectMeta meta = new GcsObjectMeta();
         meta.setId(bucket + "/" + objectName + "/" + generation);
         meta.setName(objectName);
@@ -203,26 +243,59 @@ public class GcsService {
         meta.setSelfLink(baseUrl + "/storage/v1/b/" + bucket + "/o/" + encodedName);
         meta.setMediaLink(baseUrl + "/storage/v1/b/" + bucket + "/o/" + encodedName
                 + "?alt=media&generation=" + generation);
+        meta.setIsLatest(true);
         String crc32c = computeCrc32c(data);
         meta.setCrc32c(crc32c);
         String md5 = computeMd5(data);
         meta.setMd5Hash(md5);
         meta.setEtag(md5);
 
+        String retentionExpiry = computeRetentionExpiry(bucket, now);
+        if (retentionExpiry != null) {
+            meta.setRetentionExpirationTime(retentionExpiry);
+        }
+        GcsBucket b = bucketStore.get(bucket).orElse(null);
+        if (b != null && Boolean.TRUE.equals(b.getDefaultEventBasedHold())) {
+            meta.setEventBasedHold(true);
+        }
+
         objectMetaStore.put(key, meta);
         objectData.put(key, data);
+        publishNotificationEvent(bucket, objectName, meta, "OBJECT_FINALIZE");
         return meta;
     }
 
     public GcsObjectMeta getObjectMeta(String bucket, String objectName) {
         LOG.debugf("getObjectMeta bucket=%s name=%s", bucket, objectName);
-        return objectMetaStore.get(objectKey(bucket, objectName))
+        GcsObjectMeta meta = objectMetaStore.get(objectKey(bucket, objectName))
                 .orElseThrow(() -> GcpException.notFound("Object not found: " + objectName));
+        if (meta.getTimeDeleted() != null) {
+            throw GcpException.notFound("Object not found: " + objectName);
+        }
+        return meta;
+    }
+
+    public GcsObjectMeta getObjectMeta(String bucket, String objectName, String generation) {
+        LOG.debugf("getObjectMeta bucket=%s name=%s generation=%s", bucket, objectName, generation);
+        String liveKey = objectKey(bucket, objectName);
+        GcsObjectMeta live = objectMetaStore.get(liveKey).orElse(null);
+        if (live != null && generation.equals(live.getGeneration())) {
+            return live;
+        }
+        String archiveKey = liveKey + "\0" + generation;
+        return objectMetaStore.get(archiveKey)
+                .orElseThrow(() -> GcpException.notFound(
+                        "Object version not found: " + objectName + "@" + generation));
     }
 
     public byte[] getObjectData(String bucket, String objectName) {
         LOG.debugf("getObjectData bucket=%s name=%s", bucket, objectName);
-        byte[] data = objectData.get(objectKey(bucket, objectName));
+        String key = objectKey(bucket, objectName);
+        GcsObjectMeta meta = objectMetaStore.get(key).orElse(null);
+        if (meta != null && meta.getTimeDeleted() != null) {
+            throw GcpException.notFound("Object not found: " + objectName);
+        }
+        byte[] data = objectData.get(key);
         if (data == null) {
             LOG.warnf("getObjectData failed: object not found bucket=%s name=%s", bucket, objectName);
             throw GcpException.notFound("Object not found: " + objectName);
@@ -230,16 +303,80 @@ public class GcsService {
         return data;
     }
 
+    public byte[] getObjectData(String bucket, String objectName, String generation) {
+        LOG.debugf("getObjectData bucket=%s name=%s generation=%s", bucket, objectName, generation);
+        String liveKey = objectKey(bucket, objectName);
+        GcsObjectMeta live = objectMetaStore.get(liveKey).orElse(null);
+        if (live != null && generation.equals(live.getGeneration())) {
+            byte[] data = objectData.get(liveKey);
+            if (data != null) {
+                return data;
+            }
+        }
+        String archiveKey = liveKey + "\0" + generation;
+        byte[] data = objectData.get(archiveKey);
+        if (data == null) {
+            throw GcpException.notFound("Object version not found: " + objectName + "@" + generation);
+        }
+        return data;
+    }
+
     public boolean deleteObject(String bucket, String objectName) {
         LOG.infof("deleteObject bucket=%s name=%s", bucket, objectName);
         String key = objectKey(bucket, objectName);
-        objectData.remove(key);
-        if (objectMetaStore.get(key).isEmpty()) {
+        GcsObjectMeta live = objectMetaStore.get(key).orElse(null);
+        if (live == null) {
             LOG.debugf("deleteObject: object metadata not found bucket=%s name=%s", bucket, objectName);
             return false;
         }
+        if (live.getTimeDeleted() == null) {
+            checkObjectMutable(live);
+        }
+        if (isVersioningEnabled(bucket)) {
+            String archiveKey = key + "\0" + live.getGeneration();
+            GcsObjectMeta archived = cloneMeta(live);
+            archived.setIsLatest(false);
+            objectMetaStore.put(archiveKey, archived);
+            byte[] oldData = objectData.get(key);
+            if (oldData != null) {
+                objectData.put(archiveKey, oldData);
+            }
+            long markerGen = System.currentTimeMillis() + 1;
+            GcsObjectMeta marker = new GcsObjectMeta();
+            marker.setName(objectName);
+            marker.setBucket(bucket);
+            marker.setGeneration(String.valueOf(markerGen));
+            marker.setIsLatest(true);
+            String now = Instant.now().toString();
+            marker.setTimeDeleted(now);
+            marker.setTimeCreated(now);
+            marker.setUpdated(now);
+            objectMetaStore.put(key + "\0" + markerGen, marker);
+        }
+        GcsObjectMeta deletedMeta = live;
         objectMetaStore.delete(key);
+        objectData.remove(key);
+        if (deletedMeta != null) {
+            publishNotificationEvent(bucket, objectName, deletedMeta, "OBJECT_DELETE");
+        }
         return true;
+    }
+
+    public void deleteObjectVersion(String bucket, String objectName, String generation) {
+        LOG.infof("deleteObjectVersion bucket=%s name=%s generation=%s", bucket, objectName, generation);
+        String liveKey = objectKey(bucket, objectName);
+        GcsObjectMeta live = objectMetaStore.get(liveKey).orElse(null);
+        if (live != null && generation.equals(live.getGeneration())) {
+            objectMetaStore.delete(liveKey);
+            objectData.remove(liveKey);
+            return;
+        }
+        String archiveKey = liveKey + "\0" + generation;
+        if (objectMetaStore.get(archiveKey).isEmpty()) {
+            throw GcpException.notFound("Object version not found: " + objectName + "@" + generation);
+        }
+        objectMetaStore.delete(archiveKey);
+        objectData.remove(archiveKey);
     }
 
     public GcsObjectMeta patchObject(String bucket, String objectName, Map<String, Object> patch) {
@@ -264,6 +401,12 @@ public class GcsService {
             @SuppressWarnings("unchecked")
             Map<String, String> userMeta = (Map<String, String>) patch.get("metadata");
             meta.setMetadata(userMeta);
+        }
+        if (patch.containsKey("temporaryHold")) {
+            meta.setTemporaryHold((Boolean) patch.get("temporaryHold"));
+        }
+        if (patch.containsKey("eventBasedHold")) {
+            meta.setEventBasedHold((Boolean) patch.get("eventBasedHold"));
         }
         meta.setUpdated(Instant.now().toString());
         long mg = Long.parseLong(meta.getMetageneration() != null ? meta.getMetageneration() : "1");
@@ -339,9 +482,27 @@ public class GcsService {
             LOG.warnf("listObjects failed: bucket not found bucket=%s", bucket);
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
-        List<GcsObjectMeta> objects = objectMetaStore.scan(k -> k.startsWith(bucket + "\0"));
+        String prefix = bucket + "\0";
+        int prefixLen = prefix.length();
+        List<GcsObjectMeta> objects = objectMetaStore.scan(k ->
+                k.startsWith(prefix) && k.indexOf('\0', prefixLen) == -1
+                        && (objectMetaStore.get(k).map(m -> m.getTimeDeleted() == null).orElse(true)));
         LOG.debugf("listObjects bucket=%s count=%d", bucket, objects.size());
         return objects;
+    }
+
+    public List<GcsObjectMeta> listObjectVersions(String bucket, String prefix) {
+        LOG.debugf("listObjectVersions bucket=%s prefix=%s", bucket, prefix);
+        if (bucketStore.get(bucket).isEmpty()) {
+            throw GcpException.notFound("Bucket not found: " + bucket);
+        }
+        String bucketPrefix = bucket + "\0";
+        List<GcsObjectMeta> all = objectMetaStore.scan(k -> k.startsWith(bucketPrefix));
+        List<GcsObjectMeta> result = all.stream()
+                .filter(m -> prefix == null || prefix.isBlank() || m.getName() != null && m.getName().startsWith(prefix))
+                .toList();
+        LOG.debugf("listObjectVersions bucket=%s count=%d", bucket, result.size());
+        return result;
     }
 
     // ── ACLs ───────────────────────────────────────────────────────────────────
@@ -448,6 +609,199 @@ public class GcsService {
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data, baseUrl);
+    }
+
+    // ── Notifications ──────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    public StoredNotification createNotification(String bucket, Map<String, Object> body) {
+        LOG.infof("createNotification bucket=%s", bucket);
+        getBucket(bucket);
+        String prefix = bucket + ":";
+        int nextId = (int) notificationStore.scan(k -> k.startsWith(prefix)).size() + 1;
+        String id = String.valueOf(nextId);
+
+        StoredNotification notif = new StoredNotification();
+        notif.setId(id);
+        notif.setTopic((String) body.get("topic"));
+        String fmt = (String) body.get("payloadFormat");
+        if (fmt != null) notif.setPayloadFormat(fmt);
+        if (body.containsKey("eventTypes")) {
+            notif.setEventTypes((List<String>) body.get("eventTypes"));
+        }
+        if (body.containsKey("customAttributes")) {
+            notif.setCustomAttributes((Map<String, String>) body.get("customAttributes"));
+        }
+        if (body.containsKey("objectNamePrefix")) {
+            notif.setObjectNamePrefix((String) body.get("objectNamePrefix"));
+        }
+        notif.setSelfLink(config != null
+                ? config.baseUrl() + "/storage/v1/b/" + bucket + "/notificationConfigs/" + id
+                : "/storage/v1/b/" + bucket + "/notificationConfigs/" + id);
+        notificationStore.put(prefix + id, notif);
+        return notif;
+    }
+
+    public StoredNotification getNotification(String bucket, String notificationId) {
+        LOG.debugf("getNotification bucket=%s id=%s", bucket, notificationId);
+        return notificationStore.get(bucket + ":" + notificationId)
+                .orElseThrow(() -> GcpException.notFound(
+                        "Notification not found: " + notificationId));
+    }
+
+    public List<StoredNotification> listNotifications(String bucket) {
+        LOG.debugf("listNotifications bucket=%s", bucket);
+        String prefix = bucket + ":";
+        return notificationStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public void deleteNotification(String bucket, String notificationId) {
+        LOG.infof("deleteNotification bucket=%s id=%s", bucket, notificationId);
+        String key = bucket + ":" + notificationId;
+        if (notificationStore.get(key).isEmpty()) {
+            throw GcpException.notFound("Notification not found: " + notificationId);
+        }
+        notificationStore.delete(key);
+    }
+
+    private void publishNotificationEvent(String bucket, String objectName,
+            GcsObjectMeta meta, String eventType) {
+        if (pubSubService == null) return;
+        String prefix = bucket + ":";
+        List<StoredNotification> notifications = notificationStore.scan(k -> k.startsWith(prefix));
+        if (notifications.isEmpty()) return;
+
+        for (StoredNotification notif : notifications) {
+            if (notif.getEventTypes() != null && !notif.getEventTypes().contains(eventType)) {
+                continue;
+            }
+            String namePrefix = notif.getObjectNamePrefix();
+            if (namePrefix != null && !namePrefix.isBlank() && !objectName.startsWith(namePrefix)) {
+                continue;
+            }
+            try {
+                PubsubMessage.Builder msg = PubsubMessage.newBuilder()
+                        .putAttributes("eventType", eventType)
+                        .putAttributes("payloadFormat", notif.getPayloadFormat() != null
+                                ? notif.getPayloadFormat() : "JSON_API_V1")
+                        .putAttributes("bucketId", bucket)
+                        .putAttributes("objectId", objectName)
+                        .putAttributes("objectGeneration",
+                                meta.getGeneration() != null ? meta.getGeneration() : "0")
+                        .putAttributes("notificationConfig", notif.getSelfLink() != null
+                                ? notif.getSelfLink() : bucket + "/notificationConfigs/" + notif.getId());
+
+                if ("JSON_API_V1".equals(notif.getPayloadFormat()) || notif.getPayloadFormat() == null) {
+                    byte[] payload = MAPPER.writeValueAsBytes(meta);
+                    msg.setData(ByteString.copyFrom(payload));
+                }
+
+                pubSubService.publish(notif.getTopic(), List.of(msg.build()));
+            } catch (Exception e) {
+                LOG.warnf("Failed to publish GCS notification event bucket=%s object=%s topic=%s: %s",
+                        bucket, objectName, notif.getTopic(), e.getMessage());
+            }
+        }
+    }
+
+    public Optional<GcsBucket> findBucket(String name) {
+        return bucketStore.get(name);
+    }
+
+    public GcsBucket lockRetentionPolicy(String bucket, Long ifMetagenerationMatch) {
+        LOG.infof("lockRetentionPolicy bucket=%s", bucket);
+        GcsBucket b = getBucket(bucket);
+        long current = b.getMetageneration() != null ? Long.parseLong(b.getMetageneration()) : 1;
+        if (ifMetagenerationMatch != null && current != ifMetagenerationMatch) {
+            throw GcpException.conditionNotMet(
+                    "ifMetagenerationMatch: " + current + " != " + ifMetagenerationMatch);
+        }
+        Map<String, Object> rp = b.getRetentionPolicy();
+        if (rp == null) {
+            rp = new java.util.LinkedHashMap<>();
+        }
+        rp.put("isLocked", true);
+        if (!rp.containsKey("effectiveTime")) {
+            rp.put("effectiveTime", Instant.now().toString());
+        }
+        b.setRetentionPolicy(rp);
+        b.setMetageneration(String.valueOf(current + 1));
+        b.setUpdated(Instant.now().toString());
+        bucketStore.put(bucket, b);
+        return b;
+    }
+
+    private void checkObjectMutable(GcsObjectMeta meta) {
+        if (Boolean.TRUE.equals(meta.getTemporaryHold())) {
+            throw GcpException.permissionDenied(
+                    "Object '" + meta.getName() + "' is under a temporary hold.");
+        }
+        if (Boolean.TRUE.equals(meta.getEventBasedHold())) {
+            throw GcpException.permissionDenied(
+                    "Object '" + meta.getName() + "' is under an event-based hold.");
+        }
+        if (meta.getRetentionExpirationTime() != null) {
+            Instant expiry = Instant.parse(meta.getRetentionExpirationTime());
+            if (Instant.now().isBefore(expiry)) {
+                throw GcpException.permissionDenied(
+                        "Object '" + meta.getName() + "' is subject to the bucket's retention policy "
+                        + "and cannot be deleted or overwritten until "
+                        + meta.getRetentionExpirationTime());
+            }
+        }
+    }
+
+    private String computeRetentionExpiry(String bucket, String timeCreated) {
+        return bucketStore.get(bucket).map(b -> {
+            if (b.getRetentionPolicy() == null) {
+                return null;
+            }
+            Object period = b.getRetentionPolicy().get("retentionPeriod");
+            if (period == null) {
+                return null;
+            }
+            long seconds = period instanceof Number n ? n.longValue() : Long.parseLong(period.toString());
+            return Instant.parse(timeCreated).plusSeconds(seconds).toString();
+        }).orElse(null);
+    }
+
+    private boolean isVersioningEnabled(String bucketName) {
+        return bucketStore.get(bucketName)
+                .map(b -> {
+                    if (b.getVersioning() == null) {
+                        return false;
+                    }
+                    Object enabled = b.getVersioning().get("enabled");
+                    return Boolean.TRUE.equals(enabled);
+                })
+                .orElse(false);
+    }
+
+    private static GcsObjectMeta cloneMeta(GcsObjectMeta src) {
+        GcsObjectMeta copy = new GcsObjectMeta();
+        copy.setKind(src.getKind());
+        copy.setId(src.getId());
+        copy.setName(src.getName());
+        copy.setBucket(src.getBucket());
+        copy.setGeneration(src.getGeneration());
+        copy.setMetageneration(src.getMetageneration());
+        copy.setContentType(src.getContentType());
+        copy.setStorageClass(src.getStorageClass());
+        copy.setSize(src.getSize());
+        copy.setTimeCreated(src.getTimeCreated());
+        copy.setUpdated(src.getUpdated());
+        copy.setCrc32c(src.getCrc32c());
+        copy.setMd5Hash(src.getMd5Hash());
+        copy.setMediaLink(src.getMediaLink());
+        copy.setSelfLink(src.getSelfLink());
+        copy.setEtag(src.getEtag());
+        copy.setMetadata(src.getMetadata());
+        copy.setTimeDeleted(src.getTimeDeleted());
+        copy.setIsLatest(src.getIsLatest());
+        copy.setTemporaryHold(src.getTemporaryHold());
+        copy.setEventBasedHold(src.getEventBasedHold());
+        copy.setRetentionExpirationTime(src.getRetentionExpirationTime());
+        return copy;
     }
 
     private static String objectKey(String bucket, String objectName) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -1,39 +1,77 @@
 package io.floci.gcp.services.gcs;
 
+import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Handles GCS XML API downloads: GET /{bucket}/{object}.
- * The Google Cloud Go SDK uses this URL format when STORAGE_EMULATOR_HOST is set.
+ * Handles GCS XML API requests: GET/PUT /{bucket}/{object}.
+ * Used by Go SDK (STORAGE_EMULATOR_HOST) and for signed URL access.
  */
 @ApplicationScoped
 @Path("/{bucket: [a-z0-9._-]+}")
 public class GcsXmlDownloadController {
 
     private final GcsService service;
+    private final EmulatorConfig config;
 
     @Inject
-    public GcsXmlDownloadController(GcsService service) {
+    public GcsXmlDownloadController(GcsService service, EmulatorConfig config) {
         this.service = service;
+        this.config = config;
+    }
+
+    @OPTIONS
+    @Path("/{object: .*}")
+    public Response options() {
+        return Response.ok().build();
+    }
+
+    @OPTIONS
+    public Response optionsBucket() {
+        return Response.ok().build();
     }
 
     @GET
     @Path("/{object: .+}")
     public Response download(
             @PathParam("bucket") String bucket,
-            @PathParam("object") String objectPath) {
+            @PathParam("object") String objectPath,
+            @QueryParam("generation") String generation) {
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
+        if (generation != null) {
+            byte[] data = service.getObjectData(bucket, objectName, generation);
+            GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
+            return Response.ok(data).type(meta.getContentType()).build();
+        }
         byte[] data = service.getObjectData(bucket, objectName);
         GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
         return Response.ok(data).type(meta.getContentType()).build();
+    }
+
+    @PUT
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/{object: .+}")
+    public Response upload(
+            @PathParam("bucket") String bucket,
+            @PathParam("object") String objectPath,
+            @Context HttpHeaders headers,
+            byte[] body) {
+        String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
+        String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        String host = headers.getHeaderString("Host");
+        String baseUrl = host != null ? "http://" + host : config.baseUrl();
+        GcsObjectMeta meta = service.putObject(bucket, objectName, contentType, body != null ? body : new byte[0], baseUrl);
+        return Response.ok(meta).build();
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsBucket.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsBucket.java
@@ -28,6 +28,7 @@ public class GcsBucket {
     private Map<String, Object> lifecycle;
     private List<Map<String, Object>> cors;
     private Map<String, Object> retentionPolicy;
+    private Boolean defaultEventBasedHold;
 
     public String getKind() { return kind; }
     public void setKind(String kind) { this.kind = kind; }
@@ -80,4 +81,7 @@ public class GcsBucket {
 
     public Map<String, Object> getRetentionPolicy() { return retentionPolicy; }
     public void setRetentionPolicy(Map<String, Object> retentionPolicy) { this.retentionPolicy = retentionPolicy; }
+
+    public Boolean getDefaultEventBasedHold() { return defaultEventBasedHold; }
+    public void setDefaultEventBasedHold(Boolean defaultEventBasedHold) { this.defaultEventBasedHold = defaultEventBasedHold; }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
@@ -89,4 +89,25 @@ public class GcsObjectMeta {
 
     public Map<String, String> getMetadata() { return metadata; }
     public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
+
+    private String timeDeleted;
+    private Boolean isLatest;
+    private Boolean temporaryHold;
+    private Boolean eventBasedHold;
+    private String retentionExpirationTime;
+
+    public String getTimeDeleted() { return timeDeleted; }
+    public void setTimeDeleted(String timeDeleted) { this.timeDeleted = timeDeleted; }
+
+    public Boolean getIsLatest() { return isLatest; }
+    public void setIsLatest(Boolean isLatest) { this.isLatest = isLatest; }
+
+    public Boolean getTemporaryHold() { return temporaryHold; }
+    public void setTemporaryHold(Boolean temporaryHold) { this.temporaryHold = temporaryHold; }
+
+    public Boolean getEventBasedHold() { return eventBasedHold; }
+    public void setEventBasedHold(Boolean eventBasedHold) { this.eventBasedHold = eventBasedHold; }
+
+    public String getRetentionExpirationTime() { return retentionExpirationTime; }
+    public void setRetentionExpirationTime(String retentionExpirationTime) { this.retentionExpirationTime = retentionExpirationTime; }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/StoredNotification.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/StoredNotification.java
@@ -1,0 +1,45 @@
+package io.floci.gcp.services.gcs.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoredNotification {
+
+    private String kind = "storage#notification";
+    private String id;
+    private String selfLink;
+    private String topic;
+    private String payloadFormat = "JSON_API_V1";
+    private List<String> eventTypes;
+    private Map<String, String> customAttributes;
+    private String objectNamePrefix;
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getSelfLink() { return selfLink; }
+    public void setSelfLink(String selfLink) { this.selfLink = selfLink; }
+
+    public String getTopic() { return topic; }
+    public void setTopic(String topic) { this.topic = topic; }
+
+    public String getPayloadFormat() { return payloadFormat; }
+    public void setPayloadFormat(String payloadFormat) { this.payloadFormat = payloadFormat; }
+
+    public List<String> getEventTypes() { return eventTypes; }
+    public void setEventTypes(List<String> eventTypes) { this.eventTypes = eventTypes; }
+
+    public Map<String, String> getCustomAttributes() { return customAttributes; }
+    public void setCustomAttributes(Map<String, String> customAttributes) { this.customAttributes = customAttributes; }
+
+    public String getObjectNamePrefix() { return objectNamePrefix; }
+    public void setObjectNamePrefix(String objectNamePrefix) { this.objectNamePrefix = objectNamePrefix; }
+}


### PR DESCRIPTION
## Summary

- Add `temporaryHold`, `eventBasedHold`, and bucket retention policy enforcement to GCS objects — all three block delete and overwrite with HTTP 403 until the hold is cleared or the retention period expires 
- Add `POST /storage/v1/b/{bucket}/lockRetentionPolicy` endpoint; bucket `defaultEventBasedHold` auto-stamps new objects
- Fix GCS batch API (`POST /batch/storage/v1`) to canonicalize absolute URLs sent by the Java SDK, preventing double host-prepend on sub-requests
- Add Pub/Sub notification configs endpoint (`/notificationConfigs`) with real event delivery on OBJECT_FINALIZE and OBJECT_DELETE
- Add `POST /{object}` with `X-HTTP-Method-Override: PATCH` handler — required because `NetHttpTransport`/`HttpURLConnection` cannot send real PATCH requests


## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
