### PR TITLE
test(compatibility-tests): run Terraform and OpenTofu suites in CI

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -68,6 +68,8 @@ jobs:
           - sdk-test-node
           - sdk-test-python
           - sdk-test-go
+          - compat-terraform
+          - compat-opentofu
 
     steps:
       - name: Download floci-gcp image
@@ -119,6 +121,9 @@ jobs:
           mkdir -p test-results
           docker run --rm --network compat-net \
             -e FLOCI_GCP_ENDPOINT=http://floci-gcp:4588 \
+            -e FLOCI_ENDPOINT=http://floci-gcp:4588 \
+            -e FLOCI_HOST=floci-gcp:4588 \
+            -e FLOCI_PROJECT=test-project \
             -v "$(pwd)/test-results:/results" \
             compat-${{ matrix.test }}
 

--- a/compatibility-tests/compat-opentofu/.dockerignore
+++ b/compatibility-tests/compat-opentofu/.dockerignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup
+*.tfplan
+test-results/

--- a/compatibility-tests/compat-opentofu/Dockerfile
+++ b/compatibility-tests/compat-opentofu/Dockerfile
@@ -1,0 +1,28 @@
+FROM ghcr.io/opentofu/opentofu:1.8 AS opentofu
+
+FROM alpine:3.20
+
+# OpenTofu binary from the official image
+COPY --from=opentofu /usr/local/bin/tofu /usr/local/bin/tofu
+
+RUN apk add --no-cache bash curl jq git ncurses
+
+WORKDIR /app
+
+# Install bats and helpers (loaded via BATS_LIB_PATH in test_helper/common-setup)
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /opt/bats-core \
+    && git clone --depth 1 https://github.com/bats-core/bats-support.git /opt/bats-support \
+    && git clone --depth 1 https://github.com/bats-core/bats-assert.git /opt/bats-assert
+
+COPY . .
+
+# Defaults target the floci-gcp container on the compat-net Docker network;
+# override with -e at runtime for other endpoints.
+ENV FLOCI_ENDPOINT=http://floci-gcp:4588
+ENV FLOCI_HOST=floci-gcp:4588
+ENV FLOCI_PROJECT=test-project
+ENV GOOGLE_OAUTH_ACCESS_TOKEN=fake-token-floci-gcp
+ENV BATS_LIB_PATH=/opt
+
+RUN chmod +x /app/run-bats-in-container.sh && mkdir -p /results
+ENTRYPOINT ["./run-bats-in-container.sh"]

--- a/compatibility-tests/compat-opentofu/provider.tf
+++ b/compatibility-tests/compat-opentofu/provider.tf
@@ -36,5 +36,5 @@ provider "google" {
 
   storage_custom_endpoint        = "${var.endpoint}/storage/v1/"
   iam_custom_endpoint            = "${var.endpoint}/"
-  secret_manager_custom_endpoint = "${var.endpoint}/"
+  secret_manager_custom_endpoint = "${var.endpoint}/v1/"
 }

--- a/compatibility-tests/compat-opentofu/run-bats-in-container.sh
+++ b/compatibility-tests/compat-opentofu/run-bats-in-container.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+report_dir="$(mktemp -d /tmp/bats-junit-XXXXXX)"
+trap 'rm -rf "$report_dir"' EXIT
+
+set +e
+/opt/bats-core/bin/bats --report-formatter junit -o "$report_dir" test/
+status=$?
+set -e
+
+if [ -f "$report_dir/report.xml" ]; then
+    mv "$report_dir/report.xml" /results/junit.xml
+fi
+
+exit "$status"

--- a/compatibility-tests/compat-terraform/.dockerignore
+++ b/compatibility-tests/compat-terraform/.dockerignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup
+*.tfplan
+test-results/

--- a/compatibility-tests/compat-terraform/Dockerfile
+++ b/compatibility-tests/compat-terraform/Dockerfile
@@ -1,0 +1,28 @@
+FROM hashicorp/terraform:1.14.7 AS terraform
+
+FROM alpine:3.20
+
+# Terraform binary from the official image
+COPY --from=terraform /bin/terraform /usr/local/bin/terraform
+
+RUN apk add --no-cache bash curl jq git ncurses
+
+WORKDIR /app
+
+# Install bats and helpers (loaded via BATS_LIB_PATH in test_helper/common-setup)
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /opt/bats-core \
+    && git clone --depth 1 https://github.com/bats-core/bats-support.git /opt/bats-support \
+    && git clone --depth 1 https://github.com/bats-core/bats-assert.git /opt/bats-assert
+
+COPY . .
+
+# Defaults target the floci-gcp container on the compat-net Docker network;
+# override with -e at runtime for other endpoints.
+ENV FLOCI_ENDPOINT=http://floci-gcp:4588
+ENV FLOCI_HOST=floci-gcp:4588
+ENV FLOCI_PROJECT=test-project
+ENV GOOGLE_OAUTH_ACCESS_TOKEN=fake-token-floci-gcp
+ENV BATS_LIB_PATH=/opt
+
+RUN chmod +x /app/run-bats-in-container.sh && mkdir -p /results
+ENTRYPOINT ["./run-bats-in-container.sh"]

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -36,5 +36,5 @@ provider "google" {
 
   storage_custom_endpoint        = "${var.endpoint}/storage/v1/"
   iam_custom_endpoint            = "${var.endpoint}/"
-  secret_manager_custom_endpoint = "${var.endpoint}/"
+  secret_manager_custom_endpoint = "${var.endpoint}/v1/"
 }

--- a/compatibility-tests/compat-terraform/run-bats-in-container.sh
+++ b/compatibility-tests/compat-terraform/run-bats-in-container.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+report_dir="$(mktemp -d /tmp/bats-junit-XXXXXX)"
+trap 'rm -rf "$report_dir"' EXIT
+
+set +e
+/opt/bats-core/bin/bats --report-formatter junit -o "$report_dir" test/
+status=$?
+set -e
+
+if [ -f "$report_dir/report.xml" ]; then
+    mv "$report_dir/report.xml" /results/junit.xml
+fi
+
+exit "$status"

--- a/compatibility-tests/sdk-test-java/Dockerfile
+++ b/compatibility-tests/sdk-test-java/Dockerfile
@@ -18,4 +18,4 @@ ENV FIRESTORE_EMULATOR_HOST=floci-gcp:4588
 ENV DATASTORE_EMULATOR_HOST=floci-gcp:4588
 ENV STORAGE_EMULATOR_HOST=http://floci-gcp:4588
 
-ENTRYPOINT ["/bin/bash", "-c", "mvn test -q; status=$?; mkdir -p /results && cp -r target/surefire-reports/*.xml /results/ 2>/dev/null || true; exit $status"]
+ENTRYPOINT ["/bin/bash", "-c", "mvn test; status=$?; mkdir -p /results && cp -r target/surefire-reports/*.xml /results/ 2>/dev/null || true; exit $status"]


### PR DESCRIPTION
## Summary

The compat-terraform and compat-opentofu suites only ran locally via the justfile — they had no Dockerfile and were never added to the CI matrix. Containerize both (mirroring the aws-local pattern) and wire them into .github/workflows/compatibility.yml so they run on every PR.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
