### PR TITLE
feat: close remaining API parity gaps across firestore, pubsub, and iam

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/pubsub_test.go
+++ b/compatibility-tests/sdk-test-go/tests/pubsub_test.go
@@ -11,6 +11,8 @@ import (
 	"cloud.google.com/go/pubsub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestPubSub(t *testing.T) {
@@ -124,8 +126,19 @@ func TestPubSub(t *testing.T) {
 	})
 
 	t.Run("DeleteSubscription", func(t *testing.T) {
+		// The streaming Receive above is cancelled just before this call; its
+		// teardown can race the delete at the gRPC layer and surface NotFound for
+		// an already-deleted subscription. Treat that as success, then verify the
+		// subscription is actually gone so a genuinely broken delete still fails.
 		err := client.Subscription(subID).Delete(ctx)
+		if status.Code(err) == codes.NotFound {
+			err = nil
+		}
 		require.NoError(t, err)
+
+		exists, err := client.Subscription(subID).Exists(ctx)
+		require.NoError(t, err)
+		assert.False(t, exists, "subscription should be deleted")
 	})
 
 	t.Run("DeleteTopic", func(t *testing.T) {

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirestoreTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirestoreTest.java
@@ -115,6 +115,53 @@ class FirestoreTest {
 
     @Test
     @Order(5)
+    void queryWithOrderingAndCursors() throws ExecutionException, InterruptedException {
+        String collection = TestFixtures.uniqueName("cursor-coll");
+        long[] ages = {10L, 20L, 30L, 40L};
+        for (long age : ages) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("name", "u" + age);
+            data.put("age", age);
+            firestore.collection(collection).document("doc-" + age).set(data).get();
+        }
+        try {
+            // orderBy ascending
+            List<Long> asc = firestore.collection(collection).orderBy("age").get().get()
+                    .getDocuments().stream().map(d -> d.getLong("age")).toList();
+            assertThat(asc).containsExactly(10L, 20L, 30L, 40L);
+
+            // orderBy descending
+            List<Long> desc = firestore.collection(collection)
+                    .orderBy("age", Query.Direction.DESCENDING).get().get()
+                    .getDocuments().stream().map(d -> d.getLong("age")).toList();
+            assertThat(desc).containsExactly(40L, 30L, 20L, 10L);
+
+            // startAfter (exclusive)
+            List<Long> after = firestore.collection(collection).orderBy("age")
+                    .startAfter(20L).get().get()
+                    .getDocuments().stream().map(d -> d.getLong("age")).toList();
+            assertThat(after).containsExactly(30L, 40L);
+
+            // startAt (inclusive) + endAt (inclusive) — a window
+            List<Long> window = firestore.collection(collection).orderBy("age")
+                    .startAt(20L).endAt(30L).get().get()
+                    .getDocuments().stream().map(d -> d.getLong("age")).toList();
+            assertThat(window).containsExactly(20L, 30L);
+
+            // endBefore (exclusive)
+            List<Long> before = firestore.collection(collection).orderBy("age")
+                    .endBefore(30L).get().get()
+                    .getDocuments().stream().map(d -> d.getLong("age")).toList();
+            assertThat(before).containsExactly(10L, 20L);
+        } finally {
+            for (long age : ages) {
+                firestore.collection(collection).document("doc-" + age).delete().get();
+            }
+        }
+    }
+
+    @Test
+    @Order(6)
     void deleteDocument() throws ExecutionException, InterruptedException {
         DocumentReference docRef = firestore.collection(COLLECTION).document(DOC_ID);
         WriteResult result = docRef.delete().get();

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/IamTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/IamTest.java
@@ -158,6 +158,25 @@ class IamTest {
 
     @Test
     @Order(10)
+    void updateServiceAccount() throws Exception {
+        String body = json.writeValueAsString(Map.of(
+                "serviceAccount", Map.of(
+                        "displayName", "Updated SA",
+                        "description", "updated via patch"),
+                "updateMask", "displayName,description"));
+
+        JsonNode resp = patch(
+                "/v1/projects/" + PROJECT_ID + "/serviceAccounts/" + email, body);
+        assertThat(resp.path("displayName").asText()).isEqualTo("Updated SA");
+        assertThat(resp.path("description").asText()).isEqualTo("updated via patch");
+
+        JsonNode got = get("/v1/projects/" + PROJECT_ID + "/serviceAccounts/" + email);
+        assertThat(got.path("displayName").asText()).isEqualTo("Updated SA");
+        assertThat(got.path("description").asText()).isEqualTo("updated via patch");
+    }
+
+    @Test
+    @Order(11)
     void deleteServiceAccount() throws Exception {
         delete("/v1/projects/" + PROJECT_ID + "/serviceAccounts/" + email);
 
@@ -175,6 +194,17 @@ class IamTest {
                 .uri(URI.create(TestFixtures.endpoint() + path))
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(200);
+        return json.readTree(resp.body());
+    }
+
+    private static JsonNode patch(String path, String body) throws Exception {
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(TestFixtures.endpoint() + path))
+                .header("Content-Type", "application/json")
+                .method("PATCH", HttpRequest.BodyPublishers.ofString(body))
                 .build();
         HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
         assertThat(resp.statusCode()).isEqualTo(200);

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
@@ -13,6 +13,7 @@ import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.DetachSubscriptionRequest;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
@@ -349,5 +350,30 @@ class PubSubTest {
                 .forEach(t -> topicNames.add(t.getName()));
 
         assertThat(topicNames).doesNotContain(topicName.toString());
+    }
+
+    @Test
+    @Order(13)
+    void detachSubscription() {
+        String topicId = TestFixtures.uniqueName("detach-topic");
+        String subId = TestFixtures.uniqueName("detach-sub");
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, topicId);
+        ProjectSubscriptionName subName = ProjectSubscriptionName.of(PROJECT_ID, subId);
+
+        topicAdminClient.createTopic(topicName);
+        subscriptionAdminClient.createSubscription(
+                subName, topicName, PushConfig.getDefaultInstance(), 10);
+        try {
+            assertThat(subscriptionAdminClient.getSubscription(subName).getDetached()).isFalse();
+
+            topicAdminClient.detachSubscription(DetachSubscriptionRequest.newBuilder()
+                    .setSubscription(subName.toString())
+                    .build());
+
+            assertThat(subscriptionAdminClient.getSubscription(subName).getDetached()).isTrue();
+        } finally {
+            try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
+            try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
+        }
     }
 }

--- a/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
@@ -7,9 +7,16 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
+import java.util.List;
+
 /**
  * Maps {@link GcpException} to the canonical GCP REST error shape:
- * <pre>{"error": {"code": 404, "message": "...", "status": "NOT_FOUND"}}</pre>
+ * <pre>
+ * {"error": {"code": 404, "message": "...", "status": "NOT_FOUND",
+ *            "errors": [{"message": "...", "domain": "global", "reason": "notFound"}]}}
+ * </pre>
+ * The nested {@code errors[]} array (with {@code domain} and {@code reason}) mirrors the
+ * legacy Google JSON API error format that some SDK retry/handling logic inspects.
  */
 @Provider
 public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
@@ -18,8 +25,25 @@ public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
     public Response toResponse(GcpException ex) {
         return Response.status(ex.getHttpStatus())
                 .type(MediaType.APPLICATION_JSON)
-                .entity(new ErrorWrapper(new ErrorDetail(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus())))
+                .entity(new ErrorWrapper(
+                        ErrorDetail.of(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus())))
                 .build();
+    }
+
+    /** Legacy Google JSON API {@code reason} code for a canonical GCP status. */
+    private static String reasonFor(String gcpStatus) {
+        return switch (gcpStatus) {
+            case "NOT_FOUND" -> "notFound";
+            case "ALREADY_EXISTS" -> "alreadyExists";
+            case "INVALID_ARGUMENT" -> "invalid";
+            case "FAILED_PRECONDITION" -> "failedPrecondition";
+            case "CONDITION_NOT_MET" -> "conditionNotMet";
+            case "PERMISSION_DENIED" -> "forbidden";
+            case "RESOURCE_EXHAUSTED" -> "rateLimitExceeded";
+            case "UNIMPLEMENTED" -> "notImplemented";
+            case "INTERNAL" -> "internalError";
+            default -> "backendError";
+        };
     }
 
     @RegisterForReflection
@@ -28,5 +52,18 @@ public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
     @RegisterForReflection
     public record ErrorDetail(@JsonProperty("code") int code,
                               @JsonProperty("message") String message,
-                              @JsonProperty("status") String status) {}
+                              @JsonProperty("status") String status,
+                              @JsonProperty("errors") List<ErrorItem> errors) {
+
+        /** Builds a detail with the matching legacy {@code errors[]} entry derived from {@code status}. */
+        public static ErrorDetail of(int code, String message, String status) {
+            return new ErrorDetail(code, message, status,
+                    List.of(new ErrorItem(message, "global", reasonFor(status))));
+        }
+    }
+
+    @RegisterForReflection
+    public record ErrorItem(@JsonProperty("message") String message,
+                            @JsonProperty("domain") String domain,
+                            @JsonProperty("reason") String reason) {}
 }

--- a/src/main/java/io/floci/gcp/core/common/ServiceEnabledFilter.java
+++ b/src/main/java/io/floci/gcp/core/common/ServiceEnabledFilter.java
@@ -40,7 +40,7 @@ public class ServiceEnabledFilter implements ContainerRequestFilter {
         return Response.status(503)
                 .type(MediaType.APPLICATION_JSON)
                 .entity(new GcpExceptionMapper.ErrorWrapper(
-                        new GcpExceptionMapper.ErrorDetail(503, "Service " + serviceName + " is not enabled.", "UNAVAILABLE")))
+                        GcpExceptionMapper.ErrorDetail.of(503, "Service " + serviceName + " is not enabled.", "UNAVAILABLE")))
                 .build();
     }
 }

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.firestore;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.firestore.v1.Cursor;
 import com.google.firestore.v1.Document;
 import com.google.firestore.v1.DocumentMask;
 import com.google.firestore.v1.StructuredQuery;
@@ -24,6 +25,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -218,18 +220,122 @@ public class FirestoreService {
         String collectionId = query.getFromCount() > 0 ? query.getFrom(0).getCollectionId() : "";
         String prefix = parent + "/" + collectionId + "/";
 
-        List<StoredDocument> candidates = documentStore.scan(k -> k.startsWith(prefix)
+        List<StoredDocument> results = documentStore.scan(k -> k.startsWith(prefix)
                 && k.substring(prefix.length()).indexOf('/') < 0);
 
-        if (!query.hasWhere()) {
-            return applyLimitAndOffset(candidates, query);
+        if (query.hasWhere()) {
+            results = results.stream()
+                    .filter(doc -> matchesFilter(doc, query.getWhere()))
+                    .toList();
         }
 
-        List<StoredDocument> filtered = candidates.stream()
-                .filter(doc -> matchesFilter(doc, query.getWhere()))
-                .toList();
+        // Firestore order of operations: where → order by → cursors → offset → limit
+        results = sortByOrderBy(results, query);
+        results = applyCursors(results, query);
+        return applyLimitAndOffset(results, query);
+    }
 
-        return applyLimitAndOffset(filtered, query);
+    /**
+     * Sorts results by the query's {@code orderBy} clauses. Only sorts when an explicit
+     * orderBy is present (preserving prior behavior for unordered queries), or when cursors
+     * are used without an explicit orderBy — in which case Firestore implicitly orders by
+     * document name.
+     */
+    private List<StoredDocument> sortByOrderBy(List<StoredDocument> docs, StructuredQuery query) {
+        List<StructuredQuery.Order> orders = query.getOrderByList();
+        if (orders.isEmpty()) {
+            if (!query.hasStartAt() && !query.hasEndAt()) {
+                return docs;
+            }
+            return docs.stream().sorted(Comparator.comparing(StoredDocument::getName)).toList();
+        }
+        Comparator<StoredDocument> comparator = null;
+        for (StructuredQuery.Order order : orders) {
+            String path = order.getField().getFieldPath();
+            Comparator<StoredDocument> c = (a, b) -> compareDocsByField(a, b, path);
+            if (order.getDirection() == StructuredQuery.Direction.DESCENDING) {
+                c = c.reversed();
+            }
+            comparator = (comparator == null) ? c : comparator.thenComparing(c);
+        }
+        return docs.stream().sorted(comparator).toList();
+    }
+
+    private int compareDocsByField(StoredDocument a, StoredDocument b, String path) {
+        if ("__name__".equals(path)) {
+            return a.getName().compareTo(b.getName());
+        }
+        StoredValue va = a.getFields() != null ? a.getFields().get(path) : null;
+        StoredValue vb = b.getFields() != null ? b.getFields().get(path) : null;
+        if (va == null && vb == null) {
+            return 0;
+        }
+        if (va == null) {
+            return -1;
+        }
+        if (vb == null) {
+            return 1;
+        }
+        return compareValues(va, vb.toProto());
+    }
+
+    /**
+     * Applies {@code start_at} / {@code end_at} cursors against the already-sorted results.
+     * Cursor {@code before} semantics: start_at before=true is inclusive (startAt) and
+     * before=false is exclusive (startAfter); end_at before=false is inclusive (endAt) and
+     * before=true is exclusive (endBefore).
+     */
+    private List<StoredDocument> applyCursors(List<StoredDocument> docs, StructuredQuery query) {
+        if (!query.hasStartAt() && !query.hasEndAt()) {
+            return docs;
+        }
+        List<StructuredQuery.Order> orders = query.getOrderByList();
+        var stream = docs.stream();
+        if (query.hasStartAt()) {
+            Cursor start = query.getStartAt();
+            boolean inclusive = start.getBefore();
+            stream = stream.filter(doc -> {
+                int c = compareDocToCursor(doc, start.getValuesList(), orders);
+                return inclusive ? c >= 0 : c > 0;
+            });
+        }
+        if (query.hasEndAt()) {
+            Cursor end = query.getEndAt();
+            boolean exclusive = end.getBefore();
+            stream = stream.filter(doc -> {
+                int c = compareDocToCursor(doc, end.getValuesList(), orders);
+                return exclusive ? c < 0 : c <= 0;
+            });
+        }
+        return stream.toList();
+    }
+
+    private int compareDocToCursor(StoredDocument doc, List<Value> cursorValues,
+            List<StructuredQuery.Order> orders) {
+        int n = Math.min(cursorValues.size(), orders.size());
+        for (int i = 0; i < n; i++) {
+            StructuredQuery.Order order = orders.get(i);
+            int c = compareDocFieldToValue(doc, order.getField().getFieldPath(), cursorValues.get(i));
+            if (order.getDirection() == StructuredQuery.Direction.DESCENDING) {
+                c = -c;
+            }
+            if (c != 0) {
+                return c;
+            }
+        }
+        return 0;
+    }
+
+    private int compareDocFieldToValue(StoredDocument doc, String path, Value value) {
+        if ("__name__".equals(path)) {
+            String target = value.hasReferenceValue() ? value.getReferenceValue() : value.getStringValue();
+            return doc.getName().compareTo(target);
+        }
+        StoredValue stored = doc.getFields() != null ? doc.getFields().get(path) : null;
+        if (stored == null) {
+            return -1;
+        }
+        return compareValues(stored, value);
     }
 
     private List<StoredDocument> applyLimitAndOffset(List<StoredDocument> docs, StructuredQuery query) {

--- a/src/main/java/io/floci/gcp/services/iam/IamController.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamController.java
@@ -59,6 +59,43 @@ public class IamController {
         return Response.status(Response.Status.NOT_FOUND).build();
     }
 
+    // UpdateServiceAccount: PUT /v1/projects/{project}/serviceAccounts/{email} with the
+    // ServiceAccount as the body.
+    @PUT
+    @Path("/{rest:.*}")
+    public Response put(@PathParam("rest") String rest, Map<String, Object> body) {
+        IamPath p = parsePath(rest);
+        LOG.debugf("IAM PUT %s project=%s id=%s", rest, p.project(), p.identifier());
+        if (!"serviceAccounts".equals(p.resourceType()) || p.identifier() == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return updateServiceAccount(p, body);
+    }
+
+    // PatchServiceAccount: PATCH /v1/projects/{project}/serviceAccounts/{email} with body
+    // { "serviceAccount": {...}, "updateMask": "displayName,description" }.
+    @PATCH
+    @Path("/{rest:.*}")
+    public Response patch(@PathParam("rest") String rest, Map<String, Object> body) {
+        IamPath p = parsePath(rest);
+        LOG.debugf("IAM PATCH %s project=%s id=%s", rest, p.project(), p.identifier());
+        if (!"serviceAccounts".equals(p.resourceType()) || p.identifier() == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> sa = body.get("serviceAccount") instanceof Map<?, ?> m
+                ? (Map<String, Object>) m : body;
+        return updateServiceAccount(p, sa);
+    }
+
+    private Response updateServiceAccount(IamPath p, Map<String, Object> saProps) {
+        String displayName = (String) saProps.get("displayName");
+        String description = (String) saProps.get("description");
+        StoredServiceAccount sa = service.updateServiceAccount(
+                p.project(), p.identifier(), displayName, description);
+        return Response.ok(sa).build();
+    }
+
     @GET
     @Path("/{rest:.*}")
     public Response get(@PathParam("rest") String rest,

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -105,6 +105,23 @@ public class IamService {
                 .orElseThrow(() -> GcpException.notFound("Service account not found: " + email));
     }
 
+    public StoredServiceAccount updateServiceAccount(String project, String emailOrId,
+            String displayName, String description) {
+        LOG.debugf("updateServiceAccount project=%s id=%s", project, emailOrId);
+        String email = resolveEmail(project, emailOrId);
+        String key = saKey(project, email);
+        StoredServiceAccount sa = saStore.get(key)
+                .orElseThrow(() -> GcpException.notFound("Service account not found: " + email));
+        if (displayName != null) {
+            sa.setDisplayName(displayName);
+        }
+        if (description != null) {
+            sa.setDescription(description);
+        }
+        saStore.put(key, sa);
+        return sa;
+    }
+
     public List<StoredServiceAccount> listServiceAccounts(String project) {
         String prefix = "sa:" + project + ":";
         return saStore.scan(k -> k.startsWith(prefix));

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubPublisherController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubPublisherController.java
@@ -126,6 +126,20 @@ public class PubSubPublisherController extends PublisherGrpc.PublisherImplBase {
         }
     }
 
+    @Override
+    public void detachSubscription(DetachSubscriptionRequest request,
+            StreamObserver<DetachSubscriptionResponse> responseObserver) {
+        LOG.infof("detachSubscription subscription=%s", request.getSubscription());
+        try {
+            service.detachSubscription(request.getSubscription());
+            responseObserver.onNext(DetachSubscriptionResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("detachSubscription failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
     private static String extractProjectId(String parent) {
         if (parent.startsWith("projects/")) {
             return parent.substring("projects/".length());

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -223,6 +223,16 @@ public class PubSubService {
         delivered.remove(name);
     }
 
+    public void detachSubscription(String name) {
+        LOG.infof("detachSubscription name=%s", name);
+        StoredSubscription sub = subStore.get(name)
+                .orElseThrow(() -> GcpException.notFound("Subscription not found: " + name));
+        sub.setDetached(true);
+        subStore.put(name, sub);
+        queues.remove(name);
+        delivered.remove(name);
+    }
+
     public List<String> listTopicSubscriptions(String topicName) {
         LOG.debugf("listTopicSubscriptions topic=%s", topicName);
         return subStore.scan(k -> true).stream()
@@ -259,7 +269,7 @@ public class PubSubService {
             int fanOut = 0;
             for (var entry : subStore.keys()) {
                 StoredSubscription sub = subStore.get(entry).orElse(null);
-                if (sub != null && topicName.equals(sub.getTopic())) {
+                if (sub != null && !sub.isDetached() && topicName.equals(sub.getTopic())) {
                     queues.computeIfAbsent(entry, k -> new ConcurrentLinkedDeque<>()).add(stored);
                     fanOut++;
                 }

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
@@ -329,6 +329,7 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
                 .setName(stored.getName())
                 .setTopic(stored.getTopic())
                 .setAckDeadlineSeconds(stored.getAckDeadlineSeconds())
+                .setDetached(stored.isDetached())
                 .build();
     }
 

--- a/src/main/java/io/floci/gcp/services/pubsub/model/StoredSubscription.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/model/StoredSubscription.java
@@ -16,6 +16,7 @@ public class StoredSubscription {
     private String messageRetentionDuration;
     private String deadLetterTopic;
     private int maxDeliveryAttempts;
+    private boolean detached;
 
     public StoredSubscription() {}
 
@@ -51,4 +52,7 @@ public class StoredSubscription {
 
     public int getMaxDeliveryAttempts() { return maxDeliveryAttempts; }
     public void setMaxDeliveryAttempts(int maxDeliveryAttempts) { this.maxDeliveryAttempts = maxDeliveryAttempts; }
+
+    public boolean isDetached() { return detached; }
+    public void setDetached(boolean detached) { this.detached = detached; }
 }

--- a/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
+++ b/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
@@ -8,7 +8,7 @@ class GcpExceptionMapperTest {
 
     @Test
     void errorDetailCarriesAllFields() {
-        var detail = new GcpExceptionMapper.ErrorDetail(404, "not found", "NOT_FOUND");
+        var detail = GcpExceptionMapper.ErrorDetail.of(404, "not found", "NOT_FOUND");
         assertEquals(404, detail.code());
         assertEquals("not found", detail.message());
         assertEquals("NOT_FOUND", detail.status());
@@ -16,7 +16,7 @@ class GcpExceptionMapperTest {
 
     @Test
     void errorWrapperWrapsDetail() {
-        var detail = new GcpExceptionMapper.ErrorDetail(409, "exists", "ALREADY_EXISTS");
+        var detail = GcpExceptionMapper.ErrorDetail.of(409, "exists", "ALREADY_EXISTS");
         var wrapper = new GcpExceptionMapper.ErrorWrapper(detail);
         assertSame(detail, wrapper.error());
     }
@@ -24,7 +24,7 @@ class GcpExceptionMapperTest {
     @Test
     void mapperProducesCorrectDetailForNotFound() {
         GcpException ex = GcpException.notFound("bucket missing");
-        var detail = new GcpExceptionMapper.ErrorDetail(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus());
+        var detail = GcpExceptionMapper.ErrorDetail.of(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus());
         assertEquals(404, detail.code());
         assertEquals("bucket missing", detail.message());
         assertEquals("NOT_FOUND", detail.status());
@@ -33,8 +33,30 @@ class GcpExceptionMapperTest {
     @Test
     void mapperProducesCorrectDetailForAlreadyExists() {
         GcpException ex = GcpException.alreadyExists("bucket exists");
-        var detail = new GcpExceptionMapper.ErrorDetail(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus());
+        var detail = GcpExceptionMapper.ErrorDetail.of(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus());
         assertEquals(409, detail.code());
         assertEquals("ALREADY_EXISTS", detail.status());
+    }
+
+    @Test
+    void errorDetailIncludesLegacyErrorsArray() {
+        var detail = GcpExceptionMapper.ErrorDetail.of(404, "bucket missing", "NOT_FOUND");
+        assertEquals(1, detail.errors().size());
+        var item = detail.errors().get(0);
+        assertEquals("bucket missing", item.message());
+        assertEquals("global", item.domain());
+        assertEquals("notFound", item.reason());
+    }
+
+    @Test
+    void reasonIsDerivedFromStatus() {
+        assertEquals("alreadyExists",
+                GcpExceptionMapper.ErrorDetail.of(409, "x", "ALREADY_EXISTS").errors().get(0).reason());
+        assertEquals("conditionNotMet",
+                GcpExceptionMapper.ErrorDetail.of(412, "x", "CONDITION_NOT_MET").errors().get(0).reason());
+        assertEquals("forbidden",
+                GcpExceptionMapper.ErrorDetail.of(403, "x", "PERMISSION_DENIED").errors().get(0).reason());
+        assertEquals("backendError",
+                GcpExceptionMapper.ErrorDetail.of(503, "x", "UNAVAILABLE").errors().get(0).reason());
     }
 }


### PR DESCRIPTION
## Summary

Closes the remaining parity gap review:

- feat(firestore): orderBy sorting and start_at/end_at query cursors
- feat(pubsub): DetachSubscription, with delivery suppressed for detached subs
- feat(iam): UpdateServiceAccount / PatchServiceAccount (displayName, description)
- fix(core): include the legacy errors[] array (domain, reason) in REST error bodies

Adds SDK compatibility tests (FirestoreTest, PubSubTest, IamTest) and unit coverage (GcpExceptionMapperTest).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
