### PR TITLE
fix(storage): support gcloud storage cp uploads

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsMultipartUploadRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsMultipartUploadRawTest.java
@@ -1,0 +1,72 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for issue #14: `gcloud storage cp` sends a multipart upload
+ * whose Content-Type quotes the boundary with single quotes
+ * (`boundary='...'`, from Python apitools). The boundary parser only stripped
+ * double quotes, so the delimiter was not found and the upload failed with
+ * `400 "multipart boundary not found in body"`. Reproduced with a raw HTTP client.
+ */
+class GcsMultipartUploadRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("multipart-bucket");
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void multipartUploadWithSingleQuotedBoundarySucceeds() throws Exception {
+        String boundary = "===============4060149368708691179==";
+        String content = "hello world";
+        String body = "--" + boundary + "\r\n"
+                + "Content-Type: application/json\r\n\r\n"
+                + "{\"name\":\"hello.txt\"}\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/plain\r\n\r\n"
+                + content + "\r\n"
+                + "--" + boundary + "--";
+
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/upload/storage/v1/b/" + BUCKET + "/o?uploadType=multipart");
+        // Single-quoted boundary, exactly as gcloud / Python apitools sends it.
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .header("Content-Type", "multipart/related; boundary='" + boundary + "'")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("\"name\":\"hello.txt\"");
+
+        byte[] stored = storage.readAllBytes(BlobId.of(BUCKET, "hello.txt"));
+        assertThat(new String(stored, StandardCharsets.UTF_8)).isEqualTo(content);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsStorageLayoutRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsStorageLayoutRawTest.java
@@ -1,0 +1,69 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression coverage for issue #14: `gcloud storage cp` aborts before uploading
+ * because it first calls GET .../b/{bucket}/storageLayout, which was unimplemented
+ * and returned 405 (caught by the OPTIONS catch-all) instead of a valid
+ * storage#storageLayout resource. The high-level SDK does not expose this
+ * endpoint, so it is exercised with a raw HTTP client.
+ */
+class GcsStorageLayoutRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("layout-bucket");
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void storageLayoutReturnsValidResource() throws Exception {
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + BUCKET + "/storageLayout?alt=json");
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body())
+                .contains("\"kind\":\"storage#storageLayout\"")
+                .contains("\"bucket\":\"" + BUCKET + "\"")
+                .contains("\"hierarchicalNamespace\"")
+                .contains("\"enabled\":false");
+    }
+
+    @Test
+    void storageLayoutForMissingBucketReturns404() throws Exception {
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + TestFixtures.uniqueName("no-such") + "/storageLayout?alt=json");
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(404);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
@@ -133,6 +133,27 @@ public class GcsBucketController {
         return Response.ok(service.lockRetentionPolicy(bucket, ifMetagenerationMatch)).build();
     }
 
+    @GET
+    @Path("/{bucket}/storageLayout")
+    public Response getStorageLayout(@PathParam("bucket") String bucket) {
+        GcsBucket b = service.getBucket(bucket);
+        String location = b.getLocation() != null ? b.getLocation() : "US";
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "storage#storageLayout");
+        response.put("bucket", bucket);
+        response.put("location", location);
+        response.put("locationType", locationType(location));
+        response.put("hierarchicalNamespace", Map.of("enabled", false));
+        return Response.ok(response).build();
+    }
+
+    private static String locationType(String location) {
+        return switch (location.toUpperCase()) {
+            case "US", "EU", "ASIA" -> "multi-region";
+            default -> "region";
+        };
+    }
+
     // ── Bucket IAM ────────────────────────────────────────────────────────────
 
     @GET

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -203,7 +203,9 @@ public class GcsUploadController {
             String trimmed = segment.trim();
             if (trimmed.startsWith("boundary=")) {
                 String boundary = trimmed.substring("boundary=".length());
-                if (boundary.startsWith("\"") && boundary.endsWith("\"")) {
+                if (boundary.length() >= 2
+                        && ((boundary.startsWith("\"") && boundary.endsWith("\""))
+                        || (boundary.startsWith("'") && boundary.endsWith("'")))) {
                     boundary = boundary.substring(1, boundary.length() - 1);
                 }
                 return boundary;


### PR DESCRIPTION
## Summary

`gcloud storage cp` failed against floci-gcp with `GcsApiError('')`, reported in #14. Tracing the real CLI revealed **two** issues it hits in sequence:

1. **`storageLayout` unimplemented** — `gcloud storage` calls `GET /storage/v1/b/{bucket}/storageLayout` (to detect hierarchical-namespace support) before uploading. The route was unimplemented and resolved to the `OPTIONS` catch-all, returning **405**, so the CLI aborted before any upload. Now returns a valid `storage#storageLayout` resource.
2. **Single-quoted multipart boundary** — gcloud's multipart upload sets `Content-Type: multipart/related; boundary='...'` (single quotes, from Python apitools). The boundary parser only stripped double quotes, so the delimiter wasn't found → **400 "multipart boundary not found in body"**. Now tolerates single-quoted boundaries.

Closes #14.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behavior verified against the real `gcloud` CLI (Google Cloud SDK 571.0.0) with `CLOUDSDK_API_ENDPOINT_OVERRIDES_STORAGE`:

| Request gcloud issues | Before | After |
|---|---|---|
| `GET .../b/{bucket}/storageLayout` | 405 (CLI aborts) | 200 `storage#storageLayout` |
| `POST /upload/...?uploadType=multipart` with `boundary='...'` | 400 boundary not found | 200, object stored |

End-to-end after the fix: `gcloud storage cp` uploads, and `gcloud storage cat` / `ls` / download round-trip the content correctly.

## Checklist

- [x] `./mvnw test` passes locally (167/167)
- [x] New or updated integration test added (`GcsStorageLayoutRawTest`, `GcsMultipartUploadRawTest`; Java compat suite 21/21)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)