### PR TITLE
fix(storage): emit microsecond-precision GCS timestamps

### DIFF
--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -108,7 +109,7 @@ public class GcsService {
             LOG.warnf("createBucket failed: bucket already exists name=%s", name);
             throw GcpException.alreadyExists("Bucket already exists: " + name);
         }
-        String now = Instant.now().toString();
+        String now = nowTimestamp();
         GcsBucket bucket = new GcsBucket();
         bucket.setId(name);
         bucket.setName(name);
@@ -179,7 +180,7 @@ public class GcsService {
         if (patch.containsKey("defaultEventBasedHold")) {
             bucket.setDefaultEventBasedHold((Boolean) patch.get("defaultEventBasedHold"));
         }
-        bucket.setUpdated(Instant.now().toString());
+        bucket.setUpdated(nowTimestamp());
         bucketStore.put(name, bucket);
         return bucket;
     }
@@ -211,7 +212,7 @@ public class GcsService {
         }
         String key = objectKey(bucket, objectName);
         long generation = System.currentTimeMillis();
-        String now = Instant.now().toString();
+        String now = nowTimestamp();
         String encodedName = urlEncode(objectName);
 
         GcsObjectMeta existing = objectMetaStore.get(key).orElse(null);
@@ -348,7 +349,7 @@ public class GcsService {
             marker.setBucket(bucket);
             marker.setGeneration(String.valueOf(markerGen));
             marker.setIsLatest(true);
-            String now = Instant.now().toString();
+            String now = nowTimestamp();
             marker.setTimeDeleted(now);
             marker.setTimeCreated(now);
             marker.setUpdated(now);
@@ -409,7 +410,7 @@ public class GcsService {
         if (patch.containsKey("eventBasedHold")) {
             meta.setEventBasedHold((Boolean) patch.get("eventBasedHold"));
         }
-        meta.setUpdated(Instant.now().toString());
+        meta.setUpdated(nowTimestamp());
         long mg = Long.parseLong(meta.getMetageneration() != null ? meta.getMetageneration() : "1");
         meta.setMetageneration(String.valueOf(mg + 1));
         objectMetaStore.put(key, meta);
@@ -731,11 +732,11 @@ public class GcsService {
         }
         rp.put("isLocked", true);
         if (!rp.containsKey("effectiveTime")) {
-            rp.put("effectiveTime", Instant.now().toString());
+            rp.put("effectiveTime", nowTimestamp());
         }
         b.setRetentionPolicy(rp);
         b.setMetageneration(String.valueOf(current + 1));
-        b.setUpdated(Instant.now().toString());
+        b.setUpdated(nowTimestamp());
         bucketStore.put(bucket, b);
         return b;
     }
@@ -770,8 +771,18 @@ public class GcsService {
                 return null;
             }
             long seconds = period instanceof Number n ? n.longValue() : Long.parseLong(period.toString());
-            return Instant.parse(timeCreated).plusSeconds(seconds).toString();
+            return Instant.parse(timeCreated).plusSeconds(seconds)
+                    .truncatedTo(ChronoUnit.MICROS).toString();
         }).orElse(null);
+    }
+
+    /**
+     * Current time as an RFC 3339 string with at most microsecond precision.
+     * GCS timestamps are microsecond-resolution; emitting nanoseconds makes
+     * clients (e.g. the gcloud CLI) warn and truncate.
+     */
+    private static String nowTimestamp() {
+        return Instant.now().truncatedTo(ChronoUnit.MICROS).toString();
     }
 
     private boolean isVersioningEnabled(String bucketName) {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +36,20 @@ class GcsServiceTest {
         GcsBucket bucket = service.getBucket("my-bucket");
         assertNotNull(bucket);
         assertEquals("my-bucket", bucket.getName());
+    }
+
+    @Test
+    void timestampsUseAtMostMicrosecondPrecision() {
+        service.createBucket("ts-bucket", "p1", BASE_URL, Map.of());
+        GcsObjectMeta meta = service.putObject("ts-bucket", "obj.txt", "text/plain",
+                "x".getBytes(StandardCharsets.UTF_8), BASE_URL);
+
+        for (String ts : List.of(meta.getTimeCreated(), meta.getUpdated(),
+                service.getBucket("ts-bucket").getTimeCreated())) {
+            // Sub-microsecond digits make gcloud warn and truncate.
+            assertEquals(0, Instant.parse(ts).getNano() % 1000,
+                    "timestamp has finer-than-microsecond precision: " + ts);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

GCS object and bucket timestamps were rendered from `Instant.now().toString()` at **nanosecond** precision (e.g. `2026-06-04T00:09:29.700579716Z`). The GCS JSON API uses **microsecond** resolution, so the `gcloud` CLI logged a `Truncating the datetime string …` warning on every `ls`/`cat`.

Truncate all GCS timestamp emissions (`timeCreated`, `updated`, retention `effectiveTime`/expiry) to microseconds via a small `nowTimestamp()` helper.

Refs #14.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Verified against the real `gcloud` CLI (Google Cloud SDK 571.0.0):

| | Before | After |
|---|---|---|
| `timeCreated` JSON | `…:29.700579716Z` (9 digits) | `…:02.373643Z` (6 digits) |
| `gcloud storage ls`/`cat` | `WARNING: Truncating the datetime string …` | no warning |

## Checklist

- [x] `./mvnw test` passes locally (168/168)
- [x] New or updated integration test added (`GcsServiceTest#timestampsUseAtMostMicrosecondPrecision`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)