### PR TITLE
Support GCS range downloads

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsRangeDownloadRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsRangeDownloadRawTest.java
@@ -1,0 +1,83 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GcsRangeDownloadRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("range-bucket");
+    private static final String OBJECT = "range.txt";
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, OBJECT)).build(),
+                "0123456789abcdef".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void mediaDownloadHonorsRangeHeader() throws Exception {
+        assertRangeResponse(URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?alt=media"));
+    }
+
+    @Test
+    void mediaDownloadReturnsRangeNotSatisfiablePastEnd() throws Exception {
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?alt=media"))
+                        .header("Range", "bytes=16-20")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(416);
+    }
+
+    @Test
+    void downloadEndpointHonorsRangeHeader() throws Exception {
+        assertRangeResponse(URI.create(TestFixtures.endpoint()
+                + "/download/storage/v1/b/" + BUCKET + "/o/" + OBJECT));
+    }
+
+    @Test
+    void xmlDownloadHonorsRangeHeader() throws Exception {
+        assertRangeResponse(URI.create(TestFixtures.endpoint() + "/" + BUCKET + "/" + OBJECT));
+    }
+
+    private static void assertRangeResponse(URI uri) throws Exception {
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(uri)
+                        .header("Range", "bytes=4-7")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(206);
+        assertThat(response.headers().firstValue("Content-Range"))
+                .contains("bytes 4-7/16");
+        assertThat(response.body()).isEqualTo("4567");
+    }
+}

--- a/src/main/java/io/floci/gcp/core/common/GcpException.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpException.java
@@ -43,6 +43,10 @@ public class GcpException extends RuntimeException {
         return new GcpException(400, "INVALID_ARGUMENT", Status.Code.INVALID_ARGUMENT, message);
     }
 
+    public static GcpException outOfRange(String message) {
+        return new GcpException(416, "OUT_OF_RANGE", Status.Code.OUT_OF_RANGE, message);
+    }
+
     public static GcpException failedPrecondition(String message) {
         return new GcpException(400, "FAILED_PRECONDITION", Status.Code.FAILED_PRECONDITION, message);
     }

--- a/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
@@ -36,6 +36,7 @@ public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
             case "NOT_FOUND" -> "notFound";
             case "ALREADY_EXISTS" -> "alreadyExists";
             case "INVALID_ARGUMENT" -> "invalid";
+            case "OUT_OF_RANGE" -> "outOfRange";
             case "FAILED_PRECONDITION" -> "failedPrecondition";
             case "CONDITION_NOT_MET" -> "conditionNotMet";
             case "PERMISSION_DENIED" -> "forbidden";

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -30,16 +30,17 @@ public class GcsDownloadController {
             @PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @QueryParam("generation") String generation,
-            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256) {
+            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
+            @HeaderParam("Range") String rangeHeader) {
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
             byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
-            return Response.ok(data).type(meta.getContentType()).build();
+            return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
         }
         byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
         GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
-        return Response.ok(data).type(meta.getContentType()).build();
+        return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
@@ -1,0 +1,69 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Arrays;
+
+final class GcsMediaResponses {
+
+    private GcsMediaResponses() {}
+
+    static Response mediaResponse(byte[] data, String contentType, String rangeHeader) {
+        if (rangeHeader == null || rangeHeader.isBlank()) {
+            return Response.ok(data).type(contentType).build();
+        }
+
+        Range range = parseRange(rangeHeader, data.length);
+        byte[] body = Arrays.copyOfRange(data, range.start(), range.end() + 1);
+        return Response.status(Response.Status.PARTIAL_CONTENT)
+                .entity(body)
+                .type(contentType)
+                .header("Content-Range", "bytes " + range.start() + "-" + range.end() + "/" + data.length)
+                .build();
+    }
+
+    private static Range parseRange(String rangeHeader, int length) {
+        if (!rangeHeader.startsWith("bytes=")) {
+            throw GcpException.invalidArgument("invalid Range header: " + rangeHeader);
+        }
+        String spec = rangeHeader.substring("bytes=".length());
+        int dash = spec.indexOf('-');
+        if (dash < 0 || spec.indexOf(',', dash) >= 0) {
+            throw GcpException.invalidArgument("invalid Range header: " + rangeHeader);
+        }
+
+        int start;
+        int end;
+        if (dash == 0) {
+            int suffixLength = parseRangeInt(spec.substring(1), rangeHeader);
+            if (suffixLength <= 0) {
+                throw GcpException.invalidArgument("invalid Range header: " + rangeHeader);
+            }
+            start = Math.max(0, length - suffixLength);
+            end = length - 1;
+        } else {
+            start = parseRangeInt(spec.substring(0, dash), rangeHeader);
+            end = dash == spec.length() - 1 ? length - 1 : parseRangeInt(spec.substring(dash + 1), rangeHeader);
+        }
+
+        if (start >= length) {
+            throw GcpException.outOfRange("Range not satisfiable: " + rangeHeader);
+        }
+        if (start < 0 || end < start) {
+            throw GcpException.invalidArgument("invalid Range header: " + rangeHeader);
+        }
+        end = Math.min(end, length - 1);
+        return new Range(start, end);
+    }
+
+    private static int parseRangeInt(String value, String rangeHeader) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw GcpException.invalidArgument("invalid Range header: " + rangeHeader);
+        }
+    }
+
+    private record Range(int start, int end) {}
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -149,21 +149,22 @@ public class GcsObjectController {
             @PathParam("object") String objectPath,
             @QueryParam("alt") String alt,
             @QueryParam("generation") String generation,
-            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256) {
+            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
+            @HeaderParam("Range") String rangeHeader) {
         String objectName = decode(objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
             if ("media".equals(alt)) {
                 byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
                 GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
-                return Response.ok(data).type(meta.getContentType()).build();
+                return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
             }
             return Response.ok(service.getObjectMeta(bucket, objectName, generation)).build();
         }
         if ("media".equals(alt)) {
             byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
-            return Response.ok(data).type(meta.getContentType()).build();
+            return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
         }
         return Response.ok(service.getObjectMeta(bucket, objectName)).build();
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -47,17 +47,18 @@ public class GcsXmlDownloadController {
             @PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @QueryParam("generation") String generation,
-            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256) {
+            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
+            @HeaderParam("Range") String rangeHeader) {
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
             byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
-            return Response.ok(data).type(meta.getContentType()).build();
+            return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
         }
         byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
         GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
-        return Response.ok(data).type(meta.getContentType()).build();
+        return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
     }
 
     @PUT


### PR DESCRIPTION
## Summary

Support HTTP `Range` requests for Cloud Storage media download routes.

Closes #19

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behavior: media downloads returned the full object with HTTP 200 even when the request included a satisfiable `Range` header, and an unsatisfiable start offset returned the wrong error class for SDK callers.

The download routes now return HTTP 206 with `Content-Range` and the requested bytes. Unsatisfiable ranges now return HTTP 416 with `OUT_OF_RANGE`.

Checked against the Cloud Storage API: `Range: bytes=4-7` for an object containing `0123456789abcdef` returned HTTP 206, `Content-Range: bytes 4-7/16`, and body `4567`. Covered locally by `GcsRangeDownloadRawTest` for JSON media, `/download/storage/v1`, XML-style object downloads, and a past-end range returning HTTP 416.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
