### PR TITLE
Honor GCS list startOffset

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsListStartOffsetRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsListStartOffsetRawTest.java
@@ -1,0 +1,64 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GcsListStartOffsetRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("start-offset-bucket");
+    private static final String PREFIX = "list-order-raw/";
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        for (String name : new String[] {"C", "A", "B"}) {
+            storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, PREFIX + name)).build(), new byte[0]);
+        }
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void listHonorsStartOffset() throws Exception {
+        String startOffset = PREFIX + "B";
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + BUCKET + "/o?prefix=" + encode(PREFIX)
+                + "&startOffset=" + encode(startOffset));
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).doesNotContain(PREFIX + "A");
+        assertThat(response.body()).contains(PREFIX + "B", PREFIX + "C");
+        assertThat(response.body().indexOf(PREFIX + "B"))
+                .isLessThan(response.body().indexOf(PREFIX + "C"));
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.Response;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ public class GcsObjectController {
             @QueryParam("pageToken") String pageToken,
             @QueryParam("prefix") String prefix,
             @QueryParam("delimiter") String delimiter,
+            @QueryParam("startOffset") String startOffset,
             @QueryParam("versions") @DefaultValue("false") boolean includeVersions) {
         List<GcsObjectMeta> all = includeVersions
                 ? service.listObjectVersions(bucket, prefix)
@@ -55,6 +57,10 @@ public class GcsObjectController {
         if (!includeVersions && prefix != null && !prefix.isBlank()) {
             all = all.stream().filter(o -> o.getName().startsWith(prefix)).toList();
         }
+        all = all.stream()
+                .sorted(Comparator.comparing(GcsObjectMeta::getName))
+                .filter(o -> startOffset == null || o.getName().compareTo(startOffset) >= 0)
+                .toList();
         Set<String> prefixes = new TreeSet<>();
         if (delimiter != null && !delimiter.isEmpty()) {
             String basePrefix = prefix != null ? prefix : "";


### PR DESCRIPTION
## Summary

Honor `startOffset` when listing Cloud Storage objects.

Closes #21

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behavior: `objects.list` returned object names lower than the supplied `startOffset`.

The list response is ordered by object name and filters out names below `startOffset` before pagination. Checked against the Cloud Storage API with a bucket containing `list-order-raw/A`, `list-order-raw/B`, and `list-order-raw/C`: listing with `prefix=list-order-raw/` and `startOffset=list-order-raw/B` returned `list-order-raw/B,list-order-raw/C`. Covered locally by `GcsListStartOffsetRawTest`.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)