### PR TITLE
Keep GCS resumable uploads open

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadRawTest.java
@@ -1,0 +1,159 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GcsResumableUploadRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("resumable-bucket");
+    private static final String OBJECT = "resumable.bin";
+    private static final int FIRST_CHUNK_SIZE = 16 * 1024 * 1024;
+    private static final int SECOND_CHUNK_SIZE = 1024 * 1024;
+    private static final int TOTAL_SIZE = FIRST_CHUNK_SIZE + SECOND_CHUNK_SIZE;
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void resumableUploadKeepsSessionOpenUntilFinalChunk() throws Exception {
+        HttpResponse<String> init = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/upload/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=resumable&name=" + OBJECT))
+                        .header("X-Upload-Content-Type", "application/octet-stream")
+                        .header("X-Upload-Content-Length", String.valueOf(TOTAL_SIZE))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(init.statusCode()).isEqualTo(200);
+        URI uploadUri = URI.create(init.headers().firstValue("Location").orElseThrow());
+
+        HttpResponse<String> emptyStatus = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Range", "bytes */*")
+                        .PUT(HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(emptyStatus.statusCode()).isEqualTo(308);
+        assertThat(emptyStatus.headers().firstValue("Range")).isEmpty();
+
+        byte[] first = new byte[FIRST_CHUNK_SIZE];
+        byte[] second = new byte[SECOND_CHUNK_SIZE];
+        Arrays.fill(first, (byte) 'a');
+        Arrays.fill(second, (byte) 'b');
+
+        HttpResponse<String> firstChunk = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes 0-" + (FIRST_CHUNK_SIZE - 1) + "/*")
+                        .PUT(HttpRequest.BodyPublishers.ofByteArray(first))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(firstChunk.statusCode()).isEqualTo(308);
+        assertThat(firstChunk.headers().firstValue("Range"))
+                .contains("bytes=0-" + (FIRST_CHUNK_SIZE - 1));
+
+        HttpResponse<String> status = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Range", "bytes */" + TOTAL_SIZE)
+                        .PUT(HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(status.statusCode()).isEqualTo(308);
+        assertThat(status.headers().firstValue("Range"))
+                .contains("bytes=0-" + (FIRST_CHUNK_SIZE - 1));
+
+        HttpResponse<String> finalChunk = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes " + FIRST_CHUNK_SIZE + "-"
+                                + (TOTAL_SIZE - 1) + "/" + TOTAL_SIZE)
+                        .PUT(HttpRequest.BodyPublishers.ofByteArray(second))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(finalChunk.statusCode()).isEqualTo(200);
+        assertThat(finalChunk.body()).contains("\"size\":\"" + TOTAL_SIZE + "\"");
+
+        HttpResponse<byte[]> download = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?alt=media"))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(download.statusCode()).isEqualTo(200);
+        assertThat(download.body()).hasSize(TOTAL_SIZE);
+        assertThat(download.body()[0]).isEqualTo((byte) 'a');
+        assertThat(download.body()[FIRST_CHUNK_SIZE]).isEqualTo((byte) 'b');
+    }
+
+    @Test
+    void resumableUploadAcceptsUnknownSizeFinalChunk() throws Exception {
+        String objectName = "unknown-size.bin";
+        byte[] data = "unknown-size-data".getBytes(StandardCharsets.UTF_8);
+        HttpResponse<String> init = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/upload/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=resumable&name=" + objectName))
+                        .header("X-Upload-Content-Type", "application/octet-stream")
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(init.statusCode()).isEqualTo(200);
+        URI uploadUri = URI.create(init.headers().firstValue("Location").orElseThrow());
+
+        HttpResponse<String> upload = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes 0-*/*")
+                        .PUT(HttpRequest.BodyPublishers.ofByteArray(data))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(upload.statusCode()).isEqualTo(200);
+        assertThat(upload.body()).contains("\"size\":\"" + data.length + "\"");
+
+        HttpResponse<byte[]> download = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/storage/v1/b/" + BUCKET + "/o/" + objectName + "?alt=media"))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(download.statusCode()).isEqualTo(200);
+        assertThat(download.body()).containsExactly(data);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -625,7 +625,7 @@ public class GcsService {
         }
         String uploadId = UUID.randomUUID().toString();
         resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType,
-                customerEncryption.metadata()));
+                customerEncryption.metadata(), new byte[0]));
         LOG.debugf("startResumableUpload uploadId=%s", uploadId);
         return uploadId;
     }
@@ -639,6 +639,55 @@ public class GcsService {
         }
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
+    }
+
+    public long appendResumableUpload(String uploadId, long start, byte[] data) {
+        ResumableUpload upload = resumableUploads.get(uploadId);
+        if (upload == null) {
+            LOG.warnf("appendResumableUpload failed: upload not found uploadId=%s", uploadId);
+            throw GcpException.notFound("Resumable upload not found: " + uploadId);
+        }
+        byte[] combined = appendChunk(upload, start, data);
+        resumableUploads.put(uploadId, new ResumableUpload(
+                upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(), combined));
+        return combined.length - 1L;
+    }
+
+    public long resumableUploadLength(String uploadId) {
+        ResumableUpload upload = resumableUploads.get(uploadId);
+        if (upload == null) {
+            LOG.warnf("resumableUploadLength failed: upload not found uploadId=%s", uploadId);
+            throw GcpException.notFound("Resumable upload not found: " + uploadId);
+        }
+        return upload.data().length;
+    }
+
+    public GcsObjectMeta completeResumableUpload(String uploadId, long start, byte[] data,
+            long totalSize, String baseUrl) {
+        ResumableUpload upload = resumableUploads.get(uploadId);
+        if (upload == null) {
+            LOG.warnf("completeResumableUpload failed: upload not found uploadId=%s", uploadId);
+            throw GcpException.notFound("Resumable upload not found: " + uploadId);
+        }
+        byte[] combined = appendChunk(upload, start, data);
+        if (combined.length != totalSize) {
+            throw GcpException.invalidArgument(
+                    "Content-Range total size does not match uploaded bytes: " + totalSize);
+        }
+        resumableUploads.remove(uploadId);
+        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
+    }
+
+    private static byte[] appendChunk(ResumableUpload upload, long start, byte[] data) {
+        byte[] existing = upload.data();
+        if (start != existing.length) {
+            throw GcpException.invalidArgument("Content-Range start does not match uploaded bytes: " + start);
+        }
+        byte[] combined = new byte[existing.length + data.length];
+        System.arraycopy(existing, 0, combined, 0, existing.length);
+        System.arraycopy(data, 0, combined, existing.length, data.length);
+        return combined;
     }
 
     // ── Notifications ──────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -75,8 +75,76 @@ public class GcsUploadController {
         if (uploadId == null) {
             throw GcpException.invalidArgument("missing upload_id query parameter");
         }
+        String contentRange = headers.getHeaderString("Content-Range");
+        if (contentRange != null && !contentRange.isBlank()) {
+            ContentRange range = parseContentRange(contentRange, body.length);
+            if (range.statusQuery()) {
+                Response.ResponseBuilder response = Response.status(308);
+                long uploadedLength = service.resumableUploadLength(uploadId);
+                if (uploadedLength > 0) {
+                    response.header("Range", "bytes=0-" + (uploadedLength - 1));
+                }
+                return response.build();
+            }
+            if (range.totalSize() == null) {
+                long end = service.appendResumableUpload(uploadId, range.start(), body);
+                return Response.status(308).header("Range", "bytes=0-" + end).build();
+            }
+            GcsObjectMeta meta = service.completeResumableUpload(
+                    uploadId, range.start(), body, range.totalSize(), requestBaseUrl(headers));
+            return Response.ok(meta).build();
+        }
         GcsObjectMeta meta = service.completeResumableUpload(uploadId, body, requestBaseUrl(headers));
         return Response.ok(meta).build();
+    }
+
+    private record ContentRange(long start, long end, Long totalSize, boolean statusQuery) {}
+
+    private static ContentRange parseContentRange(String header, int bodyLength) {
+        if (!header.startsWith("bytes ")) {
+            throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+        }
+        String value = header.substring("bytes ".length());
+        if (value.startsWith("*/")) {
+            if (bodyLength != 0) {
+                throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+            }
+            String totalValue = value.substring(2);
+            Long totalSize = "*".equals(totalValue) ? null : parseLong(totalValue, header);
+            return new ContentRange(0, -1, totalSize, true);
+        }
+        int dash = value.indexOf('-');
+        int slash = value.indexOf('/');
+        if (dash < 0 || slash < 0 || slash < dash) {
+            throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+        }
+
+        long start = parseLong(value.substring(0, dash), header);
+        String endValue = value.substring(dash + 1, slash);
+        String totalValue = value.substring(slash + 1);
+        Long totalSize = "*".equals(totalValue) ? null : parseLong(totalValue, header);
+        long end;
+        if ("*".equals(endValue)) {
+            if (totalSize != null || bodyLength == 0) {
+                throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+            }
+            end = start + bodyLength - 1L;
+            totalSize = end + 1L;
+        } else {
+            end = parseLong(endValue, header);
+        }
+        if (start < 0 || end < start || bodyLength != end - start + 1) {
+            throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+        }
+        return new ContentRange(start, end, totalSize, false);
+    }
+
+    private static long parseLong(String value, String header) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+        }
     }
 
     private Response handleMultipart(String bucket, String nameParam, HttpHeaders headers, byte[] body,

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
@@ -3,5 +3,4 @@ package io.floci.gcp.services.gcs.model;
 import java.util.Map;
 
 public record ResumableUpload(String bucket, String objectName, String contentType,
-        Map<String, String> customerEncryption) {
-}
+        Map<String, String> customerEncryption, byte[] data) {}


### PR DESCRIPTION
## Summary

Keep Cloud Storage resumable upload sessions open until the final chunk.

Closes #23

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behavior: a non-final resumable upload chunk finalized the object and removed the upload session. The Node.js client default upload path also sends `Content-Range: bytes 0-*/*`, which must finalize the upload instead of failing header parsing.

Non-final chunks now return HTTP 308 with progress, and the object is finalized only after a final chunk. Unknown-size final chunks are accepted, and zero-byte status checks with `Content-Range: bytes */...` now return HTTP 308 with a `Range` header only after bytes have been persisted.

Checked against the Cloud Storage API: `Content-Range: bytes 0-262143/*` returned HTTP 308 with `Range: bytes=0-262143`, and the final chunk returned HTTP 200 with object size `263168`. Covered locally by `GcsResumableUploadRawTest`, including status checks and `Content-Range: bytes 0-*/*`. The Node.js Cloud Storage GCS suite also passes locally against the packaged emulator.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
