### PR TITLE
Enforce GCS customer encryption keys

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsCustomerEncryptionRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsCustomerEncryptionRawTest.java
@@ -1,0 +1,83 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GcsCustomerEncryptionRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("encryption-bucket");
+    private static final String OBJECT = "encrypted.txt";
+    private static final byte[] KEY = "0123456789abcdef0123456789abcdef".getBytes(UTF_8);
+    private static final String ENCODED_KEY = Base64.getEncoder().encodeToString(KEY);
+    private static final String KEY_SHA256 = keySha256(KEY);
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(objectUri())
+                        .header("x-goog-encryption-algorithm", "AES256")
+                        .header("x-goog-encryption-key", ENCODED_KEY)
+                        .header("x-goog-encryption-key-sha256", KEY_SHA256)
+                        .PUT(HttpRequest.BodyPublishers.ofString("encrypted-data"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void encryptedObjectRequiresCustomerKeyForDownload() throws Exception {
+        HttpResponse<String> missingKey = CLIENT.send(
+                HttpRequest.newBuilder(objectUri()).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(missingKey.statusCode()).isEqualTo(403);
+
+        HttpResponse<String> withKey = CLIENT.send(
+                HttpRequest.newBuilder(objectUri())
+                        .header("x-goog-encryption-algorithm", "AES256")
+                        .header("x-goog-encryption-key", ENCODED_KEY)
+                        .header("x-goog-encryption-key-sha256", KEY_SHA256)
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(withKey.statusCode()).isEqualTo(200);
+        assertThat(withKey.body()).isEqualTo("encrypted-data");
+    }
+
+    private static URI objectUri() {
+        return URI.create(TestFixtures.endpoint() + "/" + BUCKET + "/" + OBJECT);
+    }
+
+    private static String keySha256(byte[] key) {
+        try {
+            return Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-256").digest(key));
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsCustomerEncryption.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsCustomerEncryption.java
@@ -1,0 +1,68 @@
+package io.floci.gcp.services.gcs;
+
+import jakarta.ws.rs.core.HttpHeaders;
+
+import java.util.Map;
+
+final class GcsCustomerEncryption {
+
+    private static final String ALGORITHM_HEADER = "x-goog-encryption-algorithm";
+    private static final String KEY_SHA256_HEADER = "x-goog-encryption-key-sha256";
+    private static final String ALGORITHM = "AES256";
+    private static final GcsCustomerEncryption NONE = new GcsCustomerEncryption(null, null);
+
+    private final String algorithm;
+    private final String keySha256;
+
+    private GcsCustomerEncryption(String algorithm, String keySha256) {
+        this.algorithm = algorithm;
+        this.keySha256 = keySha256;
+    }
+
+    static GcsCustomerEncryption none() {
+        return NONE;
+    }
+
+    static GcsCustomerEncryption fromHeaders(HttpHeaders headers) {
+        String keySha256 = keySha256(headers);
+        if (keySha256 == null) {
+            return none();
+        }
+        String algorithm = headers.getHeaderString(ALGORITHM_HEADER);
+        if (algorithm == null || algorithm.isBlank()) {
+            algorithm = ALGORITHM;
+        }
+        return new GcsCustomerEncryption(algorithm, keySha256);
+    }
+
+    static GcsCustomerEncryption fromKeySha256(String keySha256) {
+        if (keySha256 == null || keySha256.isBlank()) {
+            return none();
+        }
+        return new GcsCustomerEncryption(ALGORITHM, keySha256);
+    }
+
+    static GcsCustomerEncryption fromMetadata(Map<String, String> metadata) {
+        if (metadata == null) {
+            return none();
+        }
+        return new GcsCustomerEncryption(metadata.get("encryptionAlgorithm"), metadata.get("keySha256"));
+    }
+
+    Map<String, String> metadata() {
+        if (keySha256 == null) {
+            return null;
+        }
+        return Map.of(
+                "encryptionAlgorithm", algorithm,
+                "keySha256", keySha256);
+    }
+
+    String keySha256() {
+        return keySha256;
+    }
+
+    private static String keySha256(HttpHeaders headers) {
+        return headers.getHeaderString(KEY_SHA256_HEADER);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -4,6 +4,7 @@ import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
@@ -28,14 +29,16 @@ public class GcsDownloadController {
     public Response download(
             @PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
-            @QueryParam("generation") String generation) {
+            @QueryParam("generation") String generation,
+            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256) {
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
+        GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
-            byte[] data = service.getObjectData(bucket, objectName, generation);
+            byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
             return Response.ok(data).type(meta.getContentType()).build();
         }
-        byte[] data = service.getObjectData(bucket, objectName);
+        byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
         GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
         return Response.ok(data).type(meta.getContentType()).build();
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -142,18 +142,20 @@ public class GcsObjectController {
     public Response getObject(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @QueryParam("alt") String alt,
-            @QueryParam("generation") String generation) {
+            @QueryParam("generation") String generation,
+            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256) {
         String objectName = decode(objectPath);
+        GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
             if ("media".equals(alt)) {
-                byte[] data = service.getObjectData(bucket, objectName, generation);
+                byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
                 GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
                 return Response.ok(data).type(meta.getContentType()).build();
             }
             return Response.ok(service.getObjectMeta(bucket, objectName, generation)).build();
         }
         if ("media".equals(alt)) {
-            byte[] data = service.getObjectData(bucket, objectName);
+            byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
             return Response.ok(data).type(meta.getContentType()).build();
         }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -203,7 +203,8 @@ public class GcsService {
         return buckets;
     }
 
-    public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data, String baseUrl) {
+    public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
+            GcsCustomerEncryption customerEncryption, String baseUrl) {
         LOG.debugf("putObject bucket=%s name=%s contentType=%s size=%d", bucket, objectName, contentType, data.length);
         GcsBucket b = bucketStore.get(bucket).orElse(null);
         if (b == null) {
@@ -240,6 +241,7 @@ public class GcsService {
         meta.setGeneration(String.valueOf(generation));
         meta.setSize(String.valueOf(data.length));
         meta.setContentType(contentType != null ? contentType : "application/octet-stream");
+        meta.setCustomerEncryption(customerEncryption.metadata());
         meta.setStorageClass("STANDARD");
         meta.setTimeCreated(now);
         meta.setUpdated(now);
@@ -290,13 +292,14 @@ public class GcsService {
                         "Object version not found: " + objectName + "@" + generation));
     }
 
-    public byte[] getObjectData(String bucket, String objectName) {
+    public byte[] getObjectData(String bucket, String objectName, GcsCustomerEncryption customerEncryption) {
         LOG.debugf("getObjectData bucket=%s name=%s", bucket, objectName);
         String key = objectKey(bucket, objectName);
         GcsObjectMeta meta = objectMetaStore.get(key).orElse(null);
         if (meta != null && meta.getTimeDeleted() != null) {
             throw GcpException.notFound("Object not found: " + objectName);
         }
+        checkCustomerEncryption(meta, customerEncryption);
         byte[] data = objectData.get(key);
         if (data == null) {
             LOG.warnf("getObjectData failed: object not found bucket=%s name=%s", bucket, objectName);
@@ -305,22 +308,35 @@ public class GcsService {
         return data;
     }
 
-    public byte[] getObjectData(String bucket, String objectName, String generation) {
+    public byte[] getObjectData(String bucket, String objectName, String generation,
+            GcsCustomerEncryption customerEncryption) {
         LOG.debugf("getObjectData bucket=%s name=%s generation=%s", bucket, objectName, generation);
         String liveKey = objectKey(bucket, objectName);
         GcsObjectMeta live = objectMetaStore.get(liveKey).orElse(null);
         if (live != null && generation.equals(live.getGeneration())) {
+            checkCustomerEncryption(live, customerEncryption);
             byte[] data = objectData.get(liveKey);
             if (data != null) {
                 return data;
             }
         }
         String archiveKey = liveKey + "\0" + generation;
+        checkCustomerEncryption(objectMetaStore.get(archiveKey).orElse(null), customerEncryption);
         byte[] data = objectData.get(archiveKey);
         if (data == null) {
             throw GcpException.notFound("Object version not found: " + objectName + "@" + generation);
         }
         return data;
+    }
+
+    private static void checkCustomerEncryption(GcsObjectMeta meta, GcsCustomerEncryption customerEncryption) {
+        if (meta == null || meta.getCustomerEncryption() == null) {
+            return;
+        }
+        String expected = meta.getCustomerEncryption().get("keySha256");
+        if (!expected.equals(customerEncryption.keySha256())) {
+            throw GcpException.permissionDenied("Missing or invalid customer-supplied encryption key");
+        }
     }
 
     public boolean deleteObject(String bucket, String objectName) {
@@ -425,7 +441,7 @@ public class GcsService {
         }
         byte[] composed = new byte[0];
         for (String src : sourceNames) {
-            byte[] data = getObjectData(bucket, src);
+            byte[] data = getObjectData(bucket, src, GcsCustomerEncryption.none());
             byte[] merged = new byte[composed.length + data.length];
             System.arraycopy(composed, 0, merged, 0, composed.length);
             System.arraycopy(data, 0, merged, composed.length, data.length);
@@ -437,7 +453,7 @@ public class GcsService {
                     .map(GcsObjectMeta::getContentType).orElse(null);
         }
         return putObject(bucket, destObject, resolvedType != null ? resolvedType : "application/octet-stream",
-                composed, baseUrl);
+                composed, GcsCustomerEncryption.none(), baseUrl);
     }
 
     public void checkPreconditions(String bucket, String objectName,
@@ -474,8 +490,9 @@ public class GcsService {
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject, String baseUrl) {
         LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
         GcsObjectMeta srcMeta = getObjectMeta(srcBucket, srcObject);
-        byte[] data = getObjectData(srcBucket, srcObject);
-        GcsObjectMeta dstMeta = putObject(dstBucket, dstObject, srcMeta.getContentType(), data, baseUrl);
+        byte[] data = getObjectData(srcBucket, srcObject, GcsCustomerEncryption.none());
+        GcsObjectMeta dstMeta = putObject(dstBucket, dstObject, srcMeta.getContentType(), data,
+                GcsCustomerEncryption.none(), baseUrl);
         if (srcMeta.getMetadata() != null) {
             dstMeta.setMetadata(new LinkedHashMap<>(srcMeta.getMetadata()));
         }
@@ -599,14 +616,16 @@ public class GcsService {
         return acl;
     }
 
-    public String startResumableUpload(String bucket, String objectName, String contentType) {
+    public String startResumableUpload(String bucket, String objectName, String contentType,
+            GcsCustomerEncryption customerEncryption) {
         LOG.debugf("startResumableUpload bucket=%s name=%s contentType=%s", bucket, objectName, contentType);
         if (bucketStore.get(bucket).isEmpty()) {
             LOG.warnf("startResumableUpload failed: bucket not found bucket=%s", bucket);
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
         String uploadId = UUID.randomUUID().toString();
-        resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType));
+        resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType,
+                customerEncryption.metadata()));
         LOG.debugf("startResumableUpload uploadId=%s", uploadId);
         return uploadId;
     }
@@ -618,7 +637,8 @@ public class GcsService {
             LOG.warnf("completeResumableUpload failed: upload not found uploadId=%s", uploadId);
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
-        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data, baseUrl);
+        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
     }
 
     // ── Notifications ──────────────────────────────────────────────────────────
@@ -816,6 +836,7 @@ public class GcsService {
         copy.setSelfLink(src.getSelfLink());
         copy.setEtag(src.getEtag());
         copy.setMetadata(src.getMetadata());
+        copy.setCustomerEncryption(src.getCustomerEncryption());
         copy.setTimeDeleted(src.getTimeDeleted());
         copy.setIsLatest(src.getIsLatest());
         copy.setTemporaryHold(src.getTemporaryHold());

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -101,7 +101,8 @@ public class GcsUploadController {
         }
         preconditions.check(service, bucket, objectName);
         byte[] dataBytes = extractPartBody(rawParts[1]).getBytes(ISO);
-        GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes, requestBaseUrl(headers));
+        GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes,
+                GcsCustomerEncryption.fromHeaders(headers), requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 
@@ -132,7 +133,8 @@ public class GcsUploadController {
         }
 
         preconditions.check(service, bucket, name);
-        String uploadId = service.startResumableUpload(bucket, name, contentType);
+        String uploadId = service.startResumableUpload(bucket, name, contentType,
+                GcsCustomerEncryption.fromHeaders(headers));
         String location = requestBaseUrl(headers) + "/upload/storage/v1/b/" + bucket
                 + "/o?uploadType=resumable&upload_id=" + uploadId;
 
@@ -143,7 +145,8 @@ public class GcsUploadController {
             Preconditions preconditions) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         preconditions.check(service, bucket, name);
-        GcsObjectMeta meta = service.putObject(bucket, name, contentType, body, requestBaseUrl(headers));
+        GcsObjectMeta meta = service.putObject(bucket, name, contentType, body,
+                GcsCustomerEncryption.fromHeaders(headers), requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -46,14 +46,16 @@ public class GcsXmlDownloadController {
     public Response download(
             @PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
-            @QueryParam("generation") String generation) {
+            @QueryParam("generation") String generation,
+            @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256) {
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
+        GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
-            byte[] data = service.getObjectData(bucket, objectName, generation);
+            byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
             GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
             return Response.ok(data).type(meta.getContentType()).build();
         }
-        byte[] data = service.getObjectData(bucket, objectName);
+        byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
         GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
         return Response.ok(data).type(meta.getContentType()).build();
     }
@@ -71,7 +73,8 @@ public class GcsXmlDownloadController {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String host = headers.getHeaderString("Host");
         String baseUrl = host != null ? "http://" + host : config.baseUrl();
-        GcsObjectMeta meta = service.putObject(bucket, objectName, contentType, body != null ? body : new byte[0], baseUrl);
+        GcsObjectMeta meta = service.putObject(bucket, objectName, contentType, body != null ? body : new byte[0],
+                GcsCustomerEncryption.fromHeaders(headers), baseUrl);
         return Response.ok(meta).build();
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
@@ -29,6 +29,7 @@ public class GcsObjectMeta {
     private String contentEncoding;
     private String contentLanguage;
     private Map<String, String> metadata;
+    private Map<String, String> customerEncryption;
 
     public String getKind() { return kind; }
     public void setKind(String kind) { this.kind = kind; }
@@ -89,6 +90,9 @@ public class GcsObjectMeta {
 
     public Map<String, String> getMetadata() { return metadata; }
     public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
+
+    public Map<String, String> getCustomerEncryption() { return customerEncryption; }
+    public void setCustomerEncryption(Map<String, String> customerEncryption) { this.customerEncryption = customerEncryption; }
 
     private String timeDeleted;
     private Boolean isLatest;

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
@@ -1,3 +1,7 @@
 package io.floci.gcp.services.gcs.model;
 
-public record ResumableUpload(String bucket, String objectName, String contentType) {}
+import java.util.Map;
+
+public record ResumableUpload(String bucket, String objectName, String contentType,
+        Map<String, String> customerEncryption) {
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -42,7 +42,7 @@ class GcsServiceTest {
     void timestampsUseAtMostMicrosecondPrecision() {
         service.createBucket("ts-bucket", "p1", BASE_URL, Map.of());
         GcsObjectMeta meta = service.putObject("ts-bucket", "obj.txt", "text/plain",
-                "x".getBytes(StandardCharsets.UTF_8), BASE_URL);
+                "x".getBytes(StandardCharsets.UTF_8), GcsCustomerEncryption.none(), BASE_URL);
 
         for (String ts : List.of(meta.getTimeCreated(), meta.getUpdated(),
                 service.getBucket("ts-bucket").getTimeCreated())) {
@@ -82,14 +82,15 @@ class GcsServiceTest {
         service.createBucket("bucket", "p1", BASE_URL, Map.of());
         byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
 
-        GcsObjectMeta meta = service.putObject("bucket", "obj.txt", "text/plain", data, BASE_URL);
+        GcsObjectMeta meta = service.putObject("bucket", "obj.txt", "text/plain", data,
+                GcsCustomerEncryption.none(), BASE_URL);
 
         assertNotNull(meta);
         assertEquals("obj.txt", meta.getName());
         assertEquals("text/plain", meta.getContentType());
         assertEquals(String.valueOf(data.length), meta.getSize());
 
-        byte[] retrieved = service.getObjectData("bucket", "obj.txt");
+        byte[] retrieved = service.getObjectData("bucket", "obj.txt", GcsCustomerEncryption.none());
         assertArrayEquals(data, retrieved);
     }
 
@@ -105,7 +106,8 @@ class GcsServiceTest {
     @Test
     void deleteObjectRemovesFromStorage() {
         service.createBucket("bucket", "p1", BASE_URL, Map.of());
-        service.putObject("bucket", "obj.txt", "text/plain", new byte[]{1}, BASE_URL);
+        service.putObject("bucket", "obj.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
 
         assertTrue(service.deleteObject("bucket", "obj.txt"));
 
@@ -117,8 +119,10 @@ class GcsServiceTest {
     @Test
     void listObjectsReturnsAll() {
         service.createBucket("bucket", "p1", BASE_URL, Map.of());
-        service.putObject("bucket", "a/1.txt", "text/plain", new byte[]{1}, BASE_URL);
-        service.putObject("bucket", "b/2.txt", "text/plain", new byte[]{2}, BASE_URL);
+        service.putObject("bucket", "a/1.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        service.putObject("bucket", "b/2.txt", "text/plain", new byte[]{2},
+                GcsCustomerEncryption.none(), BASE_URL);
 
         List<GcsObjectMeta> objects = service.listObjects("bucket");
         assertEquals(2, objects.size());


### PR DESCRIPTION
## Summary

Support Cloud Storage customer-supplied encryption metadata on object uploads and require the matching key hash for object media downloads.

Closes #28

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behavior: object data written with customer-supplied encryption headers could be downloaded without sending the matching customer-supplied encryption key headers.

The GCS XML, JSON media, and download routes now preserve `customerEncryption` metadata and reject object data reads when the request does not include the stored `x-goog-encryption-key-sha256` value. Checked against the Cloud Storage API: object metadata included `customerEncryption.encryptionAlgorithm=AES256` and the expected `customerEncryption.keySha256`; an unkeyed media read returned HTTP 400; a keyed media read returned HTTP 200 with the original object bytes. Checked locally with `GcsCustomerEncryptionRawTest`, which writes an object with `x-goog-encryption-*` headers, verifies an unkeyed download is rejected, and verifies a keyed download succeeds.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)