### PR TITLE
Reject expired GCS signed URLs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSignedUrlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSignedUrlTest.java
@@ -32,6 +32,8 @@ class GcsSignedUrlTest {
     private static final String BUCKET_NAME = TestFixtures.uniqueName("signed-url-bucket");
     private static final String OBJECT_NAME = "test/signed-object.txt";
     private static final String OBJECT_CONTENT = "content via signed URL";
+    private static final long MAX_EXPIRES_SECONDS = 604_800;
+    private static final String INVALID_EXPIRES = String.valueOf(MAX_EXPIRES_SECONDS + 1);
 
     private static Storage storage;
     private static ServiceAccountSigner fakeSigner;
@@ -103,13 +105,7 @@ class GcsSignedUrlTest {
         assertThat(signed).isNotNull();
         assertThat(signed.toString()).contains(BUCKET_NAME);
 
-        // SDK defaults to https:// — rewrite to http:// for the plaintext emulator
-        URL emulatorUrl = toHttp(signed);
-
-        HttpURLConnection conn = (HttpURLConnection) emulatorUrl.openConnection();
-        conn.setConnectTimeout(10_000);
-        conn.setReadTimeout(30_000);
-        conn.setRequestMethod("GET");
+        HttpURLConnection conn = openConnection(signed, "GET");
         assertThat(conn.getResponseCode()).isEqualTo(200);
         try (InputStream is = conn.getInputStream()) {
             String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
@@ -131,13 +127,8 @@ class GcsSignedUrlTest {
                 SignUrlOption.signWith(fakeSigner),
                 SignUrlOption.withHostName(emulatorHost));
 
-        URL emulatorUrl = toHttp(signed);
-
         byte[] body = "uploaded via signed url".getBytes(StandardCharsets.UTF_8);
-        HttpURLConnection conn = (HttpURLConnection) emulatorUrl.openConnection();
-        conn.setConnectTimeout(10_000);
-        conn.setReadTimeout(30_000);
-        conn.setRequestMethod("PUT");
+        HttpURLConnection conn = openConnection(signed, "PUT");
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "text/plain");
         conn.setRequestProperty("Content-Length", String.valueOf(body.length));
@@ -151,11 +142,150 @@ class GcsSignedUrlTest {
         assertThat(content).isEqualTo("uploaded via signed url");
     }
 
+    @Test
+    @Order(3)
+    void expiredSignedUrlDownloadReturnsExpiredToken() throws Exception {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME)).build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.SECONDS,
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        Thread.sleep(2_000);
+
+        HttpURLConnection conn = openConnection(signed, "GET");
+
+        assertThat(conn.getResponseCode()).isEqualTo(400);
+        try (InputStream is = conn.getErrorStream()) {
+            String error = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(error).contains("<Code>ExpiredToken</Code>");
+            assertThat(error).contains("<Message>The provided token has expired.</Message>");
+            assertThat(error).doesNotContain("<Details>");
+        }
+    }
+
+    @Test
+    @Order(4)
+    void expiredSignedUrlUploadReturnsExpiredToken() throws Exception {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, "test/expired-upload.txt"))
+                .setContentType("text/plain")
+                .build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.SECONDS,
+                SignUrlOption.httpMethod(HttpMethod.PUT),
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        Thread.sleep(2_000);
+
+        byte[] body = "expired upload".getBytes(StandardCharsets.UTF_8);
+        HttpURLConnection conn = openConnection(signed, "PUT");
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "text/plain");
+        conn.setRequestProperty("Content-Length", String.valueOf(body.length));
+        conn.getOutputStream().write(body);
+
+        assertThat(conn.getResponseCode()).isEqualTo(400);
+        try (InputStream is = conn.getErrorStream()) {
+            String error = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(error).contains("<Code>ExpiredToken</Code>");
+            assertThat(error).contains("<Message>The provided token has expired.</Message>");
+            assertThat(error).doesNotContain("<Details>");
+        }
+    }
+
+    @Test
+    @Order(5)
+    void malformedSignedUrlDateReturnsMalformedSecurityHeader() throws Exception {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME)).build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.HOURS,
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        URL malformed = replaceQueryParameterValue(signed, "X-Goog-Date", "not-a-date");
+        HttpURLConnection conn = openConnection(malformed, "GET");
+
+        assertThat(conn.getResponseCode()).isEqualTo(400);
+        try (InputStream is = conn.getErrorStream()) {
+            String error = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(error).contains("<Code>MalformedSecurityHeader</Code>");
+            assertThat(error).contains("<Message>Your request has a malformed header.</Message>");
+            assertThat(error).contains("<ParameterName>Date</ParameterName>");
+        }
+    }
+
+    @Test
+    @Order(6)
+    void invalidSignedUrlExpiresReturnsMalformedSecurityHeader() throws Exception {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME)).build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.HOURS,
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        URL invalid = replaceQueryParameterValue(signed, "X-Goog-Expires", INVALID_EXPIRES);
+        HttpURLConnection conn = openConnection(invalid, "GET");
+
+        assertThat(conn.getResponseCode()).isEqualTo(400);
+        try (InputStream is = conn.getErrorStream()) {
+            String error = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(error).contains("<Code>MalformedSecurityHeader</Code>");
+            assertThat(error).contains("<Message>Your request has a malformed header.</Message>");
+            assertThat(error).contains("<ParameterName>Expires</ParameterName>");
+        }
+    }
+
+    @Test
+    @Order(7)
+    void lowerCaseSignedUrlParametersReturnMalformedSecurityHeader() throws Exception {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, OBJECT_NAME)).build();
+
+        URL signed = storage.signUrl(blobInfo, 1, TimeUnit.HOURS,
+                SignUrlOption.withV4Signature(),
+                SignUrlOption.signWith(fakeSigner),
+                SignUrlOption.withHostName(emulatorHost));
+
+        URL lowerCase = replaceQueryParameterValue(signed, "X-Goog-Expires", INVALID_EXPIRES);
+        lowerCase = replaceQueryParameterName(lowerCase, "X-Goog-Date", "x-goog-date");
+        lowerCase = replaceQueryParameterName(lowerCase, "X-Goog-Expires", "x-goog-expires");
+        HttpURLConnection conn = openConnection(lowerCase, "GET");
+
+        assertThat(conn.getResponseCode()).isEqualTo(400);
+        try (InputStream is = conn.getErrorStream()) {
+            String error = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(error).contains("<Code>MalformedSecurityHeader</Code>");
+            assertThat(error).contains("<Message>Your request has a malformed header.</Message>");
+            assertThat(error).contains("<ParameterName>Expires</ParameterName>");
+        }
+    }
+
+    // SDK defaults to https:// — rewrite to http:// for the plaintext emulator
     private static URL toHttp(URL url) throws Exception {
         String s = url.toString();
         if (s.startsWith("https://")) {
             s = "http://" + s.substring("https://".length());
         }
         return new URL(s);
+    }
+
+    private static HttpURLConnection openConnection(URL url, String method) throws Exception {
+        HttpURLConnection conn = (HttpURLConnection) toHttp(url).openConnection();
+        conn.setConnectTimeout(10_000);
+        conn.setReadTimeout(30_000);
+        conn.setRequestMethod(method);
+        return conn;
+    }
+
+    private static URL replaceQueryParameterValue(URL url, String name, String value) throws Exception {
+        return new URL(url.toString().replaceFirst("([?&]" + name + "=)[^&]*", "$1" + value));
+    }
+
+    private static URL replaceQueryParameterName(URL url, String name, String replacement) throws Exception {
+        return new URL(url.toString().replaceFirst("([?&])" + name + "=", "$1" + replacement + "="));
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsSignedUrl.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsSignedUrl.java
@@ -1,0 +1,85 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.XmlBuilder;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+
+final class GcsSignedUrl {
+
+    private static final DateTimeFormatter V4_DATE_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmss'Z'")
+            .withZone(ZoneOffset.UTC);
+    private static final long MAX_EXPIRES_SECONDS = 604_800;
+
+    private GcsSignedUrl() {}
+
+    static void checkNotExpired(UriInfo uriInfo) {
+        String signedDate = firstQueryParameter(uriInfo, "X-Goog-Date");
+        String signedTtl = firstQueryParameter(uriInfo, "X-Goog-Expires");
+        if (signedDate == null || signedTtl == null) {
+            return;
+        }
+
+        Instant expiresAt;
+        long ttlSeconds;
+        try {
+            expiresAt = V4_DATE_FORMATTER.parse(signedDate, Instant::from);
+        }
+        catch (DateTimeParseException e) {
+            throw malformedSecurityHeader("Date not in valid ISO 8601 format.", "Date");
+        }
+        try {
+            ttlSeconds = Long.parseLong(signedTtl);
+        }
+        catch (NumberFormatException e) {
+            throw malformedSecurityHeader("Expires must be between 1 and 604800.", "Expires");
+        }
+        if (ttlSeconds < 1 || ttlSeconds > MAX_EXPIRES_SECONDS) {
+            throw malformedSecurityHeader("Expires must be between 1 and 604800.", "Expires");
+        }
+
+        expiresAt = expiresAt.plusSeconds(ttlSeconds);
+        if (Instant.now().isAfter(expiresAt)) {
+            throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                    .type(MediaType.APPLICATION_XML)
+                    .entity(xmlError("ExpiredToken", "The provided token has expired.", null, null))
+                    .build());
+        }
+    }
+
+    private static String firstQueryParameter(UriInfo uriInfo, String name) {
+        for (Map.Entry<String, List<String>> entry : uriInfo.getQueryParameters().entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(name) && !entry.getValue().isEmpty()) {
+                return entry.getValue().getFirst();
+            }
+        }
+        return null;
+    }
+
+    private static WebApplicationException malformedSecurityHeader(String details, String parameterName) {
+        return new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_XML)
+                .entity(xmlError("MalformedSecurityHeader", "Your request has a malformed header.", details, parameterName))
+                .build());
+    }
+
+    private static String xmlError(String code, String message, String details, String parameterName) {
+        return new XmlBuilder()
+                .start("Error")
+                .elem("Code", code)
+                .elem("Message", message)
+                .elem("Details", details)
+                .elem("ParameterName", parameterName)
+                .end("Error")
+                .build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -46,9 +47,11 @@ public class GcsXmlDownloadController {
     public Response download(
             @PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
+            @Context UriInfo uriInfo,
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam("Range") String rangeHeader) {
+        GcsSignedUrl.checkNotExpired(uriInfo);
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
@@ -68,8 +71,10 @@ public class GcsXmlDownloadController {
     public Response upload(
             @PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
+            @Context UriInfo uriInfo,
             @Context HttpHeaders headers,
             byte[] body) {
+        GcsSignedUrl.checkNotExpired(uriInfo);
         String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String host = headers.getHeaderString("Host");


### PR DESCRIPTION
## Summary

Reject unusable GCS XML API signed URL requests before serving downloads or accepting uploads.

Closes #32

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

The incorrect behavior was that expired signed URL requests were accepted: GET returned object bytes and PUT stored object bytes. Cloud Storage rejects expired V4 signed URL object GET and PUT requests with HTTP 400 and XML error code `ExpiredToken`.

Cloud Storage also rejects malformed signed URL date and expiry fields before object lookup with HTTP 400 and XML error code `MalformedSecurityHeader`. The compatibility tests generate V4 signed URLs with the Java Storage SDK and exercise the resulting URLs through the XML API, covering successful GET and PUT requests, expired GET and PUT requests, and malformed `X-Goog-Date` / `X-Goog-Expires` requests.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
