### PR TITLE
Complete GCS resumable uploads at declared size

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadTest.java
@@ -58,6 +58,37 @@ class GcsResumableUploadTest {
     }
 
     @Test
+    void resumableUploadCompletesAtChunkBoundary() throws Exception {
+        String objectName = "boundary-complete.bin";
+        byte[] data = new byte[CHUNK_SIZE];
+        Arrays.fill(data, (byte) 'c');
+
+        writeObject(objectName, data);
+
+        Blob blob = storage.get(BlobId.of(BUCKET, objectName));
+        assertThat(blob.getSize()).isEqualTo(data.length);
+        assertThat(storage.readAllBytes(BlobId.of(BUCKET, objectName))).containsExactly(data);
+    }
+
+    @Test
+    void resumableUploadCompletesAtSecondChunkBoundary() throws Exception {
+        String objectName = "second-boundary-complete.bin";
+        byte[] data = new byte[CHUNK_SIZE * 2];
+        Arrays.fill(data, 0, CHUNK_SIZE, (byte) 'c');
+        Arrays.fill(data, CHUNK_SIZE, data.length, (byte) 'd');
+
+        writeObject(objectName, data);
+
+        Blob blob = storage.get(BlobId.of(BUCKET, objectName));
+        assertThat(blob.getSize()).isEqualTo(data.length);
+
+        byte[] stored = storage.readAllBytes(BlobId.of(BUCKET, objectName));
+        assertThat(stored).hasSize(data.length);
+        assertThat(stored[0]).isEqualTo((byte) 'c');
+        assertThat(stored[CHUNK_SIZE]).isEqualTo((byte) 'd');
+    }
+
+    @Test
     void resumableUploadWritesSmallObject() throws Exception {
         String objectName = "small-object.bin";
         byte[] data = "small-object-data".getBytes(StandardCharsets.UTF_8);

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadTest.java
@@ -1,0 +1,81 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GcsResumableUploadTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("resumable-sdk-bucket");
+    private static final String OBJECT = "resumable.bin";
+    private static final int CHUNK_SIZE = 1024 * 1024;
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void resumableUploadWritesMultipleChunks() throws Exception {
+        int secondChunkSize = CHUNK_SIZE / 2;
+        int totalSize = CHUNK_SIZE + secondChunkSize;
+
+        byte[] data = new byte[totalSize];
+        Arrays.fill(data, 0, CHUNK_SIZE, (byte) 'a');
+        Arrays.fill(data, CHUNK_SIZE, totalSize, (byte) 'b');
+
+        writeObject(OBJECT, data);
+
+        Blob blob = storage.get(BlobId.of(BUCKET, OBJECT));
+        assertThat(blob.getSize()).isEqualTo(totalSize);
+
+        byte[] stored = storage.readAllBytes(BlobId.of(BUCKET, OBJECT));
+        assertThat(stored).hasSize(totalSize);
+        assertThat(stored[0]).isEqualTo((byte) 'a');
+        assertThat(stored[CHUNK_SIZE]).isEqualTo((byte) 'b');
+    }
+
+    @Test
+    void resumableUploadWritesSmallObject() throws Exception {
+        String objectName = "small-object.bin";
+        byte[] data = "small-object-data".getBytes(StandardCharsets.UTF_8);
+
+        writeObject(objectName, data);
+
+        Blob blob = storage.get(BlobId.of(BUCKET, objectName));
+        assertThat(blob.getSize()).isEqualTo(data.length);
+        assertThat(storage.readAllBytes(BlobId.of(BUCKET, objectName))).containsExactly(data);
+    }
+
+    private static void writeObject(String objectName, byte[] data) throws Exception {
+        BlobInfo blob = BlobInfo.newBuilder(BlobId.of(BUCKET, objectName))
+                .setContentType("application/octet-stream")
+                .build();
+        try (WriteChannel writer = storage.writer(blob)) {
+            writer.setChunkSize(CHUNK_SIZE);
+            writer.write(ByteBuffer.wrap(data));
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -662,6 +662,22 @@ public class GcsService {
         return upload.data().length;
     }
 
+    public GcsObjectMeta completeBufferedResumableUpload(String uploadId, long totalSize, String baseUrl) {
+        ResumableUpload upload = resumableUploads.get(uploadId);
+        if (upload == null) {
+            LOG.warnf("completeBufferedResumableUpload failed: upload not found uploadId=%s", uploadId);
+            throw GcpException.notFound("Resumable upload not found: " + uploadId);
+        }
+        byte[] data = upload.data();
+        if (data.length != totalSize) {
+            throw GcpException.invalidArgument(
+                    "Content-Range total size does not match uploaded bytes: " + totalSize);
+        }
+        resumableUploads.remove(uploadId);
+        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
+    }
+
     public GcsObjectMeta completeResumableUpload(String uploadId, long start, byte[] data,
             long totalSize, String baseUrl) {
         ResumableUpload upload = resumableUploads.get(uploadId);

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -79,8 +79,13 @@ public class GcsUploadController {
         if (contentRange != null && !contentRange.isBlank()) {
             ContentRange range = parseContentRange(contentRange, body.length);
             if (range.statusQuery()) {
-                Response.ResponseBuilder response = Response.status(308);
                 long uploadedLength = service.resumableUploadLength(uploadId);
+                if (range.totalSize() != null && uploadedLength == range.totalSize()) {
+                    GcsObjectMeta meta = service.completeBufferedResumableUpload(
+                            uploadId, range.totalSize(), requestBaseUrl(headers));
+                    return Response.ok(meta).build();
+                }
+                Response.ResponseBuilder response = Response.status(308);
                 if (uploadedLength > 0) {
                     response.header("Range", "bytes=0-" + (uploadedLength - 1));
                 }


### PR DESCRIPTION
## Summary

Closes #34.

Completes a GCS resumable upload when a zero-byte status/final request declares a total size equal to the bytes already received. Adds Java Storage SDK resumable upload coverage alongside the existing raw protocol coverage.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

The incorrect behavior was that floci-gcp returned `308` and kept the session open for `Content-Range: bytes */16777216` after receiving bytes `0-16777215`. Cloud Storage returns `200 OK` with the object resource for that API request, and the object is readable at `16777216` bytes.

The Java Storage SDK tests use a write channel with a 1 MiB configured chunk size to exercise exact one- and two-chunk boundary close paths, plus multi-chunk and smaller-than-chunk uploads. The raw tests remain for explicit protocol forms that the SDK does not necessarily emit, including `Content-Range: bytes */<total>` after an exact-size upload.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
