### PR TITLE
feat: add Cloud Run and Functions control planes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing! Floci is a community-driven project
 ## Ways to Contribute
 
 - **Bug reports** — open an issue with a minimal reproduction
-- **Feature requests** — open an issue describing the AWS behavior you need
+- **Feature requests** — open an issue describing the GCP behavior you need
 - **Pull requests** — bug fixes, new service implementations, or improvements
 - **Compatibility tests** — add cases to `./compatibility-tests/`
 
@@ -15,7 +15,7 @@ Thank you for your interest in contributing! Floci is a community-driven project
 
 - Java 25+
 - Maven 3.9+
-- Docker (for integration tests that spin up Lambda/RDS/ElastiCache)
+- Docker (for integration tests that spin up sidecar services such as Managed Kafka)
 
 Any Java 25+ distribution will work. If you need to install it, [SDKMAN](https://sdkman.io/) is a convenient option:
 
@@ -30,9 +30,9 @@ sdk install java 25-open
 This project includes a Maven wrapper, so you don't need to install Maven separately:
 
 ```bash
-git clone https://github.com/floci-io/floci.git
-cd floci
-./mvnw quarkus:dev     # hot reload on port 4566
+git clone https://github.com/floci-io/floci-gcp.git
+cd floci-gcp
+./mvnw quarkus:dev     # hot reload on port 4588
 ```
 
 If you prefer to use your own Maven installation (3.9+), you can use `mvn` instead of `./mvnw`.
@@ -41,8 +41,8 @@ If you prefer to use your own Maven installation (3.9+), you can use `mvn` inste
 
 ```bash
 ./mvnw test                                          # all tests
-./mvnw test -Dtest=SsmIntegrationTest                # single class
-./mvnw test -Dtest=SsmIntegrationTest#putParameter   # single method
+./mvnw test -Dtest=GcsIntegrationTest                # single class
+./mvnw test -Dtest=PubSubIntegrationTest#publishMessage   # single method
 ```
 
 ## Branching Model
@@ -68,14 +68,14 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) �
 ```
 
 - **type** — one of the values in the table below (lowercase)
-- **scope** — optional, in parentheses, identifies the service or area (e.g. `s3`, `dynamodb`, `core`)
+- **scope** — optional, in parentheses, identifies the service or area (e.g. `gcs`, `pubsub`, `core`)
 - **description** — short summary in the imperative mood, no trailing period
 - Append `!` before the colon to signal a breaking change: `feat(api)!:`
 
 | Type | When to use | Version bump |
 |------|-------------|--------------|
-| `feat` | New AWS API action or service | minor |
-| `fix` | Bug fix or AWS compatibility correction | patch |
+| `feat` | New GCP API action or service | minor |
+| `fix` | Bug fix or GCP compatibility correction | patch |
 | `perf` | Performance improvement | patch |
 | `revert` | Reverts a previous commit | patch |
 | `docs` | Documentation only | none |
@@ -90,15 +90,15 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) �
 ### Valid examples ✅
 
 ```
-feat(dynamodb): add PartiQL ExecuteStatement support
-fix(s3): make us-east-1 bucket creation idempotent
-perf(kinesis): reduce lock contention in shard iterator
+feat(pubsub): add StreamingPull support
+fix(gcs): correct multipart upload final response
+perf(firestore): reduce query lock contention
 chore: release 1.5.16
 docs: update README with new configuration options
-refactor(sqs): extract message visibility logic
-test(kms): add encrypt/decrypt round-trip test
+refactor(pubsub): extract subscription delivery logic
+test(secretmanager): add access secret version round-trip test
 feat!: remove legacy v1 endpoint
-fix(dynamodb)!: correct TransactWriteItems error shape
+fix(datastore)!: correct commit error shape
 ci: add conventional commits lint workflow
 build: bump Quarkus to 3.32.3
 ```
@@ -109,11 +109,11 @@ build: bump Quarkus to 3.32.3
 Add PartiQL support                  # missing type
 Feature: add something               # "Feature" is not a valid type
 feat : space before colon            # space before colon
-feat(dynamodb)add missing colon      # missing colon
-FIX(s3): uppercase type              # type must be lowercase
+feat(pubsub)add missing colon        # missing colon
+FIX(gcs): uppercase type             # type must be lowercase
 feat(my scope): scope has spaces     # scope cannot contain spaces
 fix(): empty scope                   # empty scope
-feat(s3):no space after colon        # missing space after colon
+feat(gcs):no space after colon       # missing space after colon
 wip: still working on this          # "wip" is not a recognised type
 ```
 
@@ -121,29 +121,29 @@ Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attrib
 
 ## Architecture
 
-See [AGENT.md](AGENT.md) for a detailed description of the three-layer architecture (Controller → Service → Storage), the AWS wire protocol mapping, and conventions for adding new services.
+See [AGENTS.md](AGENTS.md) for a detailed description of the three-layer architecture (Controller → Service → Storage), the GCP wire protocol mapping, and conventions for adding new services.
 
-`AGENT.md` is the canonical agent instructions file for this repository. If your coding agent expects a different filename, create a local symlink to `AGENT.md` instead of copying the file.
+`AGENTS.md` is the canonical agent instructions file for this repository. If your coding agent expects a different filename, create a local symlink to `AGENTS.md` instead of copying the file.
 
 ```bash
-ln -s AGENT.md CLAUDE.md
-ln -s AGENT.md GEMINI.md
-ln -s AGENT.md COPILOT.md
+ln -s AGENTS.md CLAUDE.md
+ln -s AGENTS.md GEMINI.md
+ln -s AGENTS.md COPILOT.md
 ```
 
-## Adding a New AWS Service
+## Adding a New GCP Service
 
 1. Create a package under `src/main/java/.../services/<service>/`
-2. Add a Controller (follow the correct protocol — Query, JSON 1.1, REST JSON, or REST XML)
+2. Add a Controller (follow the correct protocol — gRPC, REST JSON, REST XML, or HTTP/protobuf)
 3. Add a Service (`@ApplicationScoped`) and model POJOs
 4. Add config entries in `EmulatorConfig.java` and `application.yml`
-5. Register a `ServiceDescriptor` in `ResolvedServiceCatalog`
+5. Register a `ServiceDescriptor` in `ServiceRegistry`
 6. Wire controller/handler dispatch for the service
 7. Add integration tests in `*IntegrationTest.java`
 
-`ServiceRegistry`, `ServiceEnabledFilter`, and `StorageFactory` now resolve service metadata from the descriptor catalog. Adding a service should not require new service-keyed switch statements in those consumers.
+`ServiceRegistry`, `ServiceEnabledFilter`, and `StorageFactory` should resolve service metadata through existing service descriptors and storage patterns. Adding a service should not require new service-keyed switch statements in those consumers.
 
-Always implement the **real AWS wire protocol** — never invent custom endpoints. The AWS SDK must work against Floci without modification.
+Always implement the **real GCP wire protocol** — never invent custom endpoints. The GCP SDK must work against floci-gcp without modification.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ All GCP services — gRPC and REST — share a single port (`4588`) via HTTP/2 A
 <details>
 <summary><strong>Real GCP wire protocols</strong></summary>
 
-floci-gcp speaks the same protocols as real GCP: protobuf-over-gRPC for Pub/Sub, Firestore, and Secret Manager; binary HTTP/protobuf for Datastore; REST XML and JSON for Cloud Storage. Existing SDK calls work without modification.
+floci-gcp speaks the same protocols as real GCP: protobuf-over-gRPC for Pub/Sub, Firestore, and Secret Manager; binary HTTP/protobuf for Datastore; REST XML and JSON for Cloud Storage; and REST JSON for management APIs such as Cloud Run and Cloud Functions. Existing SDK calls work without modification.
 
 </details>
 
@@ -134,6 +134,8 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Secret Manager | ✅ | ❌ |
 | IAM | ✅ | ❌ |
 | Managed Kafka | ✅ | ❌ |
+| Cloud Run | ✅ | ❌ |
+| Cloud Functions | ✅ | ❌ |
 | Native binary | ✅ | ❌ |
 
 ## Architecture Overview
@@ -150,7 +152,7 @@ flowchart LR
         end
 
         subgraph REST ["REST services"]
-            B["Cloud Storage\nIAM\nDatastore"]
+            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions"]
         end
 
         subgraph Docker ["Docker-backed"]
@@ -177,6 +179,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Object and document storage | Cloud Storage (GCS), Firestore, Datastore |
 | Messaging | Pub/Sub, Managed Kafka |
 | Security and identity | Secret Manager, IAM |
+| Serverless control planes | Cloud Run, Cloud Functions |
 
 <details>
 <summary>Detailed service notes</summary>
@@ -190,6 +193,8 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Secret Manager** | gRPC | Secrets, versioning, access, `versions/latest` alias, disable/enable/destroy, IAM bindings |
 | **IAM** | REST JSON | Service accounts, RSA-2048 key pairs (JSON key file format), policy bindings, `SignBlob` (V4 signed URLs) |
 | **Managed Kafka** | REST JSON | Clusters, topics, consumer groups; Redpanda-backed or mock mode |
+| **Cloud Run** | REST JSON | Services, IAM policies, revisions, long-running operations; control plane only, no runtime invocation |
+| **Cloud Functions** | REST JSON | Functions, source upload URL generation, long-running operations; control plane only, no runtime invocation |
 
 </details>
 
@@ -562,6 +567,8 @@ All settings are overridable via environment variables (`FLOCI_GCP_` prefix).
 | `FLOCI_GCP_SERVICES_DATASTORE_ENABLED` | `true` | Enable/disable Datastore |
 | `FLOCI_GCP_SERVICES_IAM_ENABLED` | `true` | Enable/disable IAM |
 | `FLOCI_GCP_SERVICES_SECRETMANAGER_ENABLED` | `true` | Enable/disable Secret Manager |
+| `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Enable/disable Cloud Run |
+| `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Enable/disable Cloud Functions |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Enable/disable Managed Kafka |
 | `FLOCI_GCP_SERVICES_KAFKA_MOCK` | `false` | Use mock mode (no Docker; returns `ACTIVE` immediately) |
 | `FLOCI_GCP_DNS_EXTRA_SUFFIXES` | *(unset)* | Extra DNS suffixes for embedded DNS (comma-separated) |

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -60,6 +60,14 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-tasks</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-run</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-functions</artifactId>
+        </dependency>
 
         <!-- JSON parsing for plain-HTTP tests -->
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -7,6 +7,12 @@ import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.functions.v2.FunctionServiceClient;
+import com.google.cloud.functions.v2.FunctionServiceSettings;
+import com.google.cloud.run.v2.RevisionsClient;
+import com.google.cloud.run.v2.RevisionsSettings;
+import com.google.cloud.run.v2.ServicesClient;
+import com.google.cloud.run.v2.ServicesSettings;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
 import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
 import com.google.cloud.storage.Storage;
@@ -126,5 +132,29 @@ public final class TestFixtures {
                 .build();
 
         return CloudTasksClient.create(settings);
+    }
+
+    public static ServicesClient cloudRunServicesClient() throws IOException {
+        ServicesSettings settings = ServicesSettings.newHttpJsonBuilder()
+                .setEndpoint(endpoint())
+                .setCredentialsProvider(NoCredentialsProvider.create())
+                .build();
+        return ServicesClient.create(settings);
+    }
+
+    public static RevisionsClient cloudRunRevisionsClient() throws IOException {
+        RevisionsSettings settings = RevisionsSettings.newHttpJsonBuilder()
+                .setEndpoint(endpoint())
+                .setCredentialsProvider(NoCredentialsProvider.create())
+                .build();
+        return RevisionsClient.create(settings);
+    }
+
+    public static FunctionServiceClient cloudFunctionsClient() throws IOException {
+        FunctionServiceSettings settings = FunctionServiceSettings.newHttpJsonBuilder()
+                .setEndpoint(endpoint())
+                .setCredentialsProvider(NoCredentialsProvider.create())
+                .build();
+        return FunctionServiceClient.create(settings);
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudFunctionsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudFunctionsTest.java
@@ -1,0 +1,138 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.functions.v2.BuildConfig;
+import com.google.cloud.functions.v2.CreateFunctionRequest;
+import com.google.cloud.functions.v2.DeleteFunctionRequest;
+import com.google.cloud.functions.v2.Function;
+import com.google.cloud.functions.v2.FunctionServiceClient;
+import com.google.cloud.functions.v2.GenerateUploadUrlRequest;
+import com.google.cloud.functions.v2.GenerateUploadUrlResponse;
+import com.google.cloud.functions.v2.GetFunctionRequest;
+import com.google.cloud.functions.v2.ListFunctionsRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CloudFunctionsTest {
+
+    private static final String PROJECT_ID = TestFixtures.projectId();
+    private static final String LOCATION = "us-central1";
+    private static final String FUNCTION_ID = TestFixtures.uniqueName("java-fn");
+    private static final String PARENT = "projects/" + PROJECT_ID + "/locations/" + LOCATION;
+    private static final String FUNCTION_NAME = PARENT + "/functions/" + FUNCTION_ID;
+
+    private static FunctionServiceClient client;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        client = TestFixtures.cloudFunctionsClient();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createFunctionWithLro() throws Exception {
+        Function function = Function.newBuilder()
+                .setBuildConfig(BuildConfig.newBuilder()
+                        .setRuntime("java21")
+                        .setEntryPoint("ExampleFunction")
+                        .build())
+                .build();
+
+        Function created = client.createFunctionAsync(CreateFunctionRequest.newBuilder()
+                        .setParent(PARENT)
+                        .setFunctionId(FUNCTION_ID)
+                        .setFunction(function)
+                        .build())
+                .get(10, TimeUnit.SECONDS);
+
+        assertThat(created.getName()).isEqualTo(FUNCTION_NAME);
+        assertThat(created.getState()).isEqualTo(Function.State.ACTIVE);
+        assertThat(created.getEnvironment()).isEqualTo(com.google.cloud.functions.v2.Environment.GEN_2);
+        assertThat(created.getUrl()).isEqualTo("https://" + LOCATION + "-" + PROJECT_ID + ".cloudfunctions.net/" + FUNCTION_ID);
+        assertThat(created.getServiceConfig().getService()).isEqualTo(
+                "projects/" + PROJECT_ID + "/locations/" + LOCATION + "/services/" + FUNCTION_ID);
+    }
+
+    @Test
+    @Order(2)
+    void getFunction() {
+        Function function = client.getFunction(GetFunctionRequest.newBuilder()
+                .setName(FUNCTION_NAME)
+                .build());
+
+        assertThat(function.getName()).isEqualTo(FUNCTION_NAME);
+        assertThat(function.getState()).isEqualTo(Function.State.ACTIVE);
+    }
+
+    @Test
+    @Order(3)
+    void listFunctions() {
+        List<Function> functions = new ArrayList<>();
+        client.listFunctions(ListFunctionsRequest.newBuilder()
+                        .setParent(PARENT)
+                        .build())
+                .iterateAll()
+                .forEach(functions::add);
+
+        assertThat(functions).anyMatch(function -> function.getName().equals(FUNCTION_NAME));
+    }
+
+    @Test
+    @Order(4)
+    void generateUploadUrlAndPutSourceObject() throws Exception {
+        GenerateUploadUrlResponse response = client.generateUploadUrl(GenerateUploadUrlRequest.newBuilder()
+                .setParent(PARENT)
+                .build());
+
+        assertThat(response.getUploadUrl()).startsWith(TestFixtures.endpoint() + "/");
+        assertThat(response.getStorageSource().getBucket()).startsWith("gcf-v2-sources-");
+        assertThat(response.getStorageSource().getObject()).startsWith("source-");
+
+        HttpRequest put = HttpRequest.newBuilder(URI.create(response.getUploadUrl()))
+                .header("Content-Type", "application/zip")
+                .PUT(HttpRequest.BodyPublishers.ofString("fake source zip", StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> putResponse = HttpClient.newHttpClient().send(put, HttpResponse.BodyHandlers.ofString());
+        assertThat(putResponse.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @Order(5)
+    void deleteFunctionWithLro() throws Exception {
+        client.deleteFunctionAsync(DeleteFunctionRequest.newBuilder()
+                        .setName(FUNCTION_NAME)
+                        .build())
+                .get(10, TimeUnit.SECONDS);
+
+        List<Function> functions = new ArrayList<>();
+        client.listFunctions(ListFunctionsRequest.newBuilder()
+                        .setParent(PARENT)
+                        .build())
+                .iterateAll()
+                .forEach(functions::add);
+        assertThat(functions).noneMatch(function -> function.getName().equals(FUNCTION_NAME));
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudRunTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudRunTest.java
@@ -1,0 +1,178 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.run.v2.Container;
+import com.google.cloud.run.v2.CreateServiceRequest;
+import com.google.cloud.run.v2.DeleteServiceRequest;
+import com.google.cloud.run.v2.GetRevisionRequest;
+import com.google.cloud.run.v2.GetServiceRequest;
+import com.google.cloud.run.v2.ListRevisionsRequest;
+import com.google.cloud.run.v2.ListServicesRequest;
+import com.google.cloud.run.v2.Revision;
+import com.google.cloud.run.v2.RevisionTemplate;
+import com.google.cloud.run.v2.RevisionsClient;
+import com.google.cloud.run.v2.Service;
+import com.google.cloud.run.v2.ServicesClient;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CloudRunTest {
+
+    private static final String PROJECT_ID = TestFixtures.projectId();
+    private static final String LOCATION = "us-central1";
+    private static final String SERVICE_ID = TestFixtures.uniqueName("run-svc");
+    private static final String PARENT = "projects/" + PROJECT_ID + "/locations/" + LOCATION;
+    private static final String SERVICE_NAME = PARENT + "/services/" + SERVICE_ID;
+
+    private static ServicesClient servicesClient;
+    private static RevisionsClient revisionsClient;
+    private static String revisionName;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        servicesClient = TestFixtures.cloudRunServicesClient();
+        revisionsClient = TestFixtures.cloudRunRevisionsClient();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (servicesClient != null) {
+            servicesClient.close();
+        }
+        if (revisionsClient != null) {
+            revisionsClient.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createServiceWithLro() throws Exception {
+        Service service = Service.newBuilder()
+                .setTemplate(RevisionTemplate.newBuilder()
+                        .addContainers(Container.newBuilder()
+                                .setImage("gcr.io/" + PROJECT_ID + "/" + SERVICE_ID + ":latest")
+                                .build())
+                        .build())
+                .build();
+
+        Service created = servicesClient.createServiceAsync(CreateServiceRequest.newBuilder()
+                        .setParent(PARENT)
+                        .setServiceId(SERVICE_ID)
+                        .setService(service)
+                        .build())
+                .get(10, TimeUnit.SECONDS);
+
+        assertThat(created.getName()).isEqualTo(SERVICE_NAME);
+        assertThat(created.getUri()).startsWith("https://" + SERVICE_ID + "-");
+        assertThat(created.getLatestReadyRevision()).contains("/revisions/");
+        assertThat(created.getTerminalCondition().getType()).isEqualTo("Ready");
+        assertThat(created.getTrafficStatuses(0).getPercent()).isEqualTo(100);
+        revisionName = created.getLatestReadyRevision();
+    }
+
+    @Test
+    @Order(2)
+    void getService() {
+        Service service = servicesClient.getService(GetServiceRequest.newBuilder()
+                .setName(SERVICE_NAME)
+                .build());
+
+        assertThat(service.getName()).isEqualTo(SERVICE_NAME);
+        assertThat(service.getLatestReadyRevision()).isEqualTo(revisionName);
+    }
+
+    @Test
+    @Order(3)
+    void listServices() {
+        List<Service> services = new ArrayList<>();
+        servicesClient.listServices(ListServicesRequest.newBuilder()
+                        .setParent(PARENT)
+                        .build())
+                .iterateAll()
+                .forEach(services::add);
+
+        assertThat(services).anyMatch(service -> service.getName().equals(SERVICE_NAME));
+    }
+
+    @Test
+    @Order(4)
+    void setGetAndTestIamPolicy() {
+        Policy policy = Policy.newBuilder()
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/run.invoker")
+                        .addMembers("allUsers")
+                        .build())
+                .build();
+
+        Policy saved = servicesClient.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                .setResource(SERVICE_NAME)
+                .setPolicy(policy)
+                .build());
+        assertThat(saved.getBindings(0).getMembersList()).contains("allUsers");
+
+        Policy fetched = servicesClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                .setResource(SERVICE_NAME)
+                .build());
+        assertThat(fetched.getBindings(0).getRole()).isEqualTo("roles/run.invoker");
+
+        TestIamPermissionsResponse permissions = servicesClient.testIamPermissions(
+                TestIamPermissionsRequest.newBuilder()
+                        .setResource(SERVICE_NAME)
+                        .addPermissions("run.services.get")
+                        .addPermissions("run.services.delete")
+                        .build());
+        assertThat(permissions.getPermissionsList()).containsExactly("run.services.get", "run.services.delete");
+    }
+
+    @Test
+    @Order(5)
+    void listAndGetRevision() {
+        List<Revision> revisions = new ArrayList<>();
+        revisionsClient.listRevisions(ListRevisionsRequest.newBuilder()
+                        .setParent(SERVICE_NAME)
+                        .build())
+                .iterateAll()
+                .forEach(revisions::add);
+        assertThat(revisions).anyMatch(revision -> revision.getName().equals(revisionName));
+
+        Revision revision = revisionsClient.getRevision(GetRevisionRequest.newBuilder()
+                .setName(revisionName)
+                .build());
+        assertThat(revision.getService()).isEqualTo(SERVICE_NAME);
+        assertThat(revision.getContainers(0).getImage()).isEqualTo("gcr.io/" + PROJECT_ID + "/" + SERVICE_ID + ":latest");
+    }
+
+    @Test
+    @Order(6)
+    void deleteServiceWithLro() throws Exception {
+        servicesClient.deleteServiceAsync(DeleteServiceRequest.newBuilder()
+                        .setName(SERVICE_NAME)
+                        .build())
+                .get(10, TimeUnit.SECONDS);
+
+        List<Service> services = new ArrayList<>();
+        servicesClient.listServices(ListServicesRequest.newBuilder()
+                        .setParent(PARENT)
+                        .build())
+                .iterateAll()
+                .forEach(services::add);
+        assertThat(services).noneMatch(service -> service.getName().equals(SERVICE_NAME));
+    }
+}

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -33,6 +33,7 @@ The block below mirrors `src/main/resources/application.yml`.
 ```yaml
 floci-gcp:
   port: 4588
+  max-request-size: 512
   base-url: "http://localhost:4588"  # Used to build GCS object URLs and pre-signed URLs
   # hostname: ""                     # When set, overrides the host in base-url for multi-container Docker
   default-project-id: floci-local
@@ -40,6 +41,8 @@ floci-gcp:
   storage:
     mode: memory                      # memory | persistent | hybrid | wal
     persistent-path: ./data
+    host-persistent-path: ./data
+    prune-volumes-on-delete: false
     wal:
       compaction-interval-ms: 30000
 
@@ -72,6 +75,20 @@ floci-gcp:
       enabled: true
 
     iam:
+      enabled: true
+
+    kafka:
+      enabled: true
+      mock: false
+      default-image: "redpandadata/redpanda:latest"
+
+    cloudtasks:
+      enabled: true
+
+    cloudrun:
+      enabled: true
+
+    cloudfunctions:
       enabled: true
 ```
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -60,6 +60,8 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_IAM_ENABLED` | `true` | IAM |
 | `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Cloud Tasks |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Managed Service for Apache Kafka |
+| `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Cloud Run |
+| `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Cloud Functions |
 
 ### Sidecar containers
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,7 +69,7 @@ FIX(gcs): uppercase type      # type must be lowercase
 
 ## Adding a New GCP Service
 
-See [AGENT.md](https://github.com/floci-io/floci-gcp/blob/main/AGENT.md) for the full architecture guide.
+See [AGENTS.md](https://github.com/floci-io/floci-gcp/blob/main/AGENTS.md) for the full architecture guide.
 
 Quick summary:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,8 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | **Secret Manager** | gRPC | Secrets, versions, access, disable/enable/destroy, IAM bindings |
 | **IAM** | REST | Service accounts, RSA-2048 keys, policy bindings, SignBlob (V4 signed URLs) |
 | **Managed Kafka** | REST | Clusters, topics, consumer groups (Redpanda-backed or mock mode) |
+| **Cloud Run** | REST | Service create/get/list/delete, IAM policy operations, revisions, LRO polling; control plane only |
+| **Cloud Functions** | REST | Function create/get/list/delete, upload URL generation, LRO polling; control plane only |
 
 ## Why floci-gcp?
 

--- a/docs/services/cloud-functions.md
+++ b/docs/services/cloud-functions.md
@@ -1,0 +1,46 @@
+# Cloud Functions
+
+floci-gcp emulates the Cloud Functions v2 control plane over REST JSON using Google's published protobuf types.
+
+| Config | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Enable/disable Cloud Functions |
+
+## Supported API Surface
+
+| Operation | Path |
+|---|---|
+| Create function | `POST /v2/projects/{project}/locations/{location}/functions` |
+| List functions | `GET /v2/projects/{project}/locations/{location}/functions` |
+| Get function | `GET /v2/projects/{project}/locations/{location}/functions/{function}` |
+| Delete function | `DELETE /v2/projects/{project}/locations/{location}/functions/{function}` |
+| Generate upload URL | `POST /v2/projects/{project}/locations/{location}/functions:generateUploadUrl` |
+
+Create and delete return completed `google.longrunning.Operation` resources immediately. Operations can be read, listed, waited on, and deleted under `/v2/projects/{project}/locations/{location}/operations`.
+
+## Behavior
+
+Cloud Functions resources are metadata only. Creating a function synthesizes `ACTIVE` state, default `GEN_2` environment when omitted, URL, timestamps, and Cloud Run service references in `serviceConfig`.
+
+`generateUploadUrl` returns an upload URL backed by the existing GCS XML `PUT /{bucket}/{object}` object path and includes a `storageSource` in the response. Uploaded source archives are stored as inert GCS metadata; no function build or runtime is executed.
+
+`validateOnly=true` returns a successful operation without storing or deleting resources.
+
+## SDK Usage
+
+Cloud Functions clients should use the HTTP JSON transport, an explicit endpoint, and no credentials:
+
+```java
+FunctionServiceSettings settings = FunctionServiceSettings.newHttpJsonBuilder()
+    .setEndpoint("http://localhost:4588")
+    .setCredentialsProvider(NoCredentialsProvider.create())
+    .build();
+```
+
+## Not Implemented
+
+- Runtime invocation
+- Function updates
+- Download URL generation
+- Runtime listing
+- IAM

--- a/docs/services/cloud-functions.md
+++ b/docs/services/cloud-functions.md
@@ -22,9 +22,9 @@ Create and delete return completed `google.longrunning.Operation` resources imme
 
 Cloud Functions resources are metadata only. Creating a function synthesizes `ACTIVE` state, default `GEN_2` environment when omitted, URL, timestamps, and Cloud Run service references in `serviceConfig`.
 
-`generateUploadUrl` returns an upload URL backed by the existing GCS XML `PUT /{bucket}/{object}` object path and includes a `storageSource` in the response. Uploaded source archives are stored as inert GCS metadata; no function build or runtime is executed.
+`generateUploadUrl` returns an upload URL backed by the existing GCS XML `PUT /{bucket}/{object}` object path and includes a `storageSource` in the response. Uploaded source archives are stored as inert GCS metadata; no function build or runtime is executed. Cloud Storage must be enabled for source upload URL generation.
 
-`validateOnly=true` returns a successful operation without storing or deleting resources.
+`validateOnly=true` returns a successful completed operation without storing or deleting resources. Validate-only operations are not retained for later operation get/list calls.
 
 ## SDK Usage
 

--- a/docs/services/cloud-run.md
+++ b/docs/services/cloud-run.md
@@ -1,0 +1,47 @@
+# Cloud Run
+
+floci-gcp emulates the Cloud Run Admin API v2 control plane over REST JSON using Google's published protobuf types.
+
+| Config | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Enable/disable Cloud Run |
+
+## Supported API Surface
+
+| Operation | Path |
+|---|---|
+| Create service | `POST /v2/projects/{project}/locations/{location}/services` |
+| List services | `GET /v2/projects/{project}/locations/{location}/services` |
+| Get service | `GET /v2/projects/{project}/locations/{location}/services/{service}` |
+| Delete service | `DELETE /v2/projects/{project}/locations/{location}/services/{service}` |
+| Get IAM policy | `GET /v2/projects/{project}/locations/{location}/services/{service}:getIamPolicy` |
+| Set IAM policy | `POST /v2/projects/{project}/locations/{location}/services/{service}:setIamPolicy` |
+| Test IAM permissions | `POST /v2/projects/{project}/locations/{location}/services/{service}:testIamPermissions` |
+| List revisions | `GET /v2/projects/{project}/locations/{location}/services/{service}/revisions` |
+| Get revision | `GET /v2/projects/{project}/locations/{location}/services/{service}/revisions/{revision}` |
+
+Create and delete return completed `google.longrunning.Operation` resources immediately. Operations can be read, listed, waited on, and deleted under `/v2/projects/{project}/locations/{location}/operations`.
+
+## Behavior
+
+Cloud Run services are metadata only. Creating a service synthesizes the service URL, timestamps, etag, ready condition, traffic status, latest revision fields, and one read-only revision. No container image is pulled and no request-serving runtime is started.
+
+`validateOnly=true` returns a successful operation without storing or deleting resources.
+
+## SDK Usage
+
+Cloud Run clients should use the HTTP JSON transport, an explicit endpoint, and no credentials:
+
+```java
+ServicesSettings settings = ServicesSettings.newHttpJsonBuilder()
+    .setEndpoint("http://localhost:4588")
+    .setCredentialsProvider(NoCredentialsProvider.create())
+    .build();
+```
+
+## Not Implemented
+
+- Runtime invocation
+- Jobs
+- WorkerPools
+- Service updates

--- a/docs/services/cloud-run.md
+++ b/docs/services/cloud-run.md
@@ -26,7 +26,7 @@ Create and delete return completed `google.longrunning.Operation` resources imme
 
 Cloud Run services are metadata only. Creating a service synthesizes the service URL, timestamps, etag, ready condition, traffic status, latest revision fields, and one read-only revision. No container image is pulled and no request-serving runtime is started.
 
-`validateOnly=true` returns a successful operation without storing or deleting resources.
+`validateOnly=true` returns a successful completed operation without storing or deleting resources. Validate-only operations are not retained for later operation get/list calls.
 
 ## SDK Usage
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -13,6 +13,8 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Secret Manager](secret-manager.md) | gRPC | `google.cloud.secretmanager.v1.SecretManagerService` |
 | [IAM](iam.md) | REST JSON | `/v1/projects/{project}/serviceAccounts` |
 | [Managed Kafka](managed-kafka.md) | REST JSON | `/v1/projects/{project}/locations/{location}/clusters` |
+| [Cloud Run](cloud-run.md) | REST JSON | `/v2/projects/{project}/locations/{location}/services` |
+| [Cloud Functions](cloud-functions.md) | REST JSON | `/v2/projects/{project}/locations/{location}/functions` |
 
 ## Single-Port Design
 
@@ -35,7 +37,7 @@ export STORAGE_EMULATOR_HOST=http://localhost:4588
 export SECRET_MANAGER_EMULATOR_HOST=localhost:4588
 ```
 
-GCP SDKs automatically bypass credential validation when these variables are set.
+GCP SDKs automatically bypass credential validation when these variables are set. Some REST management SDKs, including Cloud Run and Cloud Functions, do not have emulator environment variables; configure their client endpoint explicitly as `http://localhost:4588` and use no credentials.
 
 For gcloud CLI:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,4 +75,6 @@ nav:
     - Secret Manager: services/secret-manager.md
     - IAM: services/iam.md
     - Managed Kafka: services/managed-kafka.md
+    - Cloud Run: services/cloud-run.md
+    - Cloud Functions: services/cloud-functions.md
   - Contributing: contributing.md

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,24 @@
             <version>2.71.0</version>
         </dependency>
 
+        <!-- Protobuf JSON support for REST services backed by Google proto contracts -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+
+        <!-- Cloud Run v2 proto types for REST JSON control-plane emulation -->
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>proto-google-cloud-run-v2</artifactId>
+        </dependency>
+
+        <!-- Cloud Functions v2 proto types for REST JSON control-plane emulation -->
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>proto-google-cloud-functions-v2</artifactId>
+        </dependency>
+
         <!-- Pub/Sub gRPC stubs (PublisherGrpc, SubscriberGrpc ImplBase) -->
         <dependency>
             <groupId>com.google.api.grpc</groupId>

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -87,6 +87,10 @@ public interface EmulatorConfig {
         KafkaServiceConfig kafka();
 
         CloudTasksServiceConfig cloudtasks();
+
+        CloudRunServiceConfig cloudrun();
+
+        CloudFunctionsServiceConfig cloudfunctions();
     }
 
     interface GcsServiceConfig {
@@ -133,6 +137,16 @@ public interface EmulatorConfig {
     }
 
     interface CloudTasksServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface CloudRunServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface CloudFunctionsServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/floci/gcp/core/common/GcpException.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpException.java
@@ -70,4 +70,8 @@ public class GcpException extends RuntimeException {
     public static GcpException unimplemented(String message) {
         return new GcpException(501, "UNIMPLEMENTED", Status.Code.UNIMPLEMENTED, message);
     }
+
+    public static GcpException unavailable(String message) {
+        return new GcpException(503, "UNAVAILABLE", Status.Code.UNAVAILABLE, message);
+    }
 }

--- a/src/main/java/io/floci/gcp/core/common/ProtoJson.java
+++ b/src/main/java/io/floci/gcp/core/common/ProtoJson.java
@@ -1,0 +1,57 @@
+package io.floci.gcp.core.common;
+
+import com.google.longrunning.ListOperationsResponse;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+
+/**
+ * Shared proto3 JSON parsing/printing for REST APIs backed by Google protobuf
+ * contracts. The type registry keeps packed Any responses readable to GAPIC
+ * HTTP/JSON clients.
+ */
+public final class ProtoJson {
+
+    private static final JsonFormat.TypeRegistry TYPE_REGISTRY = JsonFormat.TypeRegistry.newBuilder()
+            .add(Operation.getDescriptor())
+            .add(ListOperationsResponse.getDescriptor())
+            .add(Empty.getDescriptor())
+            .add(com.google.cloud.run.v2.Service.getDescriptor())
+            .add(com.google.cloud.run.v2.Revision.getDescriptor())
+            .add(com.google.cloud.functions.v2.Function.getDescriptor())
+            .add(com.google.cloud.functions.v2.OperationMetadata.getDescriptor())
+            .build();
+
+    private static final JsonFormat.Printer PRINTER = JsonFormat.printer()
+            .usingTypeRegistry(TYPE_REGISTRY)
+            .omittingInsignificantWhitespace();
+
+    private static final JsonFormat.Parser PARSER = JsonFormat.parser()
+            .usingTypeRegistry(TYPE_REGISTRY)
+            .ignoringUnknownFields();
+
+    private ProtoJson() {}
+
+    public static String print(MessageOrBuilder message) {
+        try {
+            return PRINTER.print(message);
+        } catch (InvalidProtocolBufferException e) {
+            throw GcpException.internal("Failed to serialize protobuf JSON: " + e.getMessage());
+        }
+    }
+
+    public static <B extends Message.Builder> B merge(String json, B builder) {
+        if (json == null || json.isBlank()) {
+            return builder;
+        }
+        try {
+            PARSER.merge(json, builder);
+            return builder;
+        } catch (InvalidProtocolBufferException e) {
+            throw GcpException.invalidArgument("Invalid protobuf JSON: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsController.java
+++ b/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsController.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.cloudfunctions;
 
 import com.google.cloud.functions.v2.GenerateUploadUrlRequest;
+import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.ProtoJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -25,10 +26,12 @@ import jakarta.ws.rs.core.Response;
 public class CloudFunctionsController {
 
     private final CloudFunctionsService service;
+    private final EmulatorConfig config;
 
     @Inject
-    public CloudFunctionsController(CloudFunctionsService service) {
+    public CloudFunctionsController(CloudFunctionsService service, EmulatorConfig config) {
         this.service = service;
+        this.config = config;
     }
 
     @POST
@@ -74,7 +77,7 @@ public class CloudFunctionsController {
                                       @Context HttpHeaders headers,
                                       String body) {
         ProtoJson.merge(body, GenerateUploadUrlRequest.newBuilder()).build();
-        return json(ProtoJson.print(service.generateUploadUrl(project, location, requestBaseUrl(headers))));
+        return json(ProtoJson.print(service.generateUploadUrl(project, location, requestBaseUrl(headers, config.effectiveBaseUrl()))));
     }
 
     private static Response json(String json) {
@@ -85,8 +88,59 @@ public class CloudFunctionsController {
         return "projects/" + project + "/locations/" + location + "/functions/" + functionId;
     }
 
-    private static String requestBaseUrl(HttpHeaders headers) {
-        String host = headers.getHeaderString("Host");
-        return host != null ? "http://" + host : "http://localhost:4588";
+    static String requestBaseUrl(HttpHeaders headers, String fallback) {
+        String forwarded = firstHeader(headers, "Forwarded");
+        String proto = firstPresent(firstHeader(headers, "X-Forwarded-Proto"), forwardedValue(forwarded, "proto"));
+        String host = firstPresent(firstHeader(headers, "X-Forwarded-Host"), forwardedValue(forwarded, "host"));
+        if (host != null) {
+            return firstPresent(proto, scheme(fallback), "http") + "://" + host;
+        }
+        if (proto != null && fallback.contains("://")) {
+            return proto + fallback.substring(fallback.indexOf("://"));
+        }
+        return fallback;
+    }
+
+    private static String firstHeader(HttpHeaders headers, String name) {
+        String value = headers.getHeaderString(name);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        int comma = value.indexOf(',');
+        return (comma < 0 ? value : value.substring(0, comma)).trim();
+    }
+
+    private static String forwardedValue(String forwarded, String key) {
+        if (forwarded == null) {
+            return null;
+        }
+        for (String part : forwarded.split(";")) {
+            String[] kv = part.trim().split("=", 2);
+            if (kv.length == 2 && kv[0].trim().equalsIgnoreCase(key)) {
+                return unquote(kv[1].trim());
+            }
+        }
+        return null;
+    }
+
+    private static String firstPresent(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String scheme(String url) {
+        int delimiter = url.indexOf("://");
+        return delimiter < 0 ? null : url.substring(0, delimiter);
+    }
+
+    private static String unquote(String value) {
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 }

--- a/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsController.java
+++ b/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsController.java
@@ -1,0 +1,92 @@
+package io.floci.gcp.services.cloudfunctions;
+
+import com.google.cloud.functions.v2.GenerateUploadUrlRequest;
+import io.floci.gcp.core.common.ProtoJson;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/v2/projects/{project}/locations/{location}")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CloudFunctionsController {
+
+    private final CloudFunctionsService service;
+
+    @Inject
+    public CloudFunctionsController(CloudFunctionsService service) {
+        this.service = service;
+    }
+
+    @POST
+    @Path("/functions")
+    public Response createFunction(@PathParam("project") String project,
+                                   @PathParam("location") String location,
+                                   @QueryParam("functionId") String functionId,
+                                   @QueryParam("validateOnly") @DefaultValue("false") boolean validateOnly,
+                                   String body) {
+        return json(ProtoJson.print(service.createFunction(project, location, functionId, body, validateOnly)));
+    }
+
+    @GET
+    @Path("/functions")
+    public Response listFunctions(@PathParam("project") String project,
+                                  @PathParam("location") String location,
+                                  @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                                  @QueryParam("pageToken") String pageToken) {
+        return json(ProtoJson.print(service.listFunctions(project, location, pageSize, pageToken)));
+    }
+
+    @GET
+    @Path("/functions/{functionId}")
+    public Response getFunction(@PathParam("project") String project,
+                                @PathParam("location") String location,
+                                @PathParam("functionId") String functionId) {
+        return json(ProtoJson.print(service.getFunction(functionName(project, location, functionId))));
+    }
+
+    @DELETE
+    @Path("/functions/{functionId}")
+    public Response deleteFunction(@PathParam("project") String project,
+                                   @PathParam("location") String location,
+                                   @PathParam("functionId") String functionId,
+                                   @QueryParam("validateOnly") @DefaultValue("false") boolean validateOnly) {
+        return json(ProtoJson.print(service.deleteFunction(functionName(project, location, functionId), validateOnly)));
+    }
+
+    @POST
+    @Path("/functions:generateUploadUrl")
+    public Response generateUploadUrl(@PathParam("project") String project,
+                                      @PathParam("location") String location,
+                                      @Context HttpHeaders headers,
+                                      String body) {
+        ProtoJson.merge(body, GenerateUploadUrlRequest.newBuilder()).build();
+        return json(ProtoJson.print(service.generateUploadUrl(project, location, requestBaseUrl(headers))));
+    }
+
+    private static Response json(String json) {
+        return Response.ok(json, MediaType.APPLICATION_JSON).build();
+    }
+
+    private static String functionName(String project, String location, String functionId) {
+        return "projects/" + project + "/locations/" + location + "/functions/" + functionId;
+    }
+
+    private static String requestBaseUrl(HttpHeaders headers) {
+        String host = headers.getHeaderString("Host");
+        return host != null ? "http://" + host : "http://localhost:4588";
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsService.java
+++ b/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsService.java
@@ -11,6 +11,7 @@ import com.google.cloud.functions.v2.ServiceConfig;
 import com.google.cloud.functions.v2.StorageSource;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
+import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
@@ -71,6 +72,17 @@ public class CloudFunctionsService {
         this.config = null;
     }
 
+    CloudFunctionsService(StorageBackend<String, String> functionStore,
+                          LongRunningOperationsService operations,
+                          GcsService gcsService,
+                          ServiceRegistry serviceRegistry) {
+        this.functionStore = functionStore;
+        this.operations = operations;
+        this.gcsService = gcsService;
+        this.serviceRegistry = serviceRegistry;
+        this.config = null;
+    }
+
     void onStart(@Observes StartupEvent ev) {
         serviceRegistry.register(ServiceDescriptor.builder("cloudfunctions")
                 .enabled(config.services().cloudfunctions().enabled())
@@ -98,7 +110,7 @@ public class CloudFunctionsService {
             functionStore.put(name, ProtoJson.print(function));
         }
         LOG.infof("create Cloud Function name=%s validateOnly=%s", name, validateOnly);
-        return operations.done(parent, function, operationMetadata(name, "create", OperationType.CREATE_FUNCTION, now));
+        return done(parent, function, operationMetadata(name, "create", OperationType.CREATE_FUNCTION, now), validateOnly);
     }
 
     public Function getFunction(String name) {
@@ -129,15 +141,19 @@ public class CloudFunctionsService {
         }
         Timestamp now = timestampNow();
         LOG.infof("delete Cloud Function name=%s validateOnly=%s", name, validateOnly);
-        return operations.done(parentFromName(name), Empty.getDefaultInstance(),
-                operationMetadata(name, "delete", OperationType.DELETE_FUNCTION, now));
+        return done(parentFromName(name), Empty.getDefaultInstance(),
+                operationMetadata(name, "delete", OperationType.DELETE_FUNCTION, now), validateOnly);
     }
 
     public GenerateUploadUrlResponse generateUploadUrl(String project, String location, String baseUrl) {
+        if (serviceRegistry != null && !serviceRegistry.isEnabled("gcs")) {
+            throw GcpException.unavailable("Cloud Functions source upload requires Cloud Storage to be enabled.");
+        }
         String bucket = sourceBucket(project, location);
         String object = "source-" + UUID.randomUUID() + ".zip";
+        String uploadBaseUrl = trimTrailingSlash(baseUrl);
         ensureSourceBucket(bucket, project, location, baseUrl);
-        String uploadUrl = baseUrl + "/" + bucket + "/" + object;
+        String uploadUrl = uploadBaseUrl + "/" + bucket + "/" + object;
         return GenerateUploadUrlResponse.newBuilder()
                 .setUploadUrl(uploadUrl)
                 .setStorageSource(StorageSource.newBuilder()
@@ -197,6 +213,12 @@ public class CloudFunctionsService {
                 .build();
     }
 
+    private Operation done(String parent, Message response, Message metadata, boolean transientOnly) {
+        return transientOnly
+                ? operations.doneTransient(parent, response, metadata)
+                : operations.done(parent, response, metadata);
+    }
+
     private static Timestamp timestampNow() {
         Instant now = Instant.now();
         return Timestamp.newBuilder()
@@ -220,6 +242,10 @@ public class CloudFunctionsService {
         String sanitized = value.toLowerCase().replaceAll("[^a-z0-9._-]", "-");
         sanitized = sanitized.replaceAll("^[^a-z0-9]+", "").replaceAll("[^a-z0-9]+$", "");
         return sanitized.isBlank() ? "gcf-v2-sources" : sanitized;
+    }
+
+    private static String trimTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
 
     private static String parent(String project, String location) {

--- a/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsService.java
+++ b/src/main/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsService.java
@@ -1,0 +1,233 @@
+package io.floci.gcp.services.cloudfunctions;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.cloud.functions.v2.Environment;
+import com.google.cloud.functions.v2.Function;
+import com.google.cloud.functions.v2.GenerateUploadUrlResponse;
+import com.google.cloud.functions.v2.ListFunctionsResponse;
+import com.google.cloud.functions.v2.OperationMetadata;
+import com.google.cloud.functions.v2.OperationType;
+import com.google.cloud.functions.v2.ServiceConfig;
+import com.google.cloud.functions.v2.StorageSource;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import com.google.protobuf.Timestamp;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.GcpResourceNames;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.ProtoJson;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.gcs.GcsService;
+import io.floci.gcp.services.operations.LongRunningOperationsService;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CloudFunctionsService {
+
+    private static final Logger LOG = Logger.getLogger(CloudFunctionsService.class);
+
+    private final StorageBackend<String, String> functionStore;
+    private final LongRunningOperationsService operations;
+    private final GcsService gcsService;
+    private final ServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+
+    @Inject
+    public CloudFunctionsService(StorageFactory storageFactory,
+                                 LongRunningOperationsService operations,
+                                 GcsService gcsService,
+                                 ServiceRegistry serviceRegistry,
+                                 EmulatorConfig config) {
+        this.functionStore = storageFactory.create("cloudfunctions-functions", "cloudfunctions-functions.json",
+                new TypeReference<Map<String, String>>() {});
+        this.operations = operations;
+        this.gcsService = gcsService;
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+    }
+
+    CloudFunctionsService(StorageBackend<String, String> functionStore,
+                          LongRunningOperationsService operations,
+                          GcsService gcsService) {
+        this.functionStore = functionStore;
+        this.operations = operations;
+        this.gcsService = gcsService;
+        this.serviceRegistry = null;
+        this.config = null;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("cloudfunctions")
+                .enabled(config.services().cloudfunctions().enabled())
+                .storageKey("cloudfunctions")
+                .protocol(ServiceProtocol.REST)
+                .resourceClasses(CloudFunctionsController.class)
+                .build());
+    }
+
+    public Operation createFunction(String project, String location, String functionId, String body, boolean validateOnly) {
+        String parent = parent(project, location);
+        Function requested = ProtoJson.merge(body, Function.newBuilder()).build();
+        String id = firstPresent(functionId, GcpResourceNames.lastSegment(requested.getName()));
+        if (id == null || id.isBlank()) {
+            throw GcpException.invalidArgument("functionId query parameter is required");
+        }
+        String name = parent + "/functions/" + id;
+        if (functionStore.get(name).isPresent()) {
+            throw GcpException.alreadyExists("Cloud Function already exists: " + name);
+        }
+
+        Timestamp now = timestampNow();
+        Function function = populateFunction(project, location, id, requested, name, now);
+        if (!validateOnly) {
+            functionStore.put(name, ProtoJson.print(function));
+        }
+        LOG.infof("create Cloud Function name=%s validateOnly=%s", name, validateOnly);
+        return operations.done(parent, function, operationMetadata(name, "create", OperationType.CREATE_FUNCTION, now));
+    }
+
+    public Function getFunction(String name) {
+        return functionStore.get(name)
+                .map(json -> ProtoJson.merge(json, Function.newBuilder()).build())
+                .orElseThrow(() -> GcpException.notFound("Cloud Function not found: " + name));
+    }
+
+    public ListFunctionsResponse listFunctions(String project, String location, int pageSize, String pageToken) {
+        String prefix = parent(project, location) + "/functions/";
+        List<Function> functions = functionStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(json -> ProtoJson.merge(json, Function.newBuilder()).build())
+                .sorted(Comparator.comparing(Function::getName))
+                .toList();
+        PageToken.Page<Function> page = PageToken.paginate(functions, pageSize, pageToken);
+        ListFunctionsResponse.Builder response = ListFunctionsResponse.newBuilder()
+                .addAllFunctions(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return response.build();
+    }
+
+    public Operation deleteFunction(String name, boolean validateOnly) {
+        getFunction(name);
+        if (!validateOnly) {
+            functionStore.delete(name);
+        }
+        Timestamp now = timestampNow();
+        LOG.infof("delete Cloud Function name=%s validateOnly=%s", name, validateOnly);
+        return operations.done(parentFromName(name), Empty.getDefaultInstance(),
+                operationMetadata(name, "delete", OperationType.DELETE_FUNCTION, now));
+    }
+
+    public GenerateUploadUrlResponse generateUploadUrl(String project, String location, String baseUrl) {
+        String bucket = sourceBucket(project, location);
+        String object = "source-" + UUID.randomUUID() + ".zip";
+        ensureSourceBucket(bucket, project, location, baseUrl);
+        String uploadUrl = baseUrl + "/" + bucket + "/" + object;
+        return GenerateUploadUrlResponse.newBuilder()
+                .setUploadUrl(uploadUrl)
+                .setStorageSource(StorageSource.newBuilder()
+                        .setBucket(bucket)
+                        .setObject(object)
+                        .setSourceUploadUrl(uploadUrl)
+                        .build())
+                .build();
+    }
+
+    private void ensureSourceBucket(String bucket, String project, String location, String baseUrl) {
+        try {
+            gcsService.createBucket(bucket, project, baseUrl, Map.of("location", location));
+        } catch (GcpException e) {
+            if (!"ALREADY_EXISTS".equals(e.getGcpStatus())) {
+                throw e;
+            }
+        }
+    }
+
+    private static Function populateFunction(String project, String location, String id,
+                                             Function requested, String name, Timestamp now) {
+        String url = "https://" + location + "-" + project + ".cloudfunctions.net/" + id;
+        String revision = name + "/revisions/" + id + "-00001";
+        ServiceConfig.Builder serviceConfig = requested.hasServiceConfig()
+                ? requested.getServiceConfig().toBuilder()
+                : ServiceConfig.newBuilder();
+        serviceConfig
+                .setService("projects/" + project + "/locations/" + location + "/services/" + id)
+                .setUri(url)
+                .setRevision(revision)
+                .setAllTrafficOnLatestRevision(true);
+
+        Function.Builder builder = requested.toBuilder()
+                .setName(name)
+                .setState(Function.State.ACTIVE)
+                .setCreateTime(now)
+                .setUpdateTime(now)
+                .setUrl(url)
+                .setServiceConfig(serviceConfig);
+        if (builder.getEnvironment() == Environment.ENVIRONMENT_UNSPECIFIED) {
+            builder.setEnvironment(Environment.GEN_2);
+        }
+        return builder.build();
+    }
+
+    private static OperationMetadata operationMetadata(String target, String verb,
+                                                       OperationType type, Timestamp now) {
+        return OperationMetadata.newBuilder()
+                .setCreateTime(now)
+                .setEndTime(now)
+                .setTarget(target)
+                .setVerb(verb)
+                .setStatusDetail("Done")
+                .setApiVersion("v2")
+                .setOperationType(type)
+                .build();
+    }
+
+    private static Timestamp timestampNow() {
+        Instant now = Instant.now();
+        return Timestamp.newBuilder()
+                .setSeconds(now.getEpochSecond())
+                .setNanos(now.getNano())
+                .build();
+    }
+
+    private static String firstPresent(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        return second != null && !second.isBlank() ? second : null;
+    }
+
+    private static String sourceBucket(String project, String location) {
+        return sanitizeBucket("gcf-v2-sources-" + project + "-" + location);
+    }
+
+    private static String sanitizeBucket(String value) {
+        String sanitized = value.toLowerCase().replaceAll("[^a-z0-9._-]", "-");
+        sanitized = sanitized.replaceAll("^[^a-z0-9]+", "").replaceAll("[^a-z0-9]+$", "");
+        return sanitized.isBlank() ? "gcf-v2-sources" : sanitized;
+    }
+
+    private static String parent(String project, String location) {
+        return "projects/" + project + "/locations/" + location;
+    }
+
+    private static String parentFromName(String name) {
+        int functions = name.indexOf("/functions/");
+        return functions < 0 ? name : name.substring(0, functions);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunController.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunController.java
@@ -1,0 +1,127 @@
+package io.floci.gcp.services.cloudrun;
+
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import io.floci.gcp.core.common.ProtoJson;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/v2/projects/{project}/locations/{location}")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CloudRunController {
+
+    private final CloudRunService service;
+
+    @Inject
+    public CloudRunController(CloudRunService service) {
+        this.service = service;
+    }
+
+    @POST
+    @Path("/services")
+    public Response createService(@PathParam("project") String project,
+                                  @PathParam("location") String location,
+                                  @QueryParam("serviceId") String serviceId,
+                                  @QueryParam("validateOnly") @DefaultValue("false") boolean validateOnly,
+                                  String body) {
+        return json(ProtoJson.print(service.createService(project, location, serviceId, body, validateOnly)));
+    }
+
+    @GET
+    @Path("/services")
+    public Response listServices(@PathParam("project") String project,
+                                 @PathParam("location") String location,
+                                 @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                                 @QueryParam("pageToken") String pageToken) {
+        return json(ProtoJson.print(service.listServices(project, location, pageSize, pageToken)));
+    }
+
+    @GET
+    @Path("/services/{serviceId}")
+    public Response getService(@PathParam("project") String project,
+                               @PathParam("location") String location,
+                               @PathParam("serviceId") String serviceId) {
+        return json(ProtoJson.print(service.getService(serviceName(project, location, serviceId))));
+    }
+
+    @DELETE
+    @Path("/services/{serviceId}")
+    public Response deleteService(@PathParam("project") String project,
+                                  @PathParam("location") String location,
+                                  @PathParam("serviceId") String serviceId,
+                                  @QueryParam("validateOnly") @DefaultValue("false") boolean validateOnly) {
+        return json(ProtoJson.print(service.deleteService(serviceName(project, location, serviceId), validateOnly)));
+    }
+
+    @GET
+    @Path("/services/{serviceId}:getIamPolicy")
+    public Response getIamPolicy(@PathParam("project") String project,
+                                 @PathParam("location") String location,
+                                 @PathParam("serviceId") String serviceId) {
+        return json(ProtoJson.print(service.getIamPolicy(serviceName(project, location, serviceId))));
+    }
+
+    @POST
+    @Path("/services/{serviceId}:setIamPolicy")
+    public Response setIamPolicy(@PathParam("project") String project,
+                                 @PathParam("location") String location,
+                                 @PathParam("serviceId") String serviceId,
+                                 String body) {
+        SetIamPolicyRequest request = ProtoJson.merge(body, SetIamPolicyRequest.newBuilder()).build();
+        Policy policy = service.setIamPolicy(serviceName(project, location, serviceId), request.getPolicy());
+        return json(ProtoJson.print(policy));
+    }
+
+    @POST
+    @Path("/services/{serviceId}:testIamPermissions")
+    public Response testIamPermissions(@PathParam("project") String project,
+                                       @PathParam("location") String location,
+                                       @PathParam("serviceId") String serviceId,
+                                       String body) {
+        TestIamPermissionsRequest request = ProtoJson.merge(body, TestIamPermissionsRequest.newBuilder()).build();
+        return json(ProtoJson.print(service.testIamPermissions(request.getPermissionsList())));
+    }
+
+    @GET
+    @Path("/services/{serviceId}/revisions")
+    public Response listRevisions(@PathParam("project") String project,
+                                  @PathParam("location") String location,
+                                  @PathParam("serviceId") String serviceId,
+                                  @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                                  @QueryParam("pageToken") String pageToken) {
+        return json(ProtoJson.print(service.listRevisions(
+                serviceName(project, location, serviceId), pageSize, pageToken)));
+    }
+
+    @GET
+    @Path("/services/{serviceId}/revisions/{revisionId}")
+    public Response getRevision(@PathParam("project") String project,
+                                @PathParam("location") String location,
+                                @PathParam("serviceId") String serviceId,
+                                @PathParam("revisionId") String revisionId) {
+        return json(ProtoJson.print(service.getRevision(
+                serviceName(project, location, serviceId) + "/revisions/" + revisionId)));
+    }
+
+    private static Response json(String json) {
+        return Response.ok(json, MediaType.APPLICATION_JSON).build();
+    }
+
+    private static String serviceName(String project, String location, String serviceId) {
+        return "projects/" + project + "/locations/" + location + "/services/" + serviceId;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -118,7 +118,7 @@ public class CloudRunService {
         }
 
         LOG.infof("create Cloud Run service name=%s validateOnly=%s", name, validateOnly);
-        return operations.done(parent, service, service);
+        return done(parent, service, service, validateOnly);
     }
 
     public com.google.cloud.run.v2.Service getService(String name) {
@@ -157,7 +157,7 @@ public class CloudRunService {
                     .forEach(revisionStore::delete);
         }
         LOG.infof("delete Cloud Run service name=%s validateOnly=%s", name, validateOnly);
-        return operations.done(parentFromName(name), deleted, deleted);
+        return done(parentFromName(name), deleted, deleted, validateOnly);
     }
 
     public Revision getRevision(String name) {
@@ -265,6 +265,13 @@ public class CloudRunService {
                 .setState(Condition.State.CONDITION_SUCCEEDED)
                 .setLastTransitionTime(now)
                 .build();
+    }
+
+    private Operation done(String parent, com.google.cloud.run.v2.Service response,
+                           com.google.cloud.run.v2.Service metadata, boolean transientOnly) {
+        return transientOnly
+                ? operations.doneTransient(parent, response, metadata)
+                : operations.done(parent, response, metadata);
     }
 
     private static StoredPolicy toStoredPolicy(Policy policy) {

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -1,0 +1,361 @@
+package io.floci.gcp.services.cloudrun;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.cloud.run.v2.Condition;
+import com.google.cloud.run.v2.ListRevisionsResponse;
+import com.google.cloud.run.v2.ListServicesResponse;
+import com.google.cloud.run.v2.Revision;
+import com.google.cloud.run.v2.TrafficTarget;
+import com.google.cloud.run.v2.TrafficTargetAllocationType;
+import com.google.cloud.run.v2.TrafficTargetStatus;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import com.google.longrunning.Operation;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import com.google.type.Expr;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.GcpResourceNames;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.ProtoJson;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.iam.IamService;
+import io.floci.gcp.services.iam.model.StoredPolicy;
+import io.floci.gcp.services.operations.LongRunningOperationsService;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CloudRunService {
+
+    private static final Logger LOG = Logger.getLogger(CloudRunService.class);
+
+    private final StorageBackend<String, String> serviceStore;
+    private final StorageBackend<String, String> revisionStore;
+    private final LongRunningOperationsService operations;
+    private final IamService iamService;
+    private final ServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+
+    @Inject
+    public CloudRunService(StorageFactory storageFactory,
+                           LongRunningOperationsService operations,
+                           IamService iamService,
+                           ServiceRegistry serviceRegistry,
+                           EmulatorConfig config) {
+        this.serviceStore = storageFactory.create("cloudrun-services", "cloudrun-services.json",
+                new TypeReference<Map<String, String>>() {});
+        this.revisionStore = storageFactory.create("cloudrun-revisions", "cloudrun-revisions.json",
+                new TypeReference<Map<String, String>>() {});
+        this.operations = operations;
+        this.iamService = iamService;
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+    }
+
+    CloudRunService(StorageBackend<String, String> serviceStore,
+                    StorageBackend<String, String> revisionStore,
+                    LongRunningOperationsService operations,
+                    IamService iamService) {
+        this.serviceStore = serviceStore;
+        this.revisionStore = revisionStore;
+        this.operations = operations;
+        this.iamService = iamService;
+        this.serviceRegistry = null;
+        this.config = null;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("cloudrun")
+                .enabled(config.services().cloudrun().enabled())
+                .storageKey("cloudrun")
+                .protocol(ServiceProtocol.REST)
+                .resourceClasses(CloudRunController.class)
+                .build());
+    }
+
+    public Operation createService(String project, String location, String serviceId,
+                                   String body, boolean validateOnly) {
+        String parent = parent(project, location);
+        com.google.cloud.run.v2.Service requested = ProtoJson
+                .merge(body, com.google.cloud.run.v2.Service.newBuilder())
+                .build();
+        String id = firstPresent(serviceId, GcpResourceNames.lastSegment(requested.getName()));
+        if (id == null || id.isBlank()) {
+            throw GcpException.invalidArgument("serviceId query parameter is required");
+        }
+        String name = parent + "/services/" + id;
+        if (serviceStore.get(name).isPresent()) {
+            throw GcpException.alreadyExists("Cloud Run service already exists: " + name);
+        }
+
+        Timestamp now = timestampNow();
+        String revisionName = name + "/revisions/" + id + "-00001";
+        String uri = "https://" + id + "-" + stableSuffix(project, location) + ".a.run.app";
+
+        com.google.cloud.run.v2.Service service = populateService(requested, name, revisionName, uri, now);
+        Revision revision = populateRevision(requested, name, revisionName, now);
+
+        if (!validateOnly) {
+            serviceStore.put(name, ProtoJson.print(service));
+            revisionStore.put(revisionName, ProtoJson.print(revision));
+        }
+
+        LOG.infof("create Cloud Run service name=%s validateOnly=%s", name, validateOnly);
+        return operations.done(parent, service, service);
+    }
+
+    public com.google.cloud.run.v2.Service getService(String name) {
+        return serviceStore.get(name)
+                .map(json -> ProtoJson.merge(json, com.google.cloud.run.v2.Service.newBuilder()).build())
+                .orElseThrow(() -> GcpException.notFound("Cloud Run service not found: " + name));
+    }
+
+    public ListServicesResponse listServices(String project, String location, int pageSize, String pageToken) {
+        String prefix = parent(project, location) + "/services/";
+        List<com.google.cloud.run.v2.Service> services = serviceStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(json -> ProtoJson.merge(json, com.google.cloud.run.v2.Service.newBuilder()).build())
+                .sorted(Comparator.comparing(com.google.cloud.run.v2.Service::getName))
+                .toList();
+        PageToken.Page<com.google.cloud.run.v2.Service> page = PageToken.paginate(services, pageSize, pageToken);
+        ListServicesResponse.Builder response = ListServicesResponse.newBuilder()
+                .addAllServices(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return response.build();
+    }
+
+    public Operation deleteService(String name, boolean validateOnly) {
+        com.google.cloud.run.v2.Service existing = getService(name);
+        Timestamp now = timestampNow();
+        com.google.cloud.run.v2.Service deleted = existing.toBuilder()
+                .setDeleteTime(now)
+                .setUpdateTime(now)
+                .build();
+        if (!validateOnly) {
+            serviceStore.delete(name);
+            String revisionPrefix = name + "/revisions/";
+            revisionStore.keys().stream()
+                    .filter(k -> k.startsWith(revisionPrefix))
+                    .forEach(revisionStore::delete);
+        }
+        LOG.infof("delete Cloud Run service name=%s validateOnly=%s", name, validateOnly);
+        return operations.done(parentFromName(name), deleted, deleted);
+    }
+
+    public Revision getRevision(String name) {
+        return revisionStore.get(name)
+                .map(json -> ProtoJson.merge(json, Revision.newBuilder()).build())
+                .orElseThrow(() -> GcpException.notFound("Cloud Run revision not found: " + name));
+    }
+
+    public ListRevisionsResponse listRevisions(String serviceName, int pageSize, String pageToken) {
+        getService(serviceName);
+        String prefix = serviceName + "/revisions/";
+        List<Revision> revisions = revisionStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(json -> ProtoJson.merge(json, Revision.newBuilder()).build())
+                .sorted(Comparator.comparing(Revision::getName))
+                .toList();
+        PageToken.Page<Revision> page = PageToken.paginate(revisions, pageSize, pageToken);
+        ListRevisionsResponse.Builder response = ListRevisionsResponse.newBuilder()
+                .addAllRevisions(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return response.build();
+    }
+
+    public Policy getIamPolicy(String resource) {
+        return toProtoPolicy(iamService.getPolicy(resource));
+    }
+
+    public Policy setIamPolicy(String resource, Policy policy) {
+        return toProtoPolicy(iamService.setPolicy(resource, toStoredPolicy(policy)));
+    }
+
+    public TestIamPermissionsResponse testIamPermissions(List<String> permissions) {
+        return TestIamPermissionsResponse.newBuilder()
+                .addAllPermissions(iamService.testPermissions(permissions))
+                .build();
+    }
+
+    private static com.google.cloud.run.v2.Service populateService(
+            com.google.cloud.run.v2.Service requested, String name, String revisionName, String uri, Timestamp now) {
+        com.google.cloud.run.v2.Service.Builder builder = requested.toBuilder()
+                .setName(name)
+                .setUid(UUID.randomUUID().toString())
+                .setGeneration(1)
+                .setObservedGeneration(1)
+                .setCreateTime(now)
+                .setUpdateTime(now)
+                .setLatestReadyRevision(revisionName)
+                .setLatestCreatedRevision(revisionName)
+                .setTerminalCondition(readyCondition(now))
+                .addConditions(readyCondition(now))
+                .setUri(uri)
+                .addUrls(uri)
+                .setReconciling(false)
+                .setEtag(UUID.randomUUID().toString());
+        if (builder.getTrafficCount() == 0) {
+            builder.addTraffic(TrafficTarget.newBuilder()
+                    .setType(TrafficTargetAllocationType.TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST)
+                    .setPercent(100)
+                    .build());
+        }
+        builder.clearTrafficStatuses();
+        for (TrafficTarget target : builder.getTrafficList()) {
+            builder.addTrafficStatuses(TrafficTargetStatus.newBuilder()
+                    .setType(target.getType())
+                    .setRevision(target.getRevision().isBlank() ? revisionName : target.getRevision())
+                    .setPercent(target.getPercent())
+                    .setTag(target.getTag())
+                    .setUri(uri)
+                    .build());
+        }
+        return builder.build();
+    }
+
+    private static Revision populateRevision(com.google.cloud.run.v2.Service requested,
+                                             String serviceName, String revisionName, Timestamp now) {
+        Revision.Builder builder = Revision.newBuilder()
+                .setName(revisionName)
+                .setService(serviceName)
+                .setUid(UUID.randomUUID().toString())
+                .setGeneration(1)
+                .setObservedGeneration(1)
+                .setCreateTime(now)
+                .setUpdateTime(now)
+                .addConditions(readyCondition(now))
+                .setReconciling(false)
+                .setEtag(UUID.randomUUID().toString());
+        builder.putAllLabels(requested.getLabelsMap());
+        builder.putAllAnnotations(requested.getAnnotationsMap());
+        if (requested.hasTemplate()) {
+            builder.addAllContainers(requested.getTemplate().getContainersList());
+            builder.addAllVolumes(requested.getTemplate().getVolumesList());
+            builder.setServiceAccount(requested.getTemplate().getServiceAccount());
+            builder.setMaxInstanceRequestConcurrency(requested.getTemplate().getMaxInstanceRequestConcurrency());
+            if (requested.getTemplate().hasTimeout()) {
+                builder.setTimeout(requested.getTemplate().getTimeout());
+            }
+        }
+        return builder.build();
+    }
+
+    private static Condition readyCondition(Timestamp now) {
+        return Condition.newBuilder()
+                .setType("Ready")
+                .setState(Condition.State.CONDITION_SUCCEEDED)
+                .setLastTransitionTime(now)
+                .build();
+    }
+
+    private static StoredPolicy toStoredPolicy(Policy policy) {
+        StoredPolicy stored = new StoredPolicy();
+        stored.setVersion(policy.getVersion());
+        if (!policy.getEtag().isEmpty()) {
+            stored.setEtag(policy.getEtag().toStringUtf8());
+        }
+        stored.setBindings(policy.getBindingsList().stream()
+                .map(CloudRunService::bindingToMap)
+                .toList());
+        return stored;
+    }
+
+    private static Policy toProtoPolicy(StoredPolicy stored) {
+        Policy.Builder builder = Policy.newBuilder()
+                .setVersion(stored.getVersion());
+        if (stored.getEtag() != null) {
+            builder.setEtag(ByteString.copyFromUtf8(stored.getEtag()));
+        }
+        if (stored.getBindings() != null) {
+            for (Map<String, Object> binding : stored.getBindings()) {
+                builder.addBindings(mapToBinding(binding));
+            }
+        }
+        return builder.build();
+    }
+
+    private static Map<String, Object> bindingToMap(Binding binding) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("role", binding.getRole());
+        map.put("members", List.copyOf(binding.getMembersList()));
+        if (binding.hasCondition()) {
+            Map<String, Object> condition = new LinkedHashMap<>();
+            condition.put("expression", binding.getCondition().getExpression());
+            condition.put("title", binding.getCondition().getTitle());
+            condition.put("description", binding.getCondition().getDescription());
+            condition.put("location", binding.getCondition().getLocation());
+            map.put("condition", condition);
+        }
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Binding mapToBinding(Map<String, Object> map) {
+        Binding.Builder builder = Binding.newBuilder()
+                .setRole((String) map.getOrDefault("role", ""));
+        Object members = map.get("members");
+        if (members instanceof List<?> list) {
+            for (Object member : list) {
+                builder.addMembers(String.valueOf(member));
+            }
+        }
+        Object condition = map.get("condition");
+        if (condition instanceof Map<?, ?> raw) {
+            Map<String, Object> c = (Map<String, Object>) raw;
+            builder.setCondition(Expr.newBuilder()
+                    .setExpression((String) c.getOrDefault("expression", ""))
+                    .setTitle((String) c.getOrDefault("title", ""))
+                    .setDescription((String) c.getOrDefault("description", ""))
+                    .setLocation((String) c.getOrDefault("location", ""))
+                    .build());
+        }
+        return builder.build();
+    }
+
+    private static String firstPresent(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        return second != null && !second.isBlank() ? second : null;
+    }
+
+    private static Timestamp timestampNow() {
+        Instant now = Instant.now();
+        return Timestamp.newBuilder()
+                .setSeconds(now.getEpochSecond())
+                .setNanos(now.getNano())
+                .build();
+    }
+
+    private static String parent(String project, String location) {
+        return "projects/" + project + "/locations/" + location;
+    }
+
+    private static String parentFromName(String name) {
+        int services = name.indexOf("/services/");
+        return services < 0 ? name : name.substring(0, services);
+    }
+
+    private static String stableSuffix(String project, String location) {
+        return Integer.toHexString((project + ":" + location).hashCode()).replace("-", "0");
+    }
+}

--- a/src/main/java/io/floci/gcp/services/operations/LongRunningOperationsController.java
+++ b/src/main/java/io/floci/gcp/services/operations/LongRunningOperationsController.java
@@ -1,0 +1,80 @@
+package io.floci.gcp.services.operations;
+
+import com.google.longrunning.WaitOperationRequest;
+import com.google.protobuf.Empty;
+import io.floci.gcp.core.common.ProtoJson;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/v2/projects/{project}/locations/{location}/operations")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class LongRunningOperationsController {
+
+    private final LongRunningOperationsService operations;
+
+    @Inject
+    public LongRunningOperationsController(LongRunningOperationsService operations) {
+        this.operations = operations;
+    }
+
+    @GET
+    @Path("/{operation}")
+    public Response get(@PathParam("project") String project,
+                        @PathParam("location") String location,
+                        @PathParam("operation") String operation) {
+        String name = operationName(project, location, operation);
+        return json(ProtoJson.print(operations.get(name)));
+    }
+
+    @GET
+    public Response list(@PathParam("project") String project,
+                         @PathParam("location") String location,
+                         @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                         @QueryParam("pageToken") String pageToken) {
+        String parent = parent(project, location);
+        return json(ProtoJson.print(operations.list(parent, pageSize, pageToken)));
+    }
+
+    @POST
+    @Path("/{operation}:wait")
+    public Response wait(@PathParam("project") String project,
+                         @PathParam("location") String location,
+                         @PathParam("operation") String operation,
+                         String body) {
+        ProtoJson.merge(body, WaitOperationRequest.newBuilder()).build();
+        String name = operationName(project, location, operation);
+        return json(ProtoJson.print(operations.get(name)));
+    }
+
+    @DELETE
+    @Path("/{operation}")
+    public Response delete(@PathParam("project") String project,
+                           @PathParam("location") String location,
+                           @PathParam("operation") String operation) {
+        operations.delete(operationName(project, location, operation));
+        return json(ProtoJson.print(Empty.getDefaultInstance()));
+    }
+
+    private static Response json(String json) {
+        return Response.ok(json, MediaType.APPLICATION_JSON).build();
+    }
+
+    private static String parent(String project, String location) {
+        return "projects/" + project + "/locations/" + location;
+    }
+
+    private static String operationName(String project, String location, String operation) {
+        return parent(project, location) + "/operations/" + operation;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/operations/LongRunningOperationsService.java
+++ b/src/main/java/io/floci/gcp/services/operations/LongRunningOperationsService.java
@@ -34,6 +34,16 @@ public class LongRunningOperationsService {
     }
 
     public Operation done(String parent, Message response, Message metadata) {
+        Operation operation = completed(parent, response, metadata);
+        operationStore.put(operation.getName(), ProtoJson.print(operation));
+        return operation;
+    }
+
+    public Operation doneTransient(String parent, Message response, Message metadata) {
+        return completed(parent, response, metadata);
+    }
+
+    private Operation completed(String parent, Message response, Message metadata) {
         Operation.Builder builder = Operation.newBuilder()
                 .setName(parent + "/operations/" + UUID.randomUUID())
                 .setDone(true);
@@ -43,9 +53,7 @@ public class LongRunningOperationsService {
         if (metadata != null) {
             builder.setMetadata(Any.pack(metadata));
         }
-        Operation operation = builder.build();
-        operationStore.put(operation.getName(), ProtoJson.print(operation));
-        return operation;
+        return builder.build();
     }
 
     public Operation get(String name) {

--- a/src/main/java/io/floci/gcp/services/operations/LongRunningOperationsService.java
+++ b/src/main/java/io/floci/gcp/services/operations/LongRunningOperationsService.java
@@ -1,0 +1,79 @@
+package io.floci.gcp.services.operations;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.longrunning.ListOperationsResponse;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.ProtoJson;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class LongRunningOperationsService {
+
+    private final StorageBackend<String, String> operationStore;
+
+    @Inject
+    public LongRunningOperationsService(StorageFactory storageFactory) {
+        this.operationStore = storageFactory.create("operations", "operations.json",
+                new TypeReference<Map<String, String>>() {});
+    }
+
+    LongRunningOperationsService(StorageBackend<String, String> operationStore) {
+        this.operationStore = operationStore;
+    }
+
+    public Operation done(String parent, Message response, Message metadata) {
+        Operation.Builder builder = Operation.newBuilder()
+                .setName(parent + "/operations/" + UUID.randomUUID())
+                .setDone(true);
+        if (response != null) {
+            builder.setResponse(Any.pack(response));
+        }
+        if (metadata != null) {
+            builder.setMetadata(Any.pack(metadata));
+        }
+        Operation operation = builder.build();
+        operationStore.put(operation.getName(), ProtoJson.print(operation));
+        return operation;
+    }
+
+    public Operation get(String name) {
+        return operationStore.get(name)
+                .map(this::parse)
+                .orElseThrow(() -> GcpException.notFound("Operation not found: " + name));
+    }
+
+    public ListOperationsResponse list(String parent, int pageSize, String pageToken) {
+        String prefix = parent + "/operations/";
+        List<Operation> operations = operationStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(this::parse)
+                .sorted(Comparator.comparing(Operation::getName))
+                .toList();
+        PageToken.Page<Operation> page = PageToken.paginate(operations, pageSize, pageToken);
+        ListOperationsResponse.Builder response = ListOperationsResponse.newBuilder()
+                .addAllOperations(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return response.build();
+    }
+
+    public void delete(String name) {
+        operationStore.delete(name);
+    }
+
+    private Operation parse(String json) {
+        return ProtoJson.merge(json, Operation.newBuilder()).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,10 @@ floci-gcp:
       default-image: "redpandadata/redpanda:latest"
     cloudtasks:
       enabled: true
+    cloudrun:
+      enabled: true
+    cloudfunctions:
+      enabled: true
   dns:
     extra-suffixes:
   docker:

--- a/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsDisabledRestIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.cloudfunctions;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(CloudFunctionsDisabledRestIntegrationTest.DisabledCloudFunctionsProfile.class)
+class CloudFunctionsDisabledRestIntegrationTest {
+
+    @Test
+    void disabledCloudFunctionsServiceReturnsUnavailableWrapper() {
+        given()
+                .when().get("/v2/projects/functions-disabled/locations/us-central1/functions")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service cloudfunctions is not enabled."));
+    }
+
+    public static class DisabledCloudFunctionsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.cloudfunctions.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsGcsDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsGcsDisabledRestIntegrationTest.java
@@ -1,0 +1,36 @@
+package io.floci.gcp.services.cloudfunctions;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(CloudFunctionsGcsDisabledRestIntegrationTest.DisabledGcsProfile.class)
+class CloudFunctionsGcsDisabledRestIntegrationTest {
+
+    @Test
+    void generateUploadUrlRequiresGcsService() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{}")
+                .when().post("/v2/projects/functions-gcs-disabled/locations/us-central1/functions:generateUploadUrl")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Cloud Functions source upload requires Cloud Storage to be enabled."));
+    }
+
+    public static class DisabledGcsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.gcs.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsRestIntegrationTest.java
@@ -1,0 +1,130 @@
+package io.floci.gcp.services.cloudfunctions;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class CloudFunctionsRestIntegrationTest {
+
+    @Test
+    void cloudFunctionsRestPathsUseProtoJsonUploadUrlAndLroPolling() {
+        String project = "functions-it-1";
+        String location = "us-central1";
+        String functionId = "fn";
+        String functionPath = "/v2/projects/" + project + "/locations/" + location + "/functions/" + functionId;
+
+        String operationName = given()
+                .contentType("application/json")
+                .queryParam("functionId", functionId)
+                .body("{\"buildConfig\":{\"runtime\":\"java21\"}}")
+                .when().post("/v2/projects/" + project + "/locations/" + location + "/functions")
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true))
+                .body("response.'@type'", equalTo("type.googleapis.com/google.cloud.functions.v2.Function"))
+                .body("response.name", equalTo("projects/" + project + "/locations/" + location + "/functions/" + functionId))
+                .body("response.state", equalTo("ACTIVE"))
+                .body("response.environment", equalTo("GEN_2"))
+                .body("response.serviceConfig.service",
+                        equalTo("projects/" + project + "/locations/" + location + "/services/" + functionId))
+                .extract().path("name");
+
+        given()
+                .when().get(functionPath)
+                .then()
+                .statusCode(200)
+                .body("url", equalTo("https://" + location + "-" + project + ".cloudfunctions.net/" + functionId))
+                .body("serviceConfig.allTrafficOnLatestRevision", equalTo(true));
+
+        given()
+                .queryParam("$alt", "json;enum-encoding=int")
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/functions")
+                .then()
+                .statusCode(200)
+                .body("functions.name", hasItem("projects/" + project + "/locations/" + location + "/functions/" + functionId));
+
+        given()
+                .when().get("/v2/" + operationName)
+                .then()
+                .statusCode(200)
+                .body("metadata.operationType", equalTo("CREATE_FUNCTION"))
+                .body("response.name", equalTo("projects/" + project + "/locations/" + location + "/functions/" + functionId));
+
+        String uploadUrl = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{}")
+                .when().post("/v2/projects/" + project + "/locations/" + location + "/functions:generateUploadUrl")
+                .then()
+                .statusCode(200)
+                .body("uploadUrl", startsWith("http://"))
+                .body("storageSource.bucket", startsWith("gcf-v2-sources-functions-it-1-us-central1"))
+                .body("storageSource.object", startsWith("source-"))
+                .extract().path("uploadUrl");
+
+        given()
+                .contentType("application/octet-stream")
+                .body("fake zip bytes".getBytes(StandardCharsets.UTF_8))
+                .when().put(URI.create(uploadUrl).getRawPath())
+                .then()
+                .statusCode(200)
+                .body("bucket", startsWith("gcf-v2-sources-functions-it-1-us-central1"))
+                .body("name", startsWith("source-"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{}")
+                .when().post("/v2/" + operationName + ":wait")
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true));
+
+        String deleteOperation = given()
+                .when().delete(functionPath)
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true))
+                .extract().path("name");
+
+        given()
+                .when().get("/v2/" + deleteOperation)
+                .then()
+                .statusCode(200)
+                .body("metadata.operationType", equalTo("DELETE_FUNCTION"));
+
+        given()
+                .when().get(functionPath)
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+    }
+
+    @Test
+    void validateOnlyCreateDoesNotPersistFunction() {
+        String project = "functions-it-validate";
+        String location = "us-central1";
+
+        given()
+                .contentType("application/json")
+                .queryParam("functionId", "fn")
+                .queryParam("validateOnly", true)
+                .body("{}")
+                .when().post("/v2/projects/" + project + "/locations/" + location + "/functions")
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true));
+
+        given()
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/functions/fn")
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsRestIntegrationTest.java
@@ -111,7 +111,7 @@ class CloudFunctionsRestIntegrationTest {
         String project = "functions-it-validate";
         String location = "us-central1";
 
-        given()
+        String operationName = given()
                 .contentType("application/json")
                 .queryParam("functionId", "fn")
                 .queryParam("validateOnly", true)
@@ -119,12 +119,40 @@ class CloudFunctionsRestIntegrationTest {
                 .when().post("/v2/projects/" + project + "/locations/" + location + "/functions")
                 .then()
                 .statusCode(200)
-                .body("done", equalTo(true));
+                .body("done", equalTo(true))
+                .extract().path("name");
 
         given()
                 .when().get("/v2/projects/" + project + "/locations/" + location + "/functions/fn")
                 .then()
                 .statusCode(404)
                 .body("error.status", equalTo("NOT_FOUND"));
+
+        given()
+                .when().get("/v2/" + operationName)
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+
+        given()
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/operations")
+                .then()
+                .statusCode(200)
+                .body("$", anEmptyMap());
+    }
+
+    @Test
+    void generateUploadUrlHonorsForwardedSchemeAndHost() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("X-Forwarded-Proto", "https")
+                .header("X-Forwarded-Host", "functions.example.test")
+                .body("{}")
+                .when().post("/v2/projects/functions-it-forwarded/locations/us-central1/functions:generateUploadUrl")
+                .then()
+                .statusCode(200)
+                .body("uploadUrl", startsWith("https://functions.example.test/"))
+                .body("storageSource.sourceUploadUrl", startsWith("https://functions.example.test/"));
     }
 }

--- a/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsServiceTest.java
@@ -8,6 +8,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.InMemoryStorage;
 import io.floci.gcp.services.gcs.GcsService;
 import io.floci.gcp.services.operations.LongRunningOperationsService;
@@ -32,6 +33,13 @@ class CloudFunctionsServiceTest {
     void setUp() {
         LongRunningOperationsService operations = mock(LongRunningOperationsService.class);
         when(operations.done(anyString(), any(Message.class), any(Message.class)))
+                .thenAnswer(invocation -> Operation.newBuilder()
+                        .setName(invocation.getArgument(0, String.class) + "/operations/test-op")
+                        .setDone(true)
+                        .setResponse(Any.pack(invocation.getArgument(1, Message.class)))
+                        .setMetadata(Any.pack(invocation.getArgument(2, Message.class)))
+                        .build());
+        when(operations.doneTransient(anyString(), any(Message.class), any(Message.class)))
                 .thenAnswer(invocation -> Operation.newBuilder()
                         .setName(invocation.getArgument(0, String.class) + "/operations/test-op")
                         .setDone(true)
@@ -134,5 +142,19 @@ class CloudFunctionsServiceTest {
                 .thenThrow(GcpException.alreadyExists("Bucket already exists"));
 
         assertDoesNotThrow(() -> service.generateUploadUrl("p1", "us-central1", "http://localhost:4588"));
+    }
+
+    @Test
+    void generateUploadUrlRequiresGcsServiceEnabled() {
+        ServiceRegistry registry = mock(ServiceRegistry.class);
+        when(registry.isEnabled("gcs")).thenReturn(false);
+        CloudFunctionsService gated = new CloudFunctionsService(new InMemoryStorage<>(),
+                mock(LongRunningOperationsService.class), gcsService, registry);
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> gated.generateUploadUrl("p1", "us-central1", "http://localhost:4588"));
+
+        assertEquals("UNAVAILABLE", ex.getGcpStatus());
+        verifyNoInteractions(gcsService);
     }
 }

--- a/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudfunctions/CloudFunctionsServiceTest.java
@@ -1,0 +1,138 @@
+package io.floci.gcp.services.cloudfunctions;
+
+import com.google.cloud.functions.v2.Environment;
+import com.google.cloud.functions.v2.Function;
+import com.google.cloud.functions.v2.GenerateUploadUrlResponse;
+import com.google.cloud.functions.v2.ListFunctionsResponse;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.gcs.GcsService;
+import io.floci.gcp.services.operations.LongRunningOperationsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class CloudFunctionsServiceTest {
+
+    private CloudFunctionsService service;
+    private GcsService gcsService;
+
+    @BeforeEach
+    void setUp() {
+        LongRunningOperationsService operations = mock(LongRunningOperationsService.class);
+        when(operations.done(anyString(), any(Message.class), any(Message.class)))
+                .thenAnswer(invocation -> Operation.newBuilder()
+                        .setName(invocation.getArgument(0, String.class) + "/operations/test-op")
+                        .setDone(true)
+                        .setResponse(Any.pack(invocation.getArgument(1, Message.class)))
+                        .setMetadata(Any.pack(invocation.getArgument(2, Message.class)))
+                        .build());
+        gcsService = mock(GcsService.class);
+        service = new CloudFunctionsService(new InMemoryStorage<>(), operations, gcsService);
+    }
+
+    @Test
+    void createSynthesizesActiveGen2Function() {
+        Operation operation = service.createFunction("p1", "us-central1", "fn",
+                "{\"buildConfig\":{\"runtime\":\"java21\"}}", false);
+
+        assertTrue(operation.getDone());
+        Function function = service.getFunction("projects/p1/locations/us-central1/functions/fn");
+        assertEquals("projects/p1/locations/us-central1/functions/fn", function.getName());
+        assertEquals(Function.State.ACTIVE, function.getState());
+        assertEquals(Environment.GEN_2, function.getEnvironment());
+        assertEquals("https://us-central1-p1.cloudfunctions.net/fn", function.getUrl());
+        assertEquals("projects/p1/locations/us-central1/services/fn", function.getServiceConfig().getService());
+        assertTrue(function.getServiceConfig().getAllTrafficOnLatestRevision());
+    }
+
+    @Test
+    void duplicateCreateAndMissingGetUseGcpErrors() {
+        service.createFunction("p1", "us-central1", "fn", "{}", false);
+
+        GcpException duplicate = assertThrows(GcpException.class,
+                () -> service.createFunction("p1", "us-central1", "fn", "{}", false));
+        assertEquals("ALREADY_EXISTS", duplicate.getGcpStatus());
+
+        GcpException missing = assertThrows(GcpException.class,
+                () -> service.getFunction("projects/p1/locations/us-central1/functions/missing"));
+        assertEquals("NOT_FOUND", missing.getGcpStatus());
+    }
+
+    @Test
+    void listFunctionsPaginatesAndFiltersByProjectAndLocation() {
+        service.createFunction("p1", "us-central1", "a", "{}", false);
+        service.createFunction("p1", "us-central1", "b", "{}", false);
+        service.createFunction("p2", "us-central1", "a", "{}", false);
+        service.createFunction("p1", "europe-west1", "c", "{}", false);
+
+        ListFunctionsResponse firstPage = service.listFunctions("p1", "us-central1", 1, null);
+        assertEquals(1, firstPage.getFunctionsCount());
+        assertFalse(firstPage.getNextPageToken().isBlank());
+
+        ListFunctionsResponse secondPage = service.listFunctions("p1", "us-central1", 10,
+                firstPage.getNextPageToken());
+        assertEquals(1, secondPage.getFunctionsCount());
+        assertEquals("", secondPage.getNextPageToken());
+
+        assertEquals(1, service.listFunctions("p2", "us-central1", 10, null).getFunctionsCount());
+        assertEquals(1, service.listFunctions("p1", "europe-west1", 10, null).getFunctionsCount());
+    }
+
+    @Test
+    void validateOnlyDoesNotPersistCreateOrDeleteMutations() {
+        service.createFunction("p1", "us-central1", "validate", "{}", true);
+        assertThrows(GcpException.class,
+                () -> service.getFunction("projects/p1/locations/us-central1/functions/validate"));
+
+        service.createFunction("p1", "us-central1", "real", "{}", false);
+        service.deleteFunction("projects/p1/locations/us-central1/functions/real", true);
+
+        assertEquals("projects/p1/locations/us-central1/functions/real",
+                service.getFunction("projects/p1/locations/us-central1/functions/real").getName());
+    }
+
+    @Test
+    void deleteFunctionRemovesStoredFunction() {
+        service.createFunction("p1", "us-central1", "fn", "{}", false);
+        String name = "projects/p1/locations/us-central1/functions/fn";
+
+        Operation operation = service.deleteFunction(name, false);
+
+        assertTrue(operation.getDone());
+        assertThrows(GcpException.class, () -> service.getFunction(name));
+    }
+
+    @Test
+    void generateUploadUrlCreatesSourceBucketAndReturnsStorageSource() {
+        GenerateUploadUrlResponse response = service.generateUploadUrl(
+                "project-1", "us-central1", "http://localhost:4588");
+
+        assertTrue(response.getUploadUrl().startsWith("http://localhost:4588/gcf-v2-sources-project-1-us-central1/"));
+        assertEquals("gcf-v2-sources-project-1-us-central1", response.getStorageSource().getBucket());
+        assertTrue(response.getStorageSource().getObject().startsWith("source-"));
+        assertEquals(response.getUploadUrl(), response.getStorageSource().getSourceUploadUrl());
+        verify(gcsService).createBucket(eq("gcf-v2-sources-project-1-us-central1"),
+                eq("project-1"), eq("http://localhost:4588"), anyMap());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void generateUploadUrlIgnoresExistingSourceBucket() {
+        when(gcsService.createBucket(anyString(), anyString(), anyString(), any(Map.class)))
+                .thenThrow(GcpException.alreadyExists("Bucket already exists"));
+
+        assertDoesNotThrow(() -> service.generateUploadUrl("p1", "us-central1", "http://localhost:4588"));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunDisabledRestIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.cloudrun;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(CloudRunDisabledRestIntegrationTest.DisabledCloudRunProfile.class)
+class CloudRunDisabledRestIntegrationTest {
+
+    @Test
+    void disabledCloudRunServiceReturnsUnavailableWrapper() {
+        given()
+                .when().get("/v2/projects/run-disabled/locations/us-central1/services")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service cloudrun is not enabled."));
+    }
+
+    public static class DisabledCloudRunProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.cloudrun.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRestIntegrationTest.java
@@ -1,0 +1,156 @@
+package io.floci.gcp.services.cloudrun;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class CloudRunRestIntegrationTest {
+
+    @Test
+    void cloudRunRestPathsUseProtoJsonAndLroPolling() {
+        String project = "run-it-1";
+        String location = "us-central1";
+        String serviceId = "svc";
+        String servicePath = "/v2/projects/" + project + "/locations/" + location + "/services/" + serviceId;
+
+        String operationName = given()
+                .contentType("application/json")
+                .queryParam("serviceId", serviceId)
+                .body("{\"template\":{\"containers\":[{\"image\":\"gcr.io/run-it-1/svc:latest\"}]}}")
+                .when().post("/v2/projects/" + project + "/locations/" + location + "/services")
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true))
+                .body("response.'@type'", equalTo("type.googleapis.com/google.cloud.run.v2.Service"))
+                .body("response.name", equalTo("projects/" + project + "/locations/" + location + "/services/" + serviceId))
+                .body("response.latestReadyRevision", containsString("/revisions/"))
+                .extract().path("name");
+
+        given()
+                .when().get("/v2/" + operationName)
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true))
+                .body("response.name", equalTo("projects/" + project + "/locations/" + location + "/services/" + serviceId));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{}")
+                .when().post("/v2/" + operationName + ":wait")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(operationName))
+                .body("done", equalTo(true));
+
+        String revisionName = given()
+                .queryParam("$alt", "json;enum-encoding=int")
+                .when().get(servicePath)
+                .then()
+                .statusCode(200)
+                .body("latestReadyRevision", containsString("/revisions/"))
+                .body("terminalCondition.type", equalTo("Ready"))
+                .body("trafficStatuses[0].percent", equalTo(100))
+                .extract().path("latestReadyRevision");
+
+        given()
+                .queryParam("$alt", "json;enum-encoding=int")
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/services")
+                .then()
+                .statusCode(200)
+                .body("services.name", hasItem("projects/" + project + "/locations/" + location + "/services/" + serviceId));
+
+        given()
+                .when().get(servicePath + "/revisions")
+                .then()
+                .statusCode(200)
+                .body("revisions[0].name", equalTo(revisionName));
+
+        given()
+                .when().get("/v2/" + revisionName)
+                .then()
+                .statusCode(200)
+                .body("service", equalTo("projects/" + project + "/locations/" + location + "/services/" + serviceId));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"policy\":{\"bindings\":[{\"role\":\"roles/run.invoker\",\"members\":[\"allUsers\"]}]}}")
+                .when().post(servicePath + ":setIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("bindings[0].role", equalTo("roles/run.invoker"))
+                .body("bindings[0].members", hasItem("allUsers"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(servicePath + ":getIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("bindings[0].members", hasItem("allUsers"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"permissions\":[\"run.services.get\",\"run.services.delete\"]}")
+                .when().post(servicePath + ":testIamPermissions")
+                .then()
+                .statusCode(200)
+                .body("permissions", contains("run.services.get", "run.services.delete"));
+
+        given()
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/operations")
+                .then()
+                .statusCode(200)
+                .body("operations.name", hasItem(operationName));
+
+        given()
+                .when().delete("/v2/" + operationName)
+                .then()
+                .statusCode(200)
+                .body("$", anEmptyMap());
+
+        given()
+                .when().get("/v2/" + operationName)
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+    }
+
+    @Test
+    void missingCloudRunResourceUsesGcpErrorWrapper() {
+        given()
+                .when().get("/v2/projects/run-it-2/locations/us-central1/services/missing")
+                .then()
+                .statusCode(404)
+                .body("error.code", equalTo(404))
+                .body("error.status", equalTo("NOT_FOUND"))
+                .body("error.errors[0].reason", equalTo("notFound"));
+    }
+
+    @Test
+    void validateOnlyCreateDoesNotPersistResource() {
+        String project = "run-it-validate";
+        String location = "us-central1";
+
+        given()
+                .contentType("application/json")
+                .queryParam("serviceId", "svc")
+                .queryParam("validateOnly", true)
+                .body("{}")
+                .when().post("/v2/projects/" + project + "/locations/" + location + "/services")
+                .then()
+                .statusCode(200)
+                .body("done", equalTo(true));
+
+        given()
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/services/svc")
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+    }
+
+}

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRestIntegrationTest.java
@@ -34,6 +34,8 @@ class CloudRunRestIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("done", equalTo(true))
+                .body("metadata.'@type'", equalTo("type.googleapis.com/google.cloud.run.v2.Service"))
+                .body("metadata.name", equalTo("projects/" + project + "/locations/" + location + "/services/" + serviceId))
                 .body("response.name", equalTo("projects/" + project + "/locations/" + location + "/services/" + serviceId));
 
         given()
@@ -136,7 +138,7 @@ class CloudRunRestIntegrationTest {
         String project = "run-it-validate";
         String location = "us-central1";
 
-        given()
+        String operationName = given()
                 .contentType("application/json")
                 .queryParam("serviceId", "svc")
                 .queryParam("validateOnly", true)
@@ -144,13 +146,26 @@ class CloudRunRestIntegrationTest {
                 .when().post("/v2/projects/" + project + "/locations/" + location + "/services")
                 .then()
                 .statusCode(200)
-                .body("done", equalTo(true));
+                .body("done", equalTo(true))
+                .extract().path("name");
 
         given()
                 .when().get("/v2/projects/" + project + "/locations/" + location + "/services/svc")
                 .then()
                 .statusCode(404)
                 .body("error.status", equalTo("NOT_FOUND"));
+
+        given()
+                .when().get("/v2/" + operationName)
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+
+        given()
+                .when().get("/v2/projects/" + project + "/locations/" + location + "/operations")
+                .then()
+                .statusCode(200)
+                .body("$", anEmptyMap());
     }
 
 }

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
@@ -1,0 +1,163 @@
+package io.floci.gcp.services.cloudrun;
+
+import com.google.cloud.run.v2.Condition;
+import com.google.cloud.run.v2.ListRevisionsResponse;
+import com.google.cloud.run.v2.ListServicesResponse;
+import com.google.cloud.run.v2.Revision;
+import com.google.cloud.run.v2.Service;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.iam.IamService;
+import io.floci.gcp.services.iam.model.StoredPolicy;
+import io.floci.gcp.services.operations.LongRunningOperationsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class CloudRunServiceTest {
+
+    private CloudRunService service;
+    private IamService iamService;
+
+    @BeforeEach
+    void setUp() {
+        LongRunningOperationsService operations = mock(LongRunningOperationsService.class);
+        when(operations.done(anyString(), any(Message.class), any(Message.class)))
+                .thenAnswer(invocation -> Operation.newBuilder()
+                        .setName(invocation.getArgument(0, String.class) + "/operations/test-op")
+                        .setDone(true)
+                        .setResponse(Any.pack(invocation.getArgument(1, Message.class)))
+                        .setMetadata(Any.pack(invocation.getArgument(2, Message.class)))
+                        .build());
+        iamService = mock(IamService.class);
+        service = new CloudRunService(new InMemoryStorage<>(), new InMemoryStorage<>(), operations, iamService);
+    }
+
+    @Test
+    void createSynthesizesServiceAndRevision() {
+        Operation operation = service.createService("p1", "us-central1", "svc",
+                "{\"template\":{\"containers\":[{\"image\":\"gcr.io/p1/svc:latest\"}]}}", false);
+
+        assertTrue(operation.getDone());
+
+        Service created = service.getService("projects/p1/locations/us-central1/services/svc");
+        assertEquals("projects/p1/locations/us-central1/services/svc", created.getName());
+        assertTrue(created.getUri().startsWith("https://svc-"));
+        assertEquals(created.getLatestCreatedRevision(), created.getLatestReadyRevision());
+        assertEquals(Condition.State.CONDITION_SUCCEEDED, created.getTerminalCondition().getState());
+        assertEquals(1, created.getTrafficStatusesCount());
+        assertEquals(100, created.getTrafficStatuses(0).getPercent());
+
+        Revision revision = service.getRevision(created.getLatestReadyRevision());
+        assertEquals(created.getName(), revision.getService());
+        assertEquals("gcr.io/p1/svc:latest", revision.getContainers(0).getImage());
+    }
+
+    @Test
+    void duplicateCreateAndMissingGetUseGcpErrors() {
+        service.createService("p1", "us-central1", "svc", "{}", false);
+
+        GcpException duplicate = assertThrows(GcpException.class,
+                () -> service.createService("p1", "us-central1", "svc", "{}", false));
+        assertEquals("ALREADY_EXISTS", duplicate.getGcpStatus());
+
+        GcpException missing = assertThrows(GcpException.class,
+                () -> service.getService("projects/p1/locations/us-central1/services/missing"));
+        assertEquals("NOT_FOUND", missing.getGcpStatus());
+    }
+
+    @Test
+    void listServicesPaginatesAndFiltersByProjectAndLocation() {
+        service.createService("p1", "us-central1", "a", "{}", false);
+        service.createService("p1", "us-central1", "b", "{}", false);
+        service.createService("p2", "us-central1", "a", "{}", false);
+        service.createService("p1", "europe-west1", "c", "{}", false);
+
+        ListServicesResponse firstPage = service.listServices("p1", "us-central1", 1, null);
+        assertEquals(1, firstPage.getServicesCount());
+        assertFalse(firstPage.getNextPageToken().isBlank());
+
+        ListServicesResponse secondPage = service.listServices("p1", "us-central1", 10,
+                firstPage.getNextPageToken());
+        assertEquals(1, secondPage.getServicesCount());
+        assertEquals("", secondPage.getNextPageToken());
+
+        assertEquals(1, service.listServices("p2", "us-central1", 10, null).getServicesCount());
+        assertEquals(1, service.listServices("p1", "europe-west1", 10, null).getServicesCount());
+    }
+
+    @Test
+    void validateOnlyDoesNotPersistCreateOrDeleteMutations() {
+        service.createService("p1", "us-central1", "validate", "{}", true);
+        assertThrows(GcpException.class,
+                () -> service.getService("projects/p1/locations/us-central1/services/validate"));
+
+        service.createService("p1", "us-central1", "real", "{}", false);
+        service.deleteService("projects/p1/locations/us-central1/services/real", true);
+
+        assertEquals("projects/p1/locations/us-central1/services/real",
+                service.getService("projects/p1/locations/us-central1/services/real").getName());
+    }
+
+    @Test
+    void deleteRemovesServiceAndReadOnlyRevision() {
+        service.createService("p1", "us-central1", "svc", "{}", false);
+        String name = "projects/p1/locations/us-central1/services/svc";
+        String revision = service.getService(name).getLatestReadyRevision();
+
+        Operation operation = service.deleteService(name, false);
+
+        assertTrue(operation.getDone());
+        assertThrows(GcpException.class, () -> service.getService(name));
+        assertThrows(GcpException.class, () -> service.getRevision(revision));
+    }
+
+    @Test
+    void listRevisionsPaginatesAndRequiresParentService() {
+        service.createService("p1", "us-central1", "svc", "{}", false);
+
+        ListRevisionsResponse revisions = service.listRevisions(
+                "projects/p1/locations/us-central1/services/svc", 1, null);
+
+        assertEquals(1, revisions.getRevisionsCount());
+        assertEquals("projects/p1/locations/us-central1/services/svc", revisions.getRevisions(0).getService());
+        assertThrows(GcpException.class, () -> service.listRevisions(
+                "projects/p1/locations/us-central1/services/missing", 1, null));
+    }
+
+    @Test
+    void iamPolicyConversionsDelegateToIamService() {
+        String resource = "projects/p1/locations/us-central1/services/svc";
+        StoredPolicy stored = new StoredPolicy();
+        stored.setVersion(3);
+        stored.setBindings(List.of());
+        when(iamService.getPolicy(resource)).thenReturn(stored);
+
+        assertEquals(3, service.getIamPolicy(resource).getVersion());
+
+        Policy requested = Policy.newBuilder()
+                .setVersion(1)
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/run.invoker")
+                        .addMembers("allUsers")
+                        .build())
+                .build();
+        when(iamService.setPolicy(eq(resource), any(StoredPolicy.class))).thenAnswer(invocation -> invocation.getArgument(1));
+
+        Policy saved = service.setIamPolicy(resource, requested);
+
+        assertEquals("roles/run.invoker", saved.getBindings(0).getRole());
+        assertEquals(List.of("allUsers"), saved.getBindings(0).getMembersList());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
@@ -40,6 +40,13 @@ class CloudRunServiceTest {
                         .setResponse(Any.pack(invocation.getArgument(1, Message.class)))
                         .setMetadata(Any.pack(invocation.getArgument(2, Message.class)))
                         .build());
+        when(operations.doneTransient(anyString(), any(Message.class), any(Message.class)))
+                .thenAnswer(invocation -> Operation.newBuilder()
+                        .setName(invocation.getArgument(0, String.class) + "/operations/test-op")
+                        .setDone(true)
+                        .setResponse(Any.pack(invocation.getArgument(1, Message.class)))
+                        .setMetadata(Any.pack(invocation.getArgument(2, Message.class)))
+                        .build());
         iamService = mock(IamService.class);
         service = new CloudRunService(new InMemoryStorage<>(), new InMemoryStorage<>(), operations, iamService);
     }

--- a/src/test/java/io/floci/gcp/services/operations/LongRunningOperationsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/operations/LongRunningOperationsServiceTest.java
@@ -1,0 +1,73 @@
+package io.floci.gcp.services.operations;
+
+import com.google.cloud.functions.v2.OperationMetadata;
+import com.google.cloud.run.v2.Service;
+import com.google.longrunning.ListOperationsResponse;
+import com.google.longrunning.Operation;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LongRunningOperationsServiceTest {
+
+    private LongRunningOperationsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LongRunningOperationsService(new InMemoryStorage<>());
+    }
+
+    @Test
+    void donePersistsPackedResponseAndMetadata() throws InvalidProtocolBufferException {
+        Service response = Service.newBuilder()
+                .setName("projects/p1/locations/us-central1/services/svc")
+                .build();
+        OperationMetadata metadata = OperationMetadata.newBuilder()
+                .setTarget(response.getName())
+                .setVerb("create")
+                .build();
+
+        Operation created = service.done("projects/p1/locations/us-central1", response, metadata);
+        Operation fetched = service.get(created.getName());
+
+        assertTrue(fetched.getDone());
+        assertEquals(response.getName(), fetched.getResponse().unpack(Service.class).getName());
+        assertEquals("create", fetched.getMetadata().unpack(OperationMetadata.class).getVerb());
+    }
+
+    @Test
+    void listOperationsPaginatesWithinParent() {
+        service.done("projects/p1/locations/us-central1", service("a"), service("a"));
+        service.done("projects/p1/locations/us-central1", service("b"), service("b"));
+        service.done("projects/p2/locations/us-central1", service("c"), service("c"));
+
+        ListOperationsResponse firstPage = service.list("projects/p1/locations/us-central1", 1, null);
+        assertEquals(1, firstPage.getOperationsCount());
+        assertFalse(firstPage.getNextPageToken().isBlank());
+
+        ListOperationsResponse secondPage = service.list(
+                "projects/p1/locations/us-central1", 1, firstPage.getNextPageToken());
+        assertEquals(1, secondPage.getOperationsCount());
+        assertEquals("", secondPage.getNextPageToken());
+    }
+
+    @Test
+    void deleteOperationRemovesStoredRecord() {
+        Operation operation = service.done("projects/p1/locations/us-central1", service("a"), service("a"));
+
+        service.delete(operation.getName());
+
+        GcpException ex = assertThrows(GcpException.class, () -> service.get(operation.getName()));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    private static Service service(String id) {
+        return Service.newBuilder()
+                .setName("projects/p1/locations/us-central1/services/" + id)
+                .build();
+    }
+}

--- a/src/test/java/io/floci/gcp/services/operations/LongRunningOperationsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/operations/LongRunningOperationsServiceTest.java
@@ -65,6 +65,16 @@ class LongRunningOperationsServiceTest {
         assertEquals("NOT_FOUND", ex.getGcpStatus());
     }
 
+    @Test
+    void doneTransientDoesNotPersistOperation() {
+        Operation operation = service.doneTransient("projects/p1/locations/us-central1", service("a"), service("a"));
+
+        assertTrue(operation.getDone());
+        GcpException ex = assertThrows(GcpException.class, () -> service.get(operation.getName()));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+        assertEquals(0, service.list("projects/p1/locations/us-central1", 10, null).getOperationsCount());
+    }
+
     private static Service service(String id) {
         return Service.newBuilder()
                 .setName("projects/p1/locations/us-central1/services/" + id)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,7 @@ floci-gcp:
       mock: true
     cloudtasks:
       enabled: true
+    cloudrun:
+      enabled: true
+    cloudfunctions:
+      enabled: true


### PR DESCRIPTION
## Summary

Implements REST-only Cloud Run v2 and Cloud Functions v2 control-plane emulation for issue #46.

Closes https://github.com/floci-io/floci-gcp/issues/46

## What changed

- Added Google protobuf JSON support through precompiled `proto-google-cloud-run-v2`, `proto-google-cloud-functions-v2`, and `protobuf-java-util` artifacts.
- Added Cloud Run v2 REST endpoints for create, get, list, delete, IAM policy operations, and read-only revision lookup.
- Added Cloud Functions v2 REST endpoints for create, get, list, delete, and `generateUploadUrl`.
- Added shared v2 long-running operation endpoints for get, list, wait, and delete.
- Wired Cloud Run and Cloud Functions into `EmulatorConfig`, YAML config, `ServiceRegistry`, `ServiceEnabledFilter`, `GcpExceptionMapper`, and project-aware storage.
- Added Java SDK compatibility coverage using `ServicesClient`, `RevisionsClient`, and `FunctionServiceClient` with HTTP JSON transport and no credentials.
- Added public documentation for Cloud Run and Cloud Functions service support, config flags, SDK endpoint setup, and control-plane-only limitations.
- Corrected contributor docs to point at `AGENTS.md` and GCP-specific service guidance.

## Behavior

- Create and delete operations complete immediately and persist `google.longrunning.Operation` records with packed `Any` response and metadata.
- Cloud Run creates synthesize service URI, timestamps, etag, ready condition, traffic status, latest revision fields, and a read-only revision.
- Cloud Functions creates synthesize `ACTIVE` state, default `GEN_2` environment, URL, timestamps, and backing Cloud Run service references.
- `generateUploadUrl` returns a signed-upload-style URL backed by the existing GCS XML `PUT /{bucket}/{object}` path plus a `storageSource`.
- `validateOnly=true` returns successful operations without mutating stored resources.

## Out of scope

- Runtime invocation for Cloud Run services or Cloud Functions.
- Cloud Run Jobs or WorkerPools.
- Cloud Functions update, download URL, runtimes list, or IAM.

## Validation

- `rtk ./mvnw test`
- `rtk ./mvnw test -Dtest=LongRunningOperationsServiceTest,CloudRunServiceTest,CloudFunctionsServiceTest,CloudRunRestIntegrationTest,CloudRunDisabledRestIntegrationTest,CloudFunctionsRestIntegrationTest,CloudFunctionsDisabledRestIntegrationTest`
- `rtk ./mvnw package -DskipTests`
- `rtk just test-java` from `compatibility-tests` against the packaged emulator build
- `rtk git diff --check`
