### PR TITLE
feat: add Cloud SQL PostgreSQL phase 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ All settings are overridable via environment variables (`FLOCI_GCP_` prefix).
 | `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Enable/disable Cloud Run |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Enable/disable Cloud Functions |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Enable/disable Managed Kafka |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
 | `FLOCI_GCP_SERVICES_KAFKA_MOCK` | `false` | Use mock mode (no Docker; returns `ACTIVE` immediately) |
 | `FLOCI_GCP_DNS_EXTRA_SUFFIXES` | *(unset)* | Extra DNS suffixes for embedded DNS (comma-separated) |
 

--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -38,12 +38,12 @@ just test-all-iac
 
 | Module | Tool | Framework | Command |
 |---|---|---|---|
-| [`compat-terraform`](compat-terraform/) | Terraform + GCP provider v6 | BATS | `just test-terraform` |
-| [`compat-opentofu`](compat-opentofu/) | OpenTofu + GCP provider v6 | BATS | `just test-opentofu` |
+| [`compat-terraform`](compat-terraform/) | Terraform + GCP provider v7.36 | BATS | `just test-terraform` |
+| [`compat-opentofu`](compat-opentofu/) | OpenTofu + GCP provider v7.36 | BATS | `just test-opentofu` |
 
 ## Test Coverage
 
-### SDK tests — 186 tests total
+### SDK tests — 190 tests total
 
 | Test class | GCP service | Java | Python | Node | Go |
 |---|---|:---:|:---:|:---:|:---:|
@@ -54,14 +54,15 @@ just test-all-iac
 | `DatastoreTest` | Datastore | 5 | 5 | 5 | 5 |
 | `IamTest` | IAM | 7 | 5 | 7 | 7 |
 | `KafkaTest` | Managed Kafka | 11 | 9 | 11 | 11 |
-| **Total** | | **44** | **39** | **52** | **51** |
+| `CloudSqlAdminTest` | Cloud SQL for PostgreSQL | 4 | 0 | 0 | 0 |
+| **Total** | | **48** | **39** | **52** | **51** |
 
 ### IaC tests
 
 | Suite | Resources tested |
 |---|---|
-| `compat-terraform` | GCS bucket (with labels), GCS object, IAM service account |
-| `compat-opentofu` | GCS bucket (with labels), GCS object, IAM service account |
+| `compat-terraform` | GCS bucket (with labels), GCS object, IAM service account, Secret Manager secret/version, Cloud SQL PostgreSQL instance/database/user |
+| `compat-opentofu` | GCS bucket (with labels), GCS object, IAM service account, Secret Manager secret/version, Cloud SQL PostgreSQL instance/database/user |
 
 Each IaC suite runs: `init` → `validate` → `plan` → `apply` → BATS spot-checks → `destroy`.
 
@@ -73,8 +74,8 @@ Each IaC suite runs: `init` → `validate` → `plan` → `apply` → BATS spot-
 - **Node.js 18+** — for `sdk-test-node`
 - **Go 1.21+** — for `sdk-test-go`
 - **just** — task runner
-- **terraform** — for `compat-terraform` BATS tests
-- **tofu** — for `compat-opentofu` BATS tests
+- **terraform** — for `compat-terraform` BATS tests; use a CLI compatible with `hashicorp/google` v7.36
+- **tofu** — for `compat-opentofu` BATS tests; use a CLI compatible with `hashicorp/google` v7.36
 - **bats-core** — for IaC BATS tests (`brew install bats-core`)
 
 ## Configuration
@@ -124,12 +125,15 @@ docker run --rm \
 
 ## IaC suites — notes
 
-The Terraform and OpenTofu GCP provider (v6) does **not** respect `STORAGE_EMULATOR_HOST` or `PUBSUB_EMULATOR_HOST` for resource management. The suites configure explicit custom endpoints in `provider.tf`:
+The Terraform and OpenTofu GCP provider does **not** respect `STORAGE_EMULATOR_HOST` or `PUBSUB_EMULATOR_HOST` for resource management. The suites configure explicit custom endpoints in `provider.tf`:
 
 ```hcl
 provider "google" {
-  storage_custom_endpoint = "${var.endpoint}/storage/v1/"
-  iam_custom_endpoint     = "${var.endpoint}/"
+  storage_custom_endpoint        = "${var.endpoint}/storage/v1/"
+  iam_custom_endpoint            = "${var.endpoint}/"
+  iam_beta_custom_endpoint       = "${var.endpoint}/v1/"
+  secret_manager_custom_endpoint = "${var.endpoint}/v1/"
+  sql_custom_endpoint            = "${var.endpoint}/sql/v1beta4/"
 }
 ```
 

--- a/compatibility-tests/compat-opentofu/Dockerfile
+++ b/compatibility-tests/compat-opentofu/Dockerfile
@@ -1,11 +1,20 @@
-FROM ghcr.io/opentofu/opentofu:1.12.2 AS opentofu
-
 FROM alpine:3.20
 
-# OpenTofu binary from the official image
-COPY --from=opentofu /usr/local/bin/tofu /usr/local/bin/tofu
+ARG OPENTOFU_VERSION=1.12.2
+ARG TARGETARCH
 
-RUN apk add --no-cache bash curl jq git ncurses
+RUN apk add --no-cache bash curl jq git ncurses unzip ca-certificates \
+    && case "${TARGETARCH}" in \
+        amd64) OPENTOFU_ARCH=amd64 ;; \
+        arm64) OPENTOFU_ARCH=arm64 ;; \
+        *) echo "Unsupported OpenTofu architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+        "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_${OPENTOFU_ARCH}.zip" \
+        -o /tmp/tofu.zip \
+    && unzip /tmp/tofu.zip -d /usr/local/bin tofu \
+    && chmod +x /usr/local/bin/tofu \
+    && rm /tmp/tofu.zip
 
 WORKDIR /app
 

--- a/compatibility-tests/compat-opentofu/Dockerfile
+++ b/compatibility-tests/compat-opentofu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/opentofu/opentofu:1.8 AS opentofu
+FROM ghcr.io/opentofu/opentofu:1.12.2 AS opentofu
 
 FROM alpine:3.20
 

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -41,6 +41,33 @@ resource "google_secret_manager_secret_version" "compat" {
   secret_data = "floci-gcp-opentofu-compat-test-secret-value"
 }
 
+# ── Cloud SQL for PostgreSQL ─────────────────────────────────────────────────
+resource "google_sql_database_instance" "compat" {
+  name             = "floci-compat-postgres-tofu"
+  project          = var.project
+  region           = var.region
+  database_version = "POSTGRES_15"
+
+  deletion_protection = false
+
+  settings {
+    tier = "db-custom-1-3840"
+  }
+}
+
+resource "google_sql_database" "compat" {
+  name     = "appdb"
+  project  = var.project
+  instance = google_sql_database_instance.compat.name
+}
+
+resource "google_sql_user" "compat" {
+  name     = "app"
+  project  = var.project
+  instance = google_sql_database_instance.compat.name
+  password = "floci-compat-password"
+}
+
 # ── Outputs ───────────────────────────────────────────────────────────────────
 output "bucket_name" {
   value = google_storage_bucket.compat.name
@@ -60,4 +87,16 @@ output "secret_name" {
 
 output "secret_version_name" {
   value = google_secret_manager_secret_version.compat.name
+}
+
+output "sql_instance_name" {
+  value = google_sql_database_instance.compat.name
+}
+
+output "sql_database_name" {
+  value = google_sql_database.compat.name
+}
+
+output "sql_user_name" {
+  value = google_sql_user.compat.name
 }

--- a/compatibility-tests/compat-opentofu/provider.tf
+++ b/compatibility-tests/compat-opentofu/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.36"
     }
   }
 }
@@ -36,5 +36,7 @@ provider "google" {
 
   storage_custom_endpoint        = "${var.endpoint}/storage/v1/"
   iam_custom_endpoint            = "${var.endpoint}/"
+  iam_beta_custom_endpoint       = "${var.endpoint}/v1/"
   secret_manager_custom_endpoint = "${var.endpoint}/v1/"
+  sql_custom_endpoint            = "${var.endpoint}/sql/v1beta4/"
 }

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -141,9 +141,43 @@ setup() {
     assert_output --partial 'floci-compat-secret-tofu'
 }
 
+# ── Cloud SQL Spot Checks ────────────────────────────────────────────────────
+
+@test "OpenTofu: Cloud SQL PostgreSQL instance created" {
+    instance=$(tofu output -raw sql_instance_name 2>/dev/null)
+    [ -n "$instance" ]
+    run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}"
+    assert_success
+    assert_output --partial '"kind":"sql#instance"'
+    assert_output --partial '"databaseVersion":"POSTGRES_15"'
+    assert_output --partial '"state":"RUNNABLE"'
+}
+
+@test "OpenTofu: Cloud SQL database created" {
+    instance=$(tofu output -raw sql_instance_name 2>/dev/null)
+    database=$(tofu output -raw sql_database_name 2>/dev/null)
+    [ -n "$instance" ]
+    [ -n "$database" ]
+    run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}/databases/${database}"
+    assert_success
+    assert_output --partial '"kind":"sql#database"'
+    assert_output --partial '"name":"appdb"'
+}
+
+@test "OpenTofu: Cloud SQL user created" {
+    instance=$(tofu output -raw sql_instance_name 2>/dev/null)
+    user=$(tofu output -raw sql_user_name 2>/dev/null)
+    [ -n "$instance" ]
+    [ -n "$user" ]
+    run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}/users/${user}"
+    assert_success
+    assert_output --partial '"kind":"sql#user"'
+    assert_output --partial '"name":"app"'
+}
+
 # ── State Integrity ───────────────────────────────────────────────────────────
 
-@test "OpenTofu: all five resources tracked in state" {
+@test "OpenTofu: all eight resources tracked in state" {
     count=$(tofu state list 2>/dev/null | wc -l | tr -d ' ')
-    [ "$count" -ge 5 ]
+    [ "$count" -ge 8 ]
 }

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -41,6 +41,33 @@ resource "google_secret_manager_secret_version" "compat" {
   secret_data = "floci-gcp-compat-test-secret-value"
 }
 
+# ── Cloud SQL for PostgreSQL ─────────────────────────────────────────────────
+resource "google_sql_database_instance" "compat" {
+  name             = "floci-compat-postgres"
+  project          = var.project
+  region           = var.region
+  database_version = "POSTGRES_15"
+
+  deletion_protection = false
+
+  settings {
+    tier = "db-custom-1-3840"
+  }
+}
+
+resource "google_sql_database" "compat" {
+  name     = "appdb"
+  project  = var.project
+  instance = google_sql_database_instance.compat.name
+}
+
+resource "google_sql_user" "compat" {
+  name     = "app"
+  project  = var.project
+  instance = google_sql_database_instance.compat.name
+  password = "floci-compat-password"
+}
+
 # ── Outputs ───────────────────────────────────────────────────────────────────
 output "bucket_name" {
   value = google_storage_bucket.compat.name
@@ -60,4 +87,16 @@ output "secret_name" {
 
 output "secret_version_name" {
   value = google_secret_manager_secret_version.compat.name
+}
+
+output "sql_instance_name" {
+  value = google_sql_database_instance.compat.name
+}
+
+output "sql_database_name" {
+  value = google_sql_database.compat.name
+}
+
+output "sql_user_name" {
+  value = google_sql_user.compat.name
 }

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.0"
+      version = "~> 7.36"
     }
   }
 }
@@ -36,5 +36,7 @@ provider "google" {
 
   storage_custom_endpoint        = "${var.endpoint}/storage/v1/"
   iam_custom_endpoint            = "${var.endpoint}/"
+  iam_beta_custom_endpoint       = "${var.endpoint}/v1/"
   secret_manager_custom_endpoint = "${var.endpoint}/v1/"
+  sql_custom_endpoint            = "${var.endpoint}/sql/v1beta4/"
 }

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -141,9 +141,43 @@ setup() {
     assert_output --partial 'floci-compat-secret'
 }
 
+# ── Cloud SQL Spot Checks ────────────────────────────────────────────────────
+
+@test "Terraform: Cloud SQL PostgreSQL instance created" {
+    instance=$(terraform output -raw sql_instance_name 2>/dev/null)
+    [ -n "$instance" ]
+    run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}"
+    assert_success
+    assert_output --partial '"kind":"sql#instance"'
+    assert_output --partial '"databaseVersion":"POSTGRES_15"'
+    assert_output --partial '"state":"RUNNABLE"'
+}
+
+@test "Terraform: Cloud SQL database created" {
+    instance=$(terraform output -raw sql_instance_name 2>/dev/null)
+    database=$(terraform output -raw sql_database_name 2>/dev/null)
+    [ -n "$instance" ]
+    [ -n "$database" ]
+    run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}/databases/${database}"
+    assert_success
+    assert_output --partial '"kind":"sql#database"'
+    assert_output --partial '"name":"appdb"'
+}
+
+@test "Terraform: Cloud SQL user created" {
+    instance=$(terraform output -raw sql_instance_name 2>/dev/null)
+    user=$(terraform output -raw sql_user_name 2>/dev/null)
+    [ -n "$instance" ]
+    [ -n "$user" ]
+    run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}/users/${user}"
+    assert_success
+    assert_output --partial '"kind":"sql#user"'
+    assert_output --partial '"name":"app"'
+}
+
 # ── State Integrity ───────────────────────────────────────────────────────────
 
-@test "Terraform: all five resources tracked in state" {
+@test "Terraform: all eight resources tracked in state" {
     count=$(terraform state list 2>/dev/null | wc -l | tr -d ' ')
-    [ "$count" -ge 5 ]
+    [ "$count" -ge 8 ]
 }

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -68,6 +68,11 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-functions</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-sqladmin</artifactId>
+            <version>v1beta4-rev20260510-2.0.0</version>
+        </dependency>
 
         <!-- JSON parsing for plain-HTTP tests -->
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -19,6 +19,9 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.tasks.v2.CloudTasksClient;
 import com.google.cloud.tasks.v2.CloudTasksSettings;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.sqladmin.SQLAdmin;
 
 import java.io.IOException;
 import java.net.URI;
@@ -156,5 +159,17 @@ public final class TestFixtures {
                 .setCredentialsProvider(NoCredentialsProvider.create())
                 .build();
         return FunctionServiceClient.create(settings);
+    }
+
+    public static SQLAdmin sqlAdminClient() {
+        return new SQLAdmin.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance(), request -> {
+        })
+                .setApplicationName("floci-gcp-compat")
+                .setRootUrl(endpoint() + "/")
+                // The generated v1beta4 request classes already include sql/v1beta4/
+                // in their URI templates. Setting it here would produce
+                // /sql/v1beta4/sql/v1beta4/... and miss the emulator routes.
+                .setServicePath("")
+                .build();
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudSqlAdminTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudSqlAdminTest.java
@@ -1,0 +1,117 @@
+package io.floci.gcp.test;
+
+import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.api.services.sqladmin.model.Database;
+import com.google.api.services.sqladmin.model.DatabaseInstance;
+import com.google.api.services.sqladmin.model.Flag;
+import com.google.api.services.sqladmin.model.Operation;
+import com.google.api.services.sqladmin.model.Settings;
+import com.google.api.services.sqladmin.model.Tier;
+import com.google.api.services.sqladmin.model.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CloudSqlAdminTest {
+
+    private static final String PROJECT_ID = TestFixtures.projectId();
+    private static final String INSTANCE_ID = TestFixtures.uniqueName("java-pg");
+    private static final String DATABASE_ID = "appdb";
+    private static final String USER_ID = "app";
+
+    private static SQLAdmin client;
+
+    @BeforeAll
+    static void setUp() {
+        client = TestFixtures.sqlAdminClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (client != null) {
+            try {
+                client.users().delete(PROJECT_ID, INSTANCE_ID).setName(USER_ID).execute();
+            } catch (Exception ignored) {
+            }
+            try {
+                client.databases().delete(PROJECT_ID, INSTANCE_ID, DATABASE_ID).execute();
+            } catch (Exception ignored) {
+            }
+            try {
+                client.instances().delete(PROJECT_ID, INSTANCE_ID).execute();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createPostgresInstance() throws Exception {
+        DatabaseInstance instance = new DatabaseInstance()
+                .setName(INSTANCE_ID)
+                .setRegion("us-central1")
+                .setDatabaseVersion("POSTGRES_15")
+                .setSettings(new Settings().setTier("db-custom-1-3840"));
+
+        Operation operation = client.instances().insert(PROJECT_ID, instance).execute();
+        assertDone(operation, "CREATE");
+
+        DatabaseInstance created = client.instances().get(PROJECT_ID, INSTANCE_ID).execute();
+        assertThat(created.getName()).isEqualTo(INSTANCE_ID);
+        assertThat(created.getDatabaseVersion()).isEqualTo("POSTGRES_15");
+        assertThat(created.getState()).isEqualTo("RUNNABLE");
+        assertThat(created.getConnectionName()).isEqualTo(PROJECT_ID + ":us-central1:" + INSTANCE_ID);
+    }
+
+    @Test
+    @Order(2)
+    void staticDiscoveryListsTiersAndFlags() throws Exception {
+        List<Tier> tiers = client.tiers().list(PROJECT_ID).execute().getItems();
+        assertThat(tiers).extracting(Tier::getTier).contains("db-custom-1-3840");
+
+        List<Flag> flags = client.flags().list().execute().getItems();
+        assertThat(flags).extracting(Flag::getName).contains("max_connections");
+    }
+
+    @Test
+    @Order(3)
+    void createDatabaseAndUser() throws Exception {
+        Operation databaseOperation = client.databases().insert(PROJECT_ID, INSTANCE_ID,
+                new Database().setName(DATABASE_ID)).execute();
+        assertDone(databaseOperation, "CREATE_DATABASE");
+
+        Database database = client.databases().get(PROJECT_ID, INSTANCE_ID, DATABASE_ID).execute();
+        assertThat(database.getName()).isEqualTo(DATABASE_ID);
+        assertThat(database.getInstance()).isEqualTo(INSTANCE_ID);
+
+        Operation userOperation = client.users().insert(PROJECT_ID, INSTANCE_ID,
+                new User().setName(USER_ID).setPassword("secret")).execute();
+        assertDone(userOperation, "CREATE_USER");
+
+        List<User> users = client.users().list(PROJECT_ID, INSTANCE_ID).execute().getItems();
+        assertThat(users).extracting(User::getName).contains(USER_ID);
+        assertThat(users).allMatch(user -> user.getPassword() == null);
+    }
+
+    @Test
+    @Order(4)
+    void deleteDatabaseUserAndInstance() throws Exception {
+        assertDone(client.users().delete(PROJECT_ID, INSTANCE_ID).setName(USER_ID).execute(), "DELETE_USER");
+        assertDone(client.databases().delete(PROJECT_ID, INSTANCE_ID, DATABASE_ID).execute(), "DELETE_DATABASE");
+        assertDone(client.instances().delete(PROJECT_ID, INSTANCE_ID).execute(), "DELETE");
+    }
+
+    private static void assertDone(Operation operation, String type) {
+        assertThat(operation.getKind()).isEqualTo("sql#operation");
+        assertThat(operation.getStatus()).isEqualTo("DONE");
+        assertThat(operation.getOperationType()).isEqualTo(type);
+    }
+}

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -82,6 +82,9 @@ floci-gcp:
       mock: false
       default-image: "redpandadata/redpanda:latest"
 
+    cloudsql:
+      enabled: true
+
     cloudtasks:
       enabled: true
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -60,6 +60,7 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_IAM_ENABLED` | `true` | IAM |
 | `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Cloud Tasks |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Managed Service for Apache Kafka |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Cloud SQL for PostgreSQL |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Cloud Run |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Cloud Functions |
 

--- a/docs/services/cloud-sql-postgres.md
+++ b/docs/services/cloud-sql-postgres.md
@@ -1,0 +1,57 @@
+# Cloud SQL for PostgreSQL
+
+floci-gcp emulates the first slice of the Cloud SQL Admin API for PostgreSQL over REST JSON.
+
+| Config | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
+
+## Supported API Surface
+
+| Operation | Path |
+|---|---|
+| Create instance | `POST /v1/projects/{project}/instances` |
+| List instances | `GET /v1/projects/{project}/instances` |
+| Get instance | `GET /v1/projects/{project}/instances/{instance}` |
+| Patch instance | `PATCH /v1/projects/{project}/instances/{instance}` |
+| Update instance | `PUT /v1/projects/{project}/instances/{instance}` |
+| Delete instance | `DELETE /v1/projects/{project}/instances/{instance}` |
+| List tiers | `GET /v1/projects/{project}/tiers` |
+| List flags | `GET /v1/flags` |
+| Get connect settings | `GET /v1/projects/{project}/instances/{instance}/connectSettings` |
+| Get operation | `GET /v1/projects/{project}/operations/{operation}` |
+| List operations | `GET /v1/projects/{project}/operations` |
+| Create database | `POST /v1/projects/{project}/instances/{instance}/databases` |
+| List databases | `GET /v1/projects/{project}/instances/{instance}/databases` |
+| Get database | `GET /v1/projects/{project}/instances/{instance}/databases/{database}` |
+| Update database | `PUT /v1/projects/{project}/instances/{instance}/databases/{database}` |
+| Patch database | `PATCH /v1/projects/{project}/instances/{instance}/databases/{database}` |
+| Delete database | `DELETE /v1/projects/{project}/instances/{instance}/databases/{database}` |
+| Create user | `POST /v1/projects/{project}/instances/{instance}/users` |
+| List users | `GET /v1/projects/{project}/instances/{instance}/users` |
+| Get user | `GET /v1/projects/{project}/instances/{instance}/users/{user}` |
+| Update user | `PUT /v1/projects/{project}/instances/{instance}/users?name={user}` |
+| Delete user | `DELETE /v1/projects/{project}/instances/{instance}/users?name={user}` |
+
+The same API surface is also exposed under `/v1beta4/projects/{project}` and the legacy discovery base path `/sql/v1beta4/projects/{project}`.
+
+## Behavior
+
+Cloud SQL resources are metadata only. Creating an instance accepts PostgreSQL `databaseVersion` values, stores a `RUNNABLE` instance resource, creates the default `postgres` database metadata, and returns an immediately completed `sql#operation`.
+
+`tiers.list` and `flags.list` return static PostgreSQL-oriented metadata so SDKs, gcloud, and IaC providers can complete discovery flows without contacting Google Cloud.
+
+No PostgreSQL data-plane container is started yet. Applications cannot connect to the returned `connectionName`; this first slice is intended for Admin API and IaC workflows that need Cloud SQL resource metadata.
+
+## Phase 1 Limitations
+
+- User passwords are accepted for Admin API compatibility but are not persisted or returned.
+- Instance `etag` values are generated but not enforced for optimistic concurrency on updates.
+- Operations are retained as metadata after target resources are deleted.
+- Resource payloads are metadata-only and do not create PostgreSQL databases or roles in a running server.
+
+## Not Implemented
+
+- PostgreSQL server/container runtime
+- Backups, SSL cert operations, import/export, failover, replicas, and maintenance operations
+- IAM policy methods for Cloud SQL resources

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -13,6 +13,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Secret Manager](secret-manager.md) | gRPC | `google.cloud.secretmanager.v1.SecretManagerService` |
 | [IAM](iam.md) | REST JSON | `/v1/projects/{project}/serviceAccounts` |
 | [Managed Kafka](managed-kafka.md) | REST JSON | `/v1/projects/{project}/locations/{location}/clusters` |
+| [Cloud SQL for PostgreSQL](cloud-sql-postgres.md) | REST JSON | `/v1/projects/{project}/instances` |
 | [Cloud Run](cloud-run.md) | REST JSON | `/v2/projects/{project}/locations/{location}/services` |
 | [Cloud Functions](cloud-functions.md) | REST JSON | `/v2/projects/{project}/locations/{location}/functions` |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
     - Secret Manager: services/secret-manager.md
     - IAM: services/iam.md
     - Managed Kafka: services/managed-kafka.md
+    - Cloud SQL for PostgreSQL: services/cloud-sql-postgres.md
     - Cloud Run: services/cloud-run.md
     - Cloud Functions: services/cloud-functions.md
   - Contributing: contributing.md

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -86,6 +86,8 @@ public interface EmulatorConfig {
 
         KafkaServiceConfig kafka();
 
+        CloudSqlServiceConfig cloudsql();
+
         CloudTasksServiceConfig cloudtasks();
 
         CloudRunServiceConfig cloudrun();
@@ -134,6 +136,11 @@ public interface EmulatorConfig {
         String defaultImage();
 
         Optional<String> dockerNetwork();
+    }
+
+    interface CloudSqlServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface CloudTasksServiceConfig {

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlController.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlController.java
@@ -1,0 +1,205 @@
+package io.floci.gcp.services.cloudsql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.Map;
+
+@Path("/v1/projects/{project}")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CloudSqlController {
+
+    private static final Logger LOG = Logger.getLogger(CloudSqlController.class);
+
+    private final CloudSqlService service;
+
+    CloudSqlController() {
+        this.service = null;
+    }
+
+    @Inject
+    public CloudSqlController(CloudSqlService service) {
+        this.service = service;
+    }
+
+    @POST
+    @Path("/instances")
+    public Response createInstance(@PathParam("project") String project, Map<String, Object> body) {
+        LOG.debugf("Cloud SQL createInstance project=%s", project);
+        return Response.ok(service.createInstance(project, body)).build();
+    }
+
+    @GET
+    @Path("/instances")
+    public Response listInstances(@QueryParam("maxResults") @DefaultValue("0") int maxResults,
+                                  @QueryParam("pageToken") String pageToken) {
+        return Response.ok(service.listInstances(maxResults, pageToken)).build();
+    }
+
+    @GET
+    @Path("/instances/{instance}")
+    public Response getInstance(@PathParam("project") String project,
+                                @PathParam("instance") String instance) {
+        return Response.ok(service.getInstance(project, instance)).build();
+    }
+
+    @PATCH
+    @Path("/instances/{instance}")
+    public Response patchInstance(@PathParam("project") String project,
+                                  @PathParam("instance") String instance,
+                                  Map<String, Object> body) {
+        return Response.ok(service.patchInstance(project, instance, body)).build();
+    }
+
+    @PUT
+    @Path("/instances/{instance}")
+    public Response updateInstance(@PathParam("project") String project,
+                                   @PathParam("instance") String instance,
+                                   Map<String, Object> body) {
+        return Response.ok(service.updateInstance(project, instance, body)).build();
+    }
+
+    @DELETE
+    @Path("/instances/{instance}")
+    @Consumes(MediaType.WILDCARD)
+    public Response deleteInstance(@PathParam("project") String project,
+                                   @PathParam("instance") String instance) {
+        return Response.ok(service.deleteInstance(project, instance)).build();
+    }
+
+    @GET
+    @Path("/tiers")
+    public Response listTiers(@PathParam("project") String project) {
+        return Response.ok(service.listTiers(project)).build();
+    }
+
+    @GET
+    @Path("/instances/{instance}/connectSettings")
+    public Response getConnectSettings(@PathParam("project") String project,
+                                       @PathParam("instance") String instance) {
+        return Response.ok(service.getConnectSettings(project, instance)).build();
+    }
+
+    @GET
+    @Path("/operations/{operation}")
+    public Response getOperation(@PathParam("operation") String operation) {
+        return Response.ok(service.getOperation(operation)).build();
+    }
+
+    @GET
+    @Path("/operations")
+    public Response listOperations(@QueryParam("maxResults") @DefaultValue("0") int maxResults,
+                                   @QueryParam("pageToken") String pageToken) {
+        return Response.ok(service.listOperations(maxResults, pageToken)).build();
+    }
+
+    @POST
+    @Path("/instances/{instance}/databases")
+    public Response createDatabase(@PathParam("project") String project,
+                                   @PathParam("instance") String instance,
+                                   Map<String, Object> body) {
+        return Response.ok(service.createDatabase(project, instance, body)).build();
+    }
+
+    @GET
+    @Path("/instances/{instance}/databases")
+    public Response listDatabases(@PathParam("project") String project,
+                                  @PathParam("instance") String instance) {
+        return Response.ok(service.listDatabases(project, instance)).build();
+    }
+
+    @GET
+    @Path("/instances/{instance}/databases/{database}")
+    public Response getDatabase(@PathParam("project") String project,
+                                @PathParam("instance") String instance,
+                                @PathParam("database") String database) {
+        return Response.ok(service.getDatabase(project, instance, database)).build();
+    }
+
+    @PUT
+    @Path("/instances/{instance}/databases/{database}")
+    public Response updateDatabase(@PathParam("project") String project,
+                                   @PathParam("instance") String instance,
+                                   @PathParam("database") String database,
+                                   Map<String, Object> body) {
+        return Response.ok(service.updateDatabase(project, instance, database, body)).build();
+    }
+
+    @PATCH
+    @Path("/instances/{instance}/databases/{database}")
+    public Response patchDatabase(@PathParam("project") String project,
+                                  @PathParam("instance") String instance,
+                                  @PathParam("database") String database,
+                                  Map<String, Object> body) {
+        return Response.ok(service.patchDatabase(project, instance, database, body)).build();
+    }
+
+    @DELETE
+    @Path("/instances/{instance}/databases/{database}")
+    @Consumes(MediaType.WILDCARD)
+    public Response deleteDatabase(@PathParam("project") String project,
+                                   @PathParam("instance") String instance,
+                                   @PathParam("database") String database) {
+        return Response.ok(service.deleteDatabase(project, instance, database)).build();
+    }
+
+    @POST
+    @Path("/instances/{instance}/users")
+    public Response createUser(@PathParam("project") String project,
+                               @PathParam("instance") String instance,
+                               Map<String, Object> body) {
+        return Response.ok(service.createUser(project, instance, body)).build();
+    }
+
+    @GET
+    @Path("/instances/{instance}/users")
+    public Response listUsers(@PathParam("project") String project,
+                              @PathParam("instance") String instance) {
+        return Response.ok(service.listUsers(project, instance)).build();
+    }
+
+    @GET
+    @Path("/instances/{instance}/users/{name}")
+    public Response getUser(@PathParam("project") String project,
+                            @PathParam("instance") String instance,
+                            @PathParam("name") String name,
+                            @QueryParam("host") String host) {
+        return Response.ok(service.getUser(project, instance, name, host)).build();
+    }
+
+    @PUT
+    @Path("/instances/{instance}/users")
+    public Response updateUser(@PathParam("project") String project,
+                               @PathParam("instance") String instance,
+                               @QueryParam("name") String name,
+                               @QueryParam("host") String host,
+                               Map<String, Object> body) {
+        return Response.ok(service.updateUser(project, instance, name, host, body)).build();
+    }
+
+    @DELETE
+    @Path("/instances/{instance}/users")
+    @Consumes(MediaType.WILDCARD)
+    public Response deleteUser(@PathParam("project") String project,
+                               @PathParam("instance") String instance,
+                               @QueryParam("name") String name,
+                               @QueryParam("host") String host) {
+        return Response.ok(service.deleteUser(project, instance, name, host)).build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlGlobalController.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlGlobalController.java
@@ -1,0 +1,32 @@
+package io.floci.gcp.services.cloudsql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/v1")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class CloudSqlGlobalController {
+
+    private final CloudSqlService service;
+
+    CloudSqlGlobalController() {
+        this.service = null;
+    }
+
+    @Inject
+    public CloudSqlGlobalController(CloudSqlService service) {
+        this.service = service;
+    }
+
+    @GET
+    @Path("/flags")
+    public Response listFlags() {
+        return Response.ok(service.listFlags()).build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlLegacyController.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlLegacyController.java
@@ -1,0 +1,18 @@
+package io.floci.gcp.services.cloudsql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+
+@Path("/sql/v1beta4/projects/{project}")
+@ApplicationScoped
+public class CloudSqlLegacyController extends CloudSqlController {
+
+    CloudSqlLegacyController() {
+    }
+
+    @Inject
+    public CloudSqlLegacyController(CloudSqlService service) {
+        super(service);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlLegacyGlobalController.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlLegacyGlobalController.java
@@ -1,0 +1,18 @@
+package io.floci.gcp.services.cloudsql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+
+@Path("/sql/v1beta4")
+@ApplicationScoped
+public class CloudSqlLegacyGlobalController extends CloudSqlGlobalController {
+
+    CloudSqlLegacyGlobalController() {
+    }
+
+    @Inject
+    public CloudSqlLegacyGlobalController(CloudSqlService service) {
+        super(service);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlService.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlService.java
@@ -1,0 +1,544 @@
+package io.floci.gcp.services.cloudsql;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CloudSqlService {
+
+    private static final Logger LOG = Logger.getLogger(CloudSqlService.class);
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final StorageBackend<String, Map<String, Object>> instanceStore;
+    private final StorageBackend<String, Map<String, Object>> databaseStore;
+    private final StorageBackend<String, Map<String, Object>> userStore;
+    private final StorageBackend<String, Map<String, Object>> operationStore;
+    private final ServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+
+    @Inject
+    public CloudSqlService(StorageFactory storageFactory,
+                           ServiceRegistry serviceRegistry,
+                           EmulatorConfig config,
+                           ObjectMapper objectMapper) {
+        this.instanceStore = storageFactory.create("cloudsql", "cloudsql-instances.json",
+                new TypeReference<Map<String, Map<String, Object>>>() {});
+        this.databaseStore = storageFactory.create("cloudsql", "cloudsql-databases.json",
+                new TypeReference<Map<String, Map<String, Object>>>() {});
+        this.userStore = storageFactory.create("cloudsql", "cloudsql-users.json",
+                new TypeReference<Map<String, Map<String, Object>>>() {});
+        this.operationStore = storageFactory.create("cloudsql", "cloudsql-operations.json",
+                new TypeReference<Map<String, Map<String, Object>>>() {});
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+        this.objectMapper = objectMapper;
+        this.baseUrl = config.effectiveBaseUrl();
+    }
+
+    CloudSqlService(StorageBackend<String, Map<String, Object>> instanceStore,
+                    StorageBackend<String, Map<String, Object>> databaseStore,
+                    StorageBackend<String, Map<String, Object>> userStore,
+                    StorageBackend<String, Map<String, Object>> operationStore,
+                    ObjectMapper objectMapper,
+                    String baseUrl) {
+        this.instanceStore = instanceStore;
+        this.databaseStore = databaseStore;
+        this.userStore = userStore;
+        this.operationStore = operationStore;
+        this.serviceRegistry = null;
+        this.config = null;
+        this.objectMapper = objectMapper;
+        this.baseUrl = baseUrl;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("cloudsql")
+                .enabled(config.services().cloudsql().enabled())
+                .storageKey("cloudsql")
+                .protocol(ServiceProtocol.REST)
+                .resourceClasses(CloudSqlController.class, CloudSqlV1Beta4Controller.class,
+                        CloudSqlLegacyController.class, CloudSqlGlobalController.class,
+                        CloudSqlV1Beta4GlobalController.class, CloudSqlLegacyGlobalController.class)
+                .build());
+    }
+
+    public Map<String, Object> createInstance(String project, Map<String, Object> body) {
+        Map<String, Object> request = copy(body);
+        String instance = stringValue(request.get("name"));
+        if (instance == null || instance.isBlank()) {
+            throw GcpException.invalidArgument("Instance name is required");
+        }
+        String databaseVersion = stringValue(request.get("databaseVersion"));
+        if (databaseVersion == null || !databaseVersion.startsWith("POSTGRES_")) {
+            throw GcpException.invalidArgument("Only PostgreSQL Cloud SQL instances are supported");
+        }
+        if (instanceStore.get(instanceKey(instance)).isPresent()) {
+            throw GcpException.alreadyExists("Cloud SQL instance already exists: " + instance);
+        }
+
+        Map<String, Object> stored = normalizeInstance(project, instance, request);
+        instanceStore.put(instanceKey(instance), stored);
+        createDefaultDatabase(project, instance);
+
+        LOG.infof("create Cloud SQL PostgreSQL instance project=%s instance=%s", project, instance);
+        return createOperation(project, "CREATE", instance, stored);
+    }
+
+    public Map<String, Object> patchInstance(String project, String instance, Map<String, Object> body) {
+        Map<String, Object> existing = getInstance(project, instance);
+        Map<String, Object> patch = copy(body);
+        merge(existing, patch);
+        existing.put("kind", "sql#instance");
+        existing.put("name", instance);
+        existing.put("project", project);
+        existing.put("connectionName", connectionName(project, existing, instance));
+        existing.put("selfLink", instanceSelfLink(project, instance));
+        instanceStore.put(instanceKey(instance), existing);
+        LOG.infof("patch Cloud SQL PostgreSQL instance project=%s instance=%s", project, instance);
+        return createOperation(project, "UPDATE", instance, existing);
+    }
+
+    public Map<String, Object> updateInstance(String project, String instance, Map<String, Object> body) {
+        Map<String, Object> existing = getInstance(project, instance);
+        Map<String, Object> update = copy(body);
+        merge(existing, update);
+        Map<String, Object> stored = normalizeInstance(project, instance, existing);
+        instanceStore.put(instanceKey(instance), stored);
+        LOG.infof("update Cloud SQL PostgreSQL instance project=%s instance=%s", project, instance);
+        return createOperation(project, "UPDATE", instance, stored);
+    }
+
+    public Map<String, Object> getInstance(String project, String instance) {
+        return instanceStore.get(instanceKey(instance))
+                .map(this::copy)
+                .orElseThrow(() -> GcpException.notFound("Cloud SQL instance not found: " + instance));
+    }
+
+    public Map<String, Object> listInstances(int maxResults, String pageToken) {
+        List<Map<String, Object>> instances = instanceStore.scan(k -> k.startsWith("instances/")).stream()
+                .map(this::copy)
+                .sorted(Comparator.comparing(m -> stringValue(m.get("name"))))
+                .toList();
+        PageToken.Page<Map<String, Object>> page = PageToken.paginate(instances, normalizedPageSize(maxResults), pageToken);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "sql#instancesList");
+        response.put("items", page.items());
+        if (page.nextPageToken() != null) {
+            response.put("nextPageToken", page.nextPageToken());
+        }
+        return response;
+    }
+
+    public Map<String, Object> deleteInstance(String project, String instance) {
+        Map<String, Object> existing = getInstance(project, instance);
+        instanceStore.delete(instanceKey(instance));
+        deleteByPrefix(databaseStore, databasePrefix(instance));
+        deleteByPrefix(userStore, userPrefix(instance));
+        LOG.infof("delete Cloud SQL PostgreSQL instance project=%s instance=%s", project, instance);
+        return createOperation(project, "DELETE", instance, existing);
+    }
+
+    public Map<String, Object> listTiers(String project) {
+        return mapOf(
+                "kind", "sql#tiersList",
+                "items", List.of(
+                        tier("db-custom-1-3840", "3840"),
+                        tier("db-custom-2-7680", "7680"),
+                        tier("db-custom-4-15360", "15360")));
+    }
+
+    public Map<String, Object> listFlags() {
+        return mapOf(
+                "kind", "sql#flagsList",
+                "items", List.of(
+                        flag("max_connections", "INTEGER", true, "POSTGRES_15", "POSTGRES_16", "POSTGRES_17"),
+                        flag("cloudsql.iam_authentication", "BOOLEAN", true, "POSTGRES_15", "POSTGRES_16", "POSTGRES_17"),
+                        flag("log_min_duration_statement", "INTEGER", false,
+                                "POSTGRES_15", "POSTGRES_16", "POSTGRES_17")));
+    }
+
+    public Map<String, Object> getConnectSettings(String project, String instance) {
+        Map<String, Object> stored = getInstance(project, instance);
+        return mapOf(
+                "kind", "sql#connectSettings",
+                "backendType", stored.get("backendType"),
+                "instanceType", stored.get("instanceType"),
+                "ipAddresses", stored.getOrDefault("ipAddresses", List.of()),
+                "serverCaCert", stored.get("serverCaCert"),
+                "region", stored.get("region"),
+                "dnsName", stored.getOrDefault("dnsName", ""),
+                "pscEnabled", false);
+    }
+
+    public Map<String, Object> getOperation(String operation) {
+        return operationStore.get(operationKey(operation))
+                .map(this::copy)
+                .orElseThrow(() -> GcpException.notFound("Cloud SQL operation not found: " + operation));
+    }
+
+    public Map<String, Object> listOperations(int maxResults, String pageToken) {
+        List<Map<String, Object>> operations = operationStore.scan(k -> k.startsWith("operations/")).stream()
+                .map(this::copy)
+                .sorted(Comparator.comparing(m -> stringValue(m.get("name"))))
+                .toList();
+        PageToken.Page<Map<String, Object>> page = PageToken.paginate(operations, normalizedPageSize(maxResults), pageToken);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "sql#operationsList");
+        response.put("items", page.items());
+        if (page.nextPageToken() != null) {
+            response.put("nextPageToken", page.nextPageToken());
+        }
+        return response;
+    }
+
+    public Map<String, Object> createDatabase(String project, String instance, Map<String, Object> body) {
+        getInstance(project, instance);
+        Map<String, Object> request = copy(body);
+        String database = stringValue(request.get("name"));
+        if (database == null || database.isBlank()) {
+            throw GcpException.invalidArgument("Database name is required");
+        }
+        String key = databaseKey(instance, database);
+        if (databaseStore.get(key).isPresent()) {
+            throw GcpException.alreadyExists("Cloud SQL database already exists: " + database);
+        }
+        Map<String, Object> stored = normalizeDatabase(project, instance, database, request);
+        databaseStore.put(key, stored);
+        LOG.infof("create Cloud SQL PostgreSQL database project=%s instance=%s database=%s",
+                project, instance, database);
+        return createOperation(project, "CREATE_DATABASE", instance, stored);
+    }
+
+    public Map<String, Object> getDatabase(String project, String instance, String database) {
+        getInstance(project, instance);
+        return databaseStore.get(databaseKey(instance, database))
+                .map(this::copy)
+                .orElseThrow(() -> GcpException.notFound("Cloud SQL database not found: " + database));
+    }
+
+    public Map<String, Object> updateDatabase(String project, String instance,
+                                              String database, Map<String, Object> body) {
+        Map<String, Object> existing = getDatabase(project, instance, database);
+        Map<String, Object> update = copy(body);
+        merge(existing, update);
+        Map<String, Object> stored = normalizeDatabase(project, instance, database, existing);
+        databaseStore.put(databaseKey(instance, database), stored);
+        LOG.infof("update Cloud SQL PostgreSQL database project=%s instance=%s database=%s",
+                project, instance, database);
+        return createOperation(project, "UPDATE_DATABASE", instance, stored);
+    }
+
+    public Map<String, Object> patchDatabase(String project, String instance,
+                                             String database, Map<String, Object> body) {
+        return updateDatabase(project, instance, database, body);
+    }
+
+    public Map<String, Object> listDatabases(String project, String instance) {
+        getInstance(project, instance);
+        List<Map<String, Object>> databases = databaseStore.scan(k -> k.startsWith(databasePrefix(instance))).stream()
+                .map(this::copy)
+                .sorted(Comparator.comparing(m -> stringValue(m.get("name"))))
+                .toList();
+        return mapOf(
+                "kind", "sql#databasesList",
+                "items", databases);
+    }
+
+    public Map<String, Object> deleteDatabase(String project, String instance, String database) {
+        Map<String, Object> existing = getDatabase(project, instance, database);
+        databaseStore.delete(databaseKey(instance, database));
+        LOG.infof("delete Cloud SQL PostgreSQL database project=%s instance=%s database=%s",
+                project, instance, database);
+        return createOperation(project, "DELETE_DATABASE", instance, existing);
+    }
+
+    public Map<String, Object> createUser(String project, String instance, Map<String, Object> body) {
+        getInstance(project, instance);
+        Map<String, Object> request = copy(body);
+        String user = stringValue(request.get("name"));
+        if (user == null || user.isBlank()) {
+            throw GcpException.invalidArgument("User name is required");
+        }
+        String host = stringValue(request.get("host"));
+        String key = userKey(instance, user, host);
+        if (userStore.get(key).isPresent()) {
+            throw GcpException.alreadyExists("Cloud SQL user already exists: " + user);
+        }
+        Map<String, Object> stored = normalizeUser(project, instance, user, host, request);
+        userStore.put(key, stored);
+        LOG.infof("create Cloud SQL PostgreSQL user project=%s instance=%s user=%s", project, instance, user);
+        return createOperation(project, "CREATE_USER", instance, stored);
+    }
+
+    public Map<String, Object> listUsers(String project, String instance) {
+        getInstance(project, instance);
+        List<Map<String, Object>> users = userStore.scan(k -> k.startsWith(userPrefix(instance))).stream()
+                .map(this::copy)
+                .sorted(Comparator.comparing(m -> stringValue(m.get("name"))))
+                .toList();
+        return mapOf(
+                "kind", "sql#usersList",
+                "items", users);
+    }
+
+    public Map<String, Object> getUser(String project, String instance, String user, String host) {
+        getInstance(project, instance);
+        validateUserName(user);
+        return userStore.get(userKey(instance, user, host))
+                .map(this::copy)
+                .orElseThrow(() -> GcpException.notFound("Cloud SQL user not found: " + user));
+    }
+
+    public Map<String, Object> updateUser(String project, String instance, String user,
+                                          String host, Map<String, Object> body) {
+        Map<String, Object> existing = getUser(project, instance, user, host);
+        Map<String, Object> update = copy(body);
+        merge(existing, update);
+        Map<String, Object> stored = normalizeUser(project, instance, user, host, existing);
+        userStore.put(userKey(instance, user, host), stored);
+        LOG.infof("update Cloud SQL PostgreSQL user project=%s instance=%s user=%s",
+                project, instance, user);
+        return createOperation(project, "UPDATE_USER", instance, stored);
+    }
+
+    public Map<String, Object> deleteUser(String project, String instance, String user, String host) {
+        getInstance(project, instance);
+        validateUserName(user);
+        String key = userKey(instance, user, host);
+        Map<String, Object> existing = userStore.get(key)
+                .orElseThrow(() -> GcpException.notFound("Cloud SQL user not found: " + user));
+        userStore.delete(key);
+        LOG.infof("delete Cloud SQL PostgreSQL user project=%s instance=%s user=%s", project, instance, user);
+        return createOperation(project, "DELETE_USER", instance, existing);
+    }
+
+    private Map<String, Object> normalizeInstance(String project, String instance, Map<String, Object> request) {
+        Map<String, Object> stored = copy(request);
+        putDefault(stored, "kind", "sql#instance");
+        stored.put("name", instance);
+        stored.put("project", project);
+        putDefault(stored, "backendType", "SECOND_GEN");
+        putDefault(stored, "instanceType", "CLOUD_SQL_INSTANCE");
+        putDefault(stored, "state", "RUNNABLE");
+        putDefault(stored, "region", "us-central1");
+        putDefault(stored, "gceZone", stored.get("region") + "-a");
+        putDefault(stored, "etag", UUID.randomUUID().toString());
+        putDefault(stored, "settings", defaultSettings());
+        putDefault(stored, "ipAddresses", List.of());
+        putDefault(stored, "serverCaCert", serverCaCert(instance));
+        stored.put("connectionName", connectionName(project, stored, instance));
+        stored.put("selfLink", instanceSelfLink(project, instance));
+        return stored;
+    }
+
+    private void createDefaultDatabase(String project, String instance) {
+        String key = databaseKey(instance, "postgres");
+        if (databaseStore.get(key).isEmpty()) {
+            databaseStore.put(key, normalizeDatabase(project, instance, "postgres", Map.of("name", "postgres")));
+        }
+    }
+
+    private Map<String, Object> normalizeDatabase(String project, String instance,
+                                                  String database, Map<String, Object> request) {
+        Map<String, Object> stored = copy(request);
+        putDefault(stored, "kind", "sql#database");
+        stored.put("name", database);
+        stored.put("project", project);
+        stored.put("instance", instance);
+        putDefault(stored, "charset", "UTF8");
+        putDefault(stored, "collation", "en_US.UTF8");
+        stored.put("selfLink", effectiveBaseUrl() + "/v1/projects/" + project
+                + "/instances/" + instance + "/databases/" + database);
+        return stored;
+    }
+
+    private Map<String, Object> normalizeUser(String project, String instance, String user,
+                                              String host, Map<String, Object> request) {
+        Map<String, Object> stored = copy(request);
+        stored.remove("password");
+        putDefault(stored, "kind", "sql#user");
+        stored.put("name", user);
+        stored.put("project", project);
+        stored.put("instance", instance);
+        if (host != null) {
+            stored.put("host", host);
+        }
+        putDefault(stored, "type", "BUILT_IN");
+        return stored;
+    }
+
+    private Map<String, Object> createOperation(String project, String operationType,
+                                                String instance, Map<String, Object> target) {
+        String id = UUID.randomUUID().toString();
+        String now = Instant.now().toString();
+        Map<String, Object> operation = new LinkedHashMap<>();
+        operation.put("kind", "sql#operation");
+        operation.put("name", id);
+        operation.put("targetId", instance);
+        operation.put("targetProject", project);
+        operation.put("targetLink", target.getOrDefault("selfLink", instanceSelfLink(project, instance)));
+        operation.put("status", "DONE");
+        operation.put("operationType", operationType);
+        operation.put("insertTime", now);
+        operation.put("startTime", now);
+        operation.put("endTime", now);
+        operation.put("selfLink", effectiveBaseUrl() + "/v1/projects/" + project + "/operations/" + id);
+        operationStore.put(operationKey(id), operation);
+        return copy(operation);
+    }
+
+    private Map<String, Object> tier(String tier, String ramMb) {
+        return mapOf(
+                "kind", "sql#tier",
+                "tier", tier,
+                "RAM", ramMb,
+                "DiskQuota", "0",
+                "region", List.of("us-central1", "us-east1", "europe-west1"));
+    }
+
+    private Map<String, Object> flag(String name, String type, boolean requiresRestart, String... appliesTo) {
+        return mapOf(
+                "kind", "sql#flag",
+                "name", name,
+                "type", type,
+                "requiresRestart", requiresRestart,
+                "appliesTo", List.of(appliesTo));
+    }
+
+    private Map<String, Object> defaultSettings() {
+        Map<String, Object> settings = new LinkedHashMap<>();
+        settings.put("kind", "sql#settings");
+        settings.put("tier", "db-custom-1-3840");
+        settings.put("activationPolicy", "ALWAYS");
+        settings.put("dataDiskType", "PD_SSD");
+        settings.put("dataDiskSizeGb", "10");
+        settings.put("availabilityType", "ZONAL");
+        return settings;
+    }
+
+    private Map<String, Object> serverCaCert(String instance) {
+        return mapOf(
+                "kind", "sql#sslCert",
+                "certSerialNumber", UUID.nameUUIDFromBytes(instance.getBytes()).toString(),
+                "commonName", "C=US,O=Google,Inc,CN=Google Cloud SQL Server CA",
+                "sha1Fingerprint", UUID.nameUUIDFromBytes(("sha1:" + instance).getBytes()).toString(),
+                "instance", instance);
+    }
+
+    private String connectionName(String project, Map<String, Object> instance, String name) {
+        return project + ":" + stringValue(instance.get("region")) + ":" + name;
+    }
+
+    private String instanceSelfLink(String project, String instance) {
+        return effectiveBaseUrl() + "/v1/projects/" + project + "/instances/" + instance;
+    }
+
+    private String effectiveBaseUrl() {
+        return baseUrl;
+    }
+
+    private int normalizedPageSize(int maxResults) {
+        if (maxResults <= 0) {
+            return 500;
+        }
+        return Math.min(maxResults, 1000);
+    }
+
+    private void deleteByPrefix(StorageBackend<String, Map<String, Object>> store, String prefix) {
+        new ArrayList<>(store.keys()).stream()
+                .filter(k -> k.startsWith(prefix))
+                .forEach(store::delete);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void merge(Map<String, Object> target, Map<String, Object> patch) {
+        for (Map.Entry<String, Object> entry : patch.entrySet()) {
+            if (entry.getValue() instanceof Map<?, ?> patchMap
+                    && target.get(entry.getKey()) instanceof Map<?, ?> targetMap) {
+                Map<String, Object> mutableTarget = copy((Map<String, Object>) targetMap);
+                merge(mutableTarget, (Map<String, Object>) patchMap);
+                target.put(entry.getKey(), mutableTarget);
+            } else {
+                target.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    private Map<String, Object> copy(Map<String, Object> value) {
+        if (value == null) {
+            return new LinkedHashMap<>();
+        }
+        return objectMapper.convertValue(value, MAP_TYPE);
+    }
+
+    private void putDefault(Map<String, Object> map, String key, Object value) {
+        if (!map.containsKey(key) || map.get(key) == null) {
+            map.put(key, value);
+        }
+    }
+
+    private void validateUserName(String user) {
+        if (user == null || user.isBlank()) {
+            throw GcpException.invalidArgument("User name is required");
+        }
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private static Map<String, Object> mapOf(Object... entries) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        for (int i = 0; i < entries.length; i += 2) {
+            map.put((String) entries[i], entries[i + 1]);
+        }
+        return map;
+    }
+
+    private static String instanceKey(String instance) {
+        return "instances/" + instance;
+    }
+
+    private static String databasePrefix(String instance) {
+        return "instances/" + instance + "/databases/";
+    }
+
+    private static String databaseKey(String instance, String database) {
+        return databasePrefix(instance) + database;
+    }
+
+    private static String userPrefix(String instance) {
+        return "instances/" + instance + "/users/";
+    }
+
+    private static String userKey(String instance, String user, String host) {
+        return userPrefix(instance) + (host == null ? "" : host) + "/" + user;
+    }
+
+    private static String operationKey(String operation) {
+        return "operations/" + operation;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlV1Beta4Controller.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlV1Beta4Controller.java
@@ -1,0 +1,18 @@
+package io.floci.gcp.services.cloudsql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+
+@Path("/v1beta4/projects/{project}")
+@ApplicationScoped
+public class CloudSqlV1Beta4Controller extends CloudSqlController {
+
+    CloudSqlV1Beta4Controller() {
+    }
+
+    @Inject
+    public CloudSqlV1Beta4Controller(CloudSqlService service) {
+        super(service);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlV1Beta4GlobalController.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlV1Beta4GlobalController.java
@@ -1,0 +1,18 @@
+package io.floci.gcp.services.cloudsql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+
+@Path("/v1beta4")
+@ApplicationScoped
+public class CloudSqlV1Beta4GlobalController extends CloudSqlGlobalController {
+
+    CloudSqlV1Beta4GlobalController() {
+    }
+
+    @Inject
+    public CloudSqlV1Beta4GlobalController(CloudSqlService service) {
+        super(service);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,8 @@ floci-gcp:
       enabled: true
       mock: false
       default-image: "redpandadata/redpanda:latest"
+    cloudsql:
+      enabled: true
     cloudtasks:
       enabled: true
     cloudrun:

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlDisabledRestIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.cloudsql;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(CloudSqlDisabledRestIntegrationTest.DisabledCloudSqlProfile.class)
+class CloudSqlDisabledRestIntegrationTest {
+
+    @Test
+    void disabledCloudSqlServiceReturnsUnavailableWrapper() {
+        given()
+                .when().get("/v1/projects/sql-disabled/instances")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service cloudsql is not enabled."));
+    }
+
+    public static class DisabledCloudSqlProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.cloudsql.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlRestIntegrationTest.java
@@ -1,0 +1,298 @@
+package io.floci.gcp.services.cloudsql;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+class CloudSqlRestIntegrationTest {
+
+    @Test
+    void cloudSqlPostgresInstanceDatabaseUserAndOperationsUseSqlAdminJsonShapes() {
+        String project = "sql-it-1";
+        String instance = "pg-main";
+        String base = "/v1/projects/" + project;
+
+        String operation = given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "name": "pg-main",
+                          "databaseVersion": "POSTGRES_15",
+                          "region": "us-central1",
+                          "settings": {"tier": "db-custom-1-3840"}
+                        }
+                        """)
+                .when().post(base + "/instances")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("status", equalTo("DONE"))
+                .body("operationType", equalTo("CREATE"))
+                .body("targetId", equalTo(instance))
+                .body("targetProject", equalTo(project))
+                .extract().path("name");
+
+        given()
+                .when().get(base + "/operations/" + operation)
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("name", equalTo(operation))
+                .body("status", equalTo("DONE"));
+
+        given()
+                .when().get(base + "/instances/" + instance)
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#instance"))
+                .body("name", equalTo(instance))
+                .body("databaseVersion", equalTo("POSTGRES_15"))
+                .body("state", equalTo("RUNNABLE"))
+                .body("connectionName", equalTo(project + ":us-central1:" + instance))
+                .body("settings.tier", equalTo("db-custom-1-3840"));
+
+        given()
+                .when().get(base + "/instances/" + instance + "/connectSettings")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#connectSettings"))
+                .body("backendType", equalTo("SECOND_GEN"))
+                .body("region", equalTo("us-central1"));
+
+        given()
+                .when().get(base + "/instances")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#instancesList"))
+                .body("items.name", hasItem(instance));
+
+        given()
+                .when().get(base + "/tiers")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#tiersList"))
+                .body("items.tier", hasItem("db-custom-1-3840"));
+
+        given()
+                .when().get("/v1/flags")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#flagsList"))
+                .body("items.name", hasItem("max_connections"));
+
+        given()
+                .when().get(base + "/instances/" + instance + "/databases")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#databasesList"))
+                .body("items.name", hasItem("postgres"));
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"appdb\"}")
+                .when().post(base + "/instances/" + instance + "/databases")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("operationType", equalTo("CREATE_DATABASE"));
+
+        given()
+                .when().get(base + "/instances/" + instance + "/databases/appdb")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#database"))
+                .body("name", equalTo("appdb"))
+                .body("instance", equalTo(instance))
+                .body("charset", equalTo("UTF8"));
+
+        given()
+                .contentType("application/json")
+                .body("{\"collation\":\"en_US.UTF8\"}")
+                .when().put(base + "/instances/" + instance + "/databases/appdb")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("operationType", equalTo("UPDATE_DATABASE"));
+
+        given()
+                .contentType("application/json")
+                .body("{\"charset\":\"UTF8\"}")
+                .when().patch(base + "/instances/" + instance + "/databases/appdb")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("operationType", equalTo("UPDATE_DATABASE"));
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"app\",\"password\":\"secret\"}")
+                .when().post(base + "/instances/" + instance + "/users")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("operationType", equalTo("CREATE_USER"));
+
+        given()
+                .when().get(base + "/instances/" + instance + "/users")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#usersList"))
+                .body("items.name", hasItem("app"))
+                .body("items[0].password", nullValue());
+
+        given()
+                .when().get(base + "/instances/" + instance + "/users/app")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#user"))
+                .body("name", equalTo("app"))
+                .body("password", nullValue());
+
+        given()
+                .contentType("application/json")
+                .body("{\"password\":\"new-secret\"}")
+                .when().put(base + "/instances/" + instance + "/users?name=app")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operation"))
+                .body("operationType", equalTo("UPDATE_USER"));
+
+        given()
+                .when().get(base + "/instances/" + instance + "/users/app")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#user"))
+                .body("name", equalTo("app"))
+                .body("password", nullValue());
+
+        given()
+                .contentType("application/json")
+                .body("{\"settings\":{\"userLabels\":{\"env\":\"test\"}}}")
+                .when().patch(base + "/instances/" + instance)
+                .then()
+                .statusCode(200)
+                .body("operationType", equalTo("UPDATE"));
+
+        given()
+                .contentType("application/json")
+                .body("{\"settings\":{\"userLabels\":{\"env\":\"put-test\"}}}")
+                .when().put(base + "/instances/" + instance)
+                .then()
+                .statusCode(200)
+                .body("operationType", equalTo("UPDATE"));
+
+        given()
+                .when().get(base + "/instances/" + instance)
+                .then()
+                .statusCode(200)
+                .body("settings.tier", equalTo("db-custom-1-3840"))
+                .body("settings.userLabels.env", equalTo("put-test"));
+
+        given()
+                .when().get(base + "/operations")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("sql#operationsList"))
+                .body("items.name", hasItem(operation));
+
+        given()
+                .when().delete(base + "/instances/" + instance + "/users?name=app")
+                .then()
+                .statusCode(200)
+                .body("operationType", equalTo("DELETE_USER"));
+
+        given()
+                .when().delete(base + "/instances/" + instance + "/databases/appdb")
+                .then()
+                .statusCode(200)
+                .body("operationType", equalTo("DELETE_DATABASE"));
+
+        given()
+                .when().delete(base + "/instances/" + instance)
+                .then()
+                .statusCode(200)
+                .body("operationType", equalTo("DELETE"));
+
+        given()
+                .when().get(base + "/instances/" + instance)
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+    }
+
+    @Test
+    void cloudSqlSupportsV1Beta4AndLegacySqlBasePaths() {
+        String project = "sql-it-legacy";
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"pg-v1beta4\",\"databaseVersion\":\"POSTGRES_16\"}")
+                .when().post("/v1beta4/projects/" + project + "/instances")
+                .then()
+                .statusCode(200)
+                .body("operationType", equalTo("CREATE"));
+
+        given()
+                .when().get("/sql/v1beta4/projects/" + project + "/instances/pg-v1beta4")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("pg-v1beta4"))
+                .body("databaseVersion", equalTo("POSTGRES_16"));
+    }
+
+    @Test
+    void cloudSqlScopesInstancesByProject() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"pg-shared\",\"databaseVersion\":\"POSTGRES_15\"}")
+                .when().post("/v1/projects/sql-project-a/instances")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"pg-shared\",\"databaseVersion\":\"POSTGRES_16\"}")
+                .when().post("/v1/projects/sql-project-b/instances")
+                .then()
+                .statusCode(200);
+
+        given()
+                .when().get("/v1/projects/sql-project-a/instances/pg-shared")
+                .then()
+                .statusCode(200)
+                .body("project", equalTo("sql-project-a"))
+                .body("databaseVersion", equalTo("POSTGRES_15"));
+
+        given()
+                .when().get("/v1/projects/sql-project-b/instances/pg-shared")
+                .then()
+                .statusCode(200)
+                .body("project", equalTo("sql-project-b"))
+                .body("databaseVersion", equalTo("POSTGRES_16"));
+    }
+
+    @Test
+    void cloudSqlRejectsNonPostgresInstancesAndMissingResourcesUseGcpErrors() {
+        String project = "sql-it-errors";
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"mysql-main\",\"databaseVersion\":\"MYSQL_8_0\"}")
+                .when().post("/v1/projects/" + project + "/instances")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+
+        given()
+                .when().get("/v1/projects/" + project + "/instances/missing")
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"))
+                .body("error.errors[0].reason", equalTo("notFound"));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlServiceTest.java
@@ -1,0 +1,125 @@
+package io.floci.gcp.services.cloudsql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.RequestContext;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.core.storage.ProjectAwareStorageBackend;
+import io.floci.gcp.core.storage.StorageBackend;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloudSqlServiceTest {
+
+    @Mock
+    Instance<RequestContext> contextInstance;
+
+    @Mock
+    RequestContext requestContext;
+
+    private CloudSqlService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CloudSqlService(
+                projectAwareStore(),
+                projectAwareStore(),
+                projectAwareStore(),
+                projectAwareStore(),
+                new ObjectMapper(),
+                "http://localhost:4588");
+    }
+
+    private StorageBackend<String, Map<String, Object>> projectAwareStore() {
+        return new ProjectAwareStorageBackend<>(new InMemoryStorage<>(), contextInstance, "default-project");
+    }
+
+    private void withProject(String project) {
+        when(contextInstance.get()).thenReturn(requestContext);
+        when(requestContext.getProjectId()).thenReturn(project);
+    }
+
+    @Test
+    void projectAwareStorageAllowsSameInstanceNameAcrossProjects() {
+        withProject("project-a");
+        service.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_15"));
+
+        withProject("project-b");
+        assertThrows(GcpException.class, () -> service.getInstance("project-b", "pg-main"));
+
+        service.createInstance("project-b", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_16"));
+
+        assertEquals("POSTGRES_16", service.getInstance("project-b", "pg-main").get("databaseVersion"));
+
+        withProject("project-a");
+        assertEquals("POSTGRES_15", service.getInstance("project-a", "pg-main").get("databaseVersion"));
+    }
+
+    @Test
+    void deleteInstanceCascadesDatabasesAndUsers() {
+        withProject("project-a");
+        service.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_15"));
+        service.createDatabase("project-a", "pg-main", Map.of("name", "appdb"));
+        service.createUser("project-a", "pg-main", Map.of("name", "app", "password", "secret"));
+
+        service.deleteInstance("project-a", "pg-main");
+
+        assertThrows(GcpException.class, () -> service.getInstance("project-a", "pg-main"));
+        assertThrows(GcpException.class, () -> service.getDatabase("project-a", "pg-main", "appdb"));
+        assertThrows(GcpException.class, () -> service.getUser("project-a", "pg-main", "app", null));
+    }
+
+    @Test
+    void updateInstanceAndPatchDatabaseReturnCompletedOperations() {
+        withProject("project-a");
+        service.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_15",
+                "settings", Map.of("tier", "db-custom-1-3840")));
+        service.createDatabase("project-a", "pg-main", Map.of("name", "appdb"));
+
+        Map<String, Object> instanceOperation = service.updateInstance("project-a", "pg-main",
+                Map.of("settings", Map.of("userLabels", Map.of("env", "test"))));
+        assertEquals("DONE", instanceOperation.get("status"));
+        assertEquals("UPDATE", instanceOperation.get("operationType"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> settings = (Map<String, Object>) service.getInstance("project-a", "pg-main")
+                .get("settings");
+        assertEquals("db-custom-1-3840", settings.get("tier"));
+        assertEquals(Map.of("env", "test"), settings.get("userLabels"));
+
+        Map<String, Object> databaseOperation = service.patchDatabase("project-a", "pg-main", "appdb",
+                Map.of("collation", "en_US.UTF8"));
+        assertEquals("DONE", databaseOperation.get("status"));
+        assertEquals("UPDATE_DATABASE", databaseOperation.get("operationType"));
+    }
+
+    @Test
+    void staticDiscoveryEndpointsReturnGcpShapes() {
+        Map<String, Object> tiers = service.listTiers("project-a");
+        assertEquals("sql#tiersList", tiers.get("kind"));
+        assertFalse(((List<?>) tiers.get("items")).isEmpty());
+
+        Map<String, Object> flags = service.listFlags();
+        assertEquals("sql#flagsList", flags.get("kind"));
+        assertFalse(((List<?>) flags.get("items")).isEmpty());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,8 @@ floci-gcp:
     kafka:
       enabled: true
       mock: true
+    cloudsql:
+      enabled: true
     cloudtasks:
       enabled: true
     cloudrun:


### PR DESCRIPTION
## Summary
- add metadata-only Cloud SQL Admin API coverage for PostgreSQL instances, databases, users, operations, tiers, and flags
- wire Cloud SQL service configuration, docs, and service index entries
- extend Java SDK, Terraform, and OpenTofu compatibility coverage using Google provider v7 endpoints

## Validation
- `./mvnw test -Dtest=CloudSqlServiceTest,CloudSqlRestIntegrationTest,CloudSqlDisabledRestIntegrationTest`
- `(cd compatibility-tests/sdk-test-java && mvn -q test -Dtest=CloudSqlAdminTest)`
- `just test-terraform`
- `just test-opentofu`
- `terraform fmt -check -recursive compatibility-tests/compat-terraform`
- `tofu fmt -check -recursive compatibility-tests/compat-opentofu`
- `git diff --check`

Refs #48
