### PR TITLE
feat: add Cloud SQL PostgreSQL data plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ All settings are overridable via environment variables (`FLOCI_GCP_` prefix).
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Enable/disable Cloud Functions |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Enable/disable Managed Kafka |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL instances for Cloud SQL |
 | `FLOCI_GCP_SERVICES_KAFKA_MOCK` | `false` | Use mock mode (no Docker; returns `ACTIVE` immediately) |
 | `FLOCI_GCP_DNS_EXTRA_SUFFIXES` | *(unset)* | Extra DNS suffixes for embedded DNS (comma-separated) |
 

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -46,7 +46,7 @@ resource "google_sql_database_instance" "compat" {
   name             = "floci-compat-postgres-tofu"
   project          = var.project
   region           = var.region
-  database_version = "POSTGRES_15"
+  database_version = "POSTGRES_18"
 
   deletion_protection = false
 

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -149,7 +149,7 @@ setup() {
     run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}"
     assert_success
     assert_output --partial '"kind":"sql#instance"'
-    assert_output --partial '"databaseVersion":"POSTGRES_15"'
+    assert_output --partial '"databaseVersion":"POSTGRES_18"'
     assert_output --partial '"state":"RUNNABLE"'
 }
 

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -46,7 +46,7 @@ resource "google_sql_database_instance" "compat" {
   name             = "floci-compat-postgres"
   project          = var.project
   region           = var.region
-  database_version = "POSTGRES_15"
+  database_version = "POSTGRES_18"
 
   deletion_protection = false
 

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -149,7 +149,7 @@ setup() {
     run gcp_curl "${FLOCI_ENDPOINT}/sql/v1beta4/projects/${FLOCI_PROJECT}/instances/${instance}"
     assert_success
     assert_output --partial '"kind":"sql#instance"'
-    assert_output --partial '"databaseVersion":"POSTGRES_15"'
+    assert_output --partial '"databaseVersion":"POSTGRES_18"'
     assert_output --partial '"state":"RUNNABLE"'
 }
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -81,6 +81,11 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-kms</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.7</version>
+        </dependency>
 
         <!-- JSON parsing for plain-HTTP tests -->
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudSqlAdminTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/CloudSqlAdminTest.java
@@ -8,22 +8,17 @@ import com.google.api.services.sqladmin.model.Operation;
 import com.google.api.services.sqladmin.model.Settings;
 import com.google.api.services.sqladmin.model.Tier;
 import com.google.api.services.sqladmin.model.User;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
+import java.sql.DriverManager;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CloudSqlAdminTest {
 
     private static final String PROJECT_ID = TestFixtures.projectId();
-    private static final String INSTANCE_ID = TestFixtures.uniqueName("java-pg");
     private static final String DATABASE_ID = "appdb";
     private static final String USER_ID = "app";
 
@@ -34,45 +29,7 @@ class CloudSqlAdminTest {
         client = TestFixtures.sqlAdminClient();
     }
 
-    @AfterAll
-    static void tearDown() throws Exception {
-        if (client != null) {
-            try {
-                client.users().delete(PROJECT_ID, INSTANCE_ID).setName(USER_ID).execute();
-            } catch (Exception ignored) {
-            }
-            try {
-                client.databases().delete(PROJECT_ID, INSTANCE_ID, DATABASE_ID).execute();
-            } catch (Exception ignored) {
-            }
-            try {
-                client.instances().delete(PROJECT_ID, INSTANCE_ID).execute();
-            } catch (Exception ignored) {
-            }
-        }
-    }
-
     @Test
-    @Order(1)
-    void createPostgresInstance() throws Exception {
-        DatabaseInstance instance = new DatabaseInstance()
-                .setName(INSTANCE_ID)
-                .setRegion("us-central1")
-                .setDatabaseVersion("POSTGRES_15")
-                .setSettings(new Settings().setTier("db-custom-1-3840"));
-
-        Operation operation = client.instances().insert(PROJECT_ID, instance).execute();
-        assertDone(operation, "CREATE");
-
-        DatabaseInstance created = client.instances().get(PROJECT_ID, INSTANCE_ID).execute();
-        assertThat(created.getName()).isEqualTo(INSTANCE_ID);
-        assertThat(created.getDatabaseVersion()).isEqualTo("POSTGRES_15");
-        assertThat(created.getState()).isEqualTo("RUNNABLE");
-        assertThat(created.getConnectionName()).isEqualTo(PROJECT_ID + ":us-central1:" + INSTANCE_ID);
-    }
-
-    @Test
-    @Order(2)
     void staticDiscoveryListsTiersAndFlags() throws Exception {
         List<Tier> tiers = client.tiers().list(PROJECT_ID).execute().getItems();
         assertThat(tiers).extracting(Tier::getTier).contains("db-custom-1-3840");
@@ -82,31 +39,84 @@ class CloudSqlAdminTest {
     }
 
     @Test
-    @Order(3)
-    void createDatabaseAndUser() throws Exception {
-        Operation databaseOperation = client.databases().insert(PROJECT_ID, INSTANCE_ID,
-                new Database().setName(DATABASE_ID)).execute();
-        assertDone(databaseOperation, "CREATE_DATABASE");
-
-        Database database = client.databases().get(PROJECT_ID, INSTANCE_ID, DATABASE_ID).execute();
-        assertThat(database.getName()).isEqualTo(DATABASE_ID);
-        assertThat(database.getInstance()).isEqualTo(INSTANCE_ID);
-
-        Operation userOperation = client.users().insert(PROJECT_ID, INSTANCE_ID,
-                new User().setName(USER_ID).setPassword("secret")).execute();
-        assertDone(userOperation, "CREATE_USER");
-
-        List<User> users = client.users().list(PROJECT_ID, INSTANCE_ID).execute().getItems();
-        assertThat(users).extracting(User::getName).contains(USER_ID);
-        assertThat(users).allMatch(user -> user.getPassword() == null);
+    void sqlAdminSdkCreatesUsableInstancesForLatestPostgresVersions() throws Exception {
+        for (String databaseVersion : List.of("POSTGRES_16", "POSTGRES_17", "POSTGRES_18")) {
+            createDatabaseUserAndConnect(databaseVersion);
+        }
     }
 
-    @Test
-    @Order(4)
-    void deleteDatabaseUserAndInstance() throws Exception {
-        assertDone(client.users().delete(PROJECT_ID, INSTANCE_ID).setName(USER_ID).execute(), "DELETE_USER");
-        assertDone(client.databases().delete(PROJECT_ID, INSTANCE_ID, DATABASE_ID).execute(), "DELETE_DATABASE");
-        assertDone(client.instances().delete(PROJECT_ID, INSTANCE_ID).execute(), "DELETE");
+    private void createDatabaseUserAndConnect(String databaseVersion) throws Exception {
+        String majorVersion = databaseVersion.substring("POSTGRES_".length());
+        String instanceId = TestFixtures.uniqueName("java-pg-" + majorVersion);
+
+        DatabaseInstance instance = new DatabaseInstance()
+                .setName(instanceId)
+                .setRegion("us-central1")
+                .setDatabaseVersion(databaseVersion)
+                .setSettings(new Settings().setTier("db-custom-1-3840"));
+
+        try {
+            Operation operation = client.instances().insert(PROJECT_ID, instance).execute();
+            assertDone(operation, "CREATE");
+
+            DatabaseInstance created = client.instances().get(PROJECT_ID, instanceId).execute();
+            assertThat(created.getName()).isEqualTo(instanceId);
+            assertThat(created.getDatabaseVersion()).isEqualTo(databaseVersion);
+            assertThat(created.getState()).isEqualTo("RUNNABLE");
+            assertThat(created.getConnectionName()).isEqualTo(PROJECT_ID + ":us-central1:" + instanceId);
+
+            Operation databaseOperation = client.databases().insert(PROJECT_ID, instanceId,
+                    new Database().setName(DATABASE_ID)).execute();
+            assertDone(databaseOperation, "CREATE_DATABASE");
+
+            Database database = client.databases().get(PROJECT_ID, instanceId, DATABASE_ID).execute();
+            assertThat(database.getName()).isEqualTo(DATABASE_ID);
+            assertThat(database.getInstance()).isEqualTo(instanceId);
+
+            Operation userOperation = client.users().insert(PROJECT_ID, instanceId,
+                    new User().setName(USER_ID).setPassword("secret")).execute();
+            assertDone(userOperation, "CREATE_USER");
+
+            List<User> users = client.users().list(PROJECT_ID, instanceId).execute().getItems();
+            assertThat(users).extracting(User::getName).contains(USER_ID);
+            assertThat(users).allMatch(user -> user.getPassword() == null);
+
+            DatabaseInstance running = client.instances().get(PROJECT_ID, instanceId).execute();
+            String host = running.getIpAddresses().get(0).getIpAddress();
+            Number port = (Number) running.getIpAddresses().get(0).get("port");
+            try (var connection = DriverManager.getConnection(
+                    "jdbc:postgresql://" + host + ":" + port.intValue() + "/" + DATABASE_ID,
+                    USER_ID, "secret");
+                 var statement = connection.createStatement()) {
+                try (var result = statement.executeQuery("SHOW server_version")) {
+                    assertThat(result.next()).isTrue();
+                    assertThat(result.getString(1)).startsWith(majorVersion + ".");
+                }
+                statement.execute("CREATE TABLE sdk_probe (id INT PRIMARY KEY, note TEXT)");
+                statement.execute("INSERT INTO sdk_probe (id, note) VALUES (1, 'ready')");
+                try (var result = statement.executeQuery("SELECT note FROM sdk_probe WHERE id = 1")) {
+                    assertThat(result.next()).isTrue();
+                    assertThat(result.getString(1)).isEqualTo("ready");
+                }
+            }
+        } finally {
+            cleanup(instanceId);
+        }
+    }
+
+    private static void cleanup(String instanceId) {
+        try {
+            client.users().delete(PROJECT_ID, instanceId).setName(USER_ID).execute();
+        } catch (Exception ignored) {
+        }
+        try {
+            client.databases().delete(PROJECT_ID, instanceId, DATABASE_ID).execute();
+        } catch (Exception ignored) {
+        }
+        try {
+            client.instances().delete(PROJECT_ID, instanceId).execute();
+        } catch (Exception ignored) {
+        }
     }
 
     private static void assertDone(Operation operation, String type) {

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -84,6 +84,12 @@ floci-gcp:
 
     cloudsql:
       enabled: true
+      data-plane-enabled: true
+      postgres15-image: "postgres:15.18-alpine"
+      postgres16-image: "postgres:16.14-alpine"
+      postgres17-image: "postgres:17.10-alpine"
+      postgres18-image: "postgres:18.4-alpine"
+      startup-timeout-seconds: 90
 
     cloudtasks:
       enabled: true

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -61,6 +61,7 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Cloud Tasks |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Managed Service for Apache Kafka |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Cloud SQL for PostgreSQL |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL data-plane instances |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Cloud Run |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Cloud Functions |
 
@@ -79,6 +80,17 @@ Some services (e.g. Managed Kafka) start real sidecar containers via the host Do
 | `FLOCI_GCP_SERVICES_KAFKA_MOCK` | `false` | When `true`, emulate the Kafka control plane only — no Redpanda broker container is started |
 | `FLOCI_GCP_SERVICES_KAFKA_DEFAULT_IMAGE` | `redpandadata/redpanda:latest` | Broker image used for spawned Kafka clusters |
 | `FLOCI_GCP_SERVICES_KAFKA_DOCKER_NETWORK` | _(none)_ | Overrides `FLOCI_GCP_SERVICES_DOCKER_NETWORK` for Kafka sidecars only |
+
+### Cloud SQL for PostgreSQL
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | When `true`, Cloud SQL instances start Docker-backed PostgreSQL containers |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES15_IMAGE` | `postgres:15.18-alpine` | Docker image used for `POSTGRES_15` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES16_IMAGE` | `postgres:16.14-alpine` | Docker image used for `POSTGRES_16` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES17_IMAGE` | `postgres:17.10-alpine` | Docker image used for `POSTGRES_17` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES18_IMAGE` | `postgres:18.4-alpine` | Docker image used for `POSTGRES_18` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_STARTUP_TIMEOUT_SECONDS` | `90` | Max time to wait for PostgreSQL readiness after container start |
 
 ---
 

--- a/docs/services/cloud-sql-postgres.md
+++ b/docs/services/cloud-sql-postgres.md
@@ -1,10 +1,17 @@
 # Cloud SQL for PostgreSQL
 
-floci-gcp emulates the first slice of the Cloud SQL Admin API for PostgreSQL over REST JSON.
+floci-gcp emulates Cloud SQL Admin API metadata for PostgreSQL over REST JSON and runs PostgreSQL
+data-plane instances in Docker-backed `postgres` containers.
 
 | Config | Default | Description |
 |---|---|---|
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL instances for Cloud SQL resources |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES15_IMAGE` | `postgres:15.18-alpine` | Docker image for `POSTGRES_15` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES16_IMAGE` | `postgres:16.14-alpine` | Docker image for `POSTGRES_16` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES17_IMAGE` | `postgres:17.10-alpine` | Docker image for `POSTGRES_17` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES18_IMAGE` | `postgres:18.4-alpine` | Docker image for `POSTGRES_18` instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_STARTUP_TIMEOUT_SECONDS` | `90` | Time to wait for PostgreSQL readiness after container start |
 
 ## Supported API Surface
 
@@ -37,21 +44,38 @@ The same API surface is also exposed under `/v1beta4/projects/{project}` and the
 
 ## Behavior
 
-Cloud SQL resources are metadata only. Creating an instance accepts PostgreSQL `databaseVersion` values, stores a `RUNNABLE` instance resource, creates the default `postgres` database metadata, and returns an immediately completed `sql#operation`.
+Creating an instance accepts PostgreSQL `databaseVersion` values, starts a matching Docker `postgres`
+container, stores a `RUNNABLE` instance resource, creates the default `postgres` database metadata,
+and returns an immediately completed `sql#operation`.
 
 `tiers.list` and `flags.list` return static PostgreSQL-oriented metadata so SDKs, gcloud, and IaC providers can complete discovery flows without contacting Google Cloud.
 
-No PostgreSQL data-plane container is started yet. Applications cannot connect to the returned `connectionName`; this first slice is intended for Admin API and IaC workflows that need Cloud SQL resource metadata.
+`instances.get` and `connect.get` include `ipAddresses[0].ipAddress` plus an emulator-specific
+`ipAddresses[0].port` field for local pgjdbc/libpq connections. `connectionName` keeps the normal
+Cloud SQL shape (`project:region:instance`) for SDK/Admin API compatibility.
 
-## Phase 1 Limitations
+Database and user Admin API operations are synchronized into the backing PostgreSQL server:
+
+- `databases.insert` creates a PostgreSQL database.
+- `databases.delete` drops the PostgreSQL database.
+- `users.insert` and `users.update` create/update PostgreSQL login roles.
+- `users.delete` drops objects owned by the role in known databases, then drops the role.
+- Created users receive connect/create privileges on existing and newly created databases.
+
+Docker storage follows the global floci-gcp storage policy. In named-volume mode, each instance gets
+a stable `floci-gcp-cloudsql-*` volume. `memory` mode, or `floci-gcp.storage.prune-volumes-on-delete=true`,
+removes the volume when the instance is deleted; `persistent`, `hybrid`, and `wal` retain volumes by
+default. When `floci-gcp.storage.host-persistent-path` is absolute, instance data is bind-mounted under
+`{hostPersistentPath}/cloudsql/{project}/{instance}`.
+
+## Limitations
 
 - User passwords are accepted for Admin API compatibility but are not persisted or returned.
 - Instance `etag` values are generated but not enforced for optimistic concurrency on updates.
 - Operations are retained as metadata after target resources are deleted.
-- Resource payloads are metadata-only and do not create PostgreSQL databases or roles in a running server.
+- Host-qualified Cloud SQL users are rejected because PostgreSQL role sync is name-based.
 
 ## Not Implemented
 
-- PostgreSQL server/container runtime
 - Backups, SSL cert operations, import/export, failover, replicas, and maintenance operations
 - IAM policy methods for Cloud SQL resources

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,13 @@
             <artifactId>dec</artifactId>
             <version>0.1.2</version>
         </dependency>
+
+        <!-- PostgreSQL wire-protocol client for Cloud SQL data-plane synchronization -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -155,6 +155,24 @@ public interface EmulatorConfig {
     interface CloudSqlServiceConfig {
         @WithDefault("true")
         boolean enabled();
+
+        @WithDefault("true")
+        boolean dataPlaneEnabled();
+
+        @WithDefault("postgres:15.18-alpine")
+        String postgres15Image();
+
+        @WithDefault("postgres:16.14-alpine")
+        String postgres16Image();
+
+        @WithDefault("postgres:17.10-alpine")
+        String postgres17Image();
+
+        @WithDefault("postgres:18.4-alpine")
+        String postgres18Image();
+
+        @WithDefault("90")
+        int startupTimeoutSeconds();
     }
 
     interface CloudTasksServiceConfig {

--- a/src/main/java/io/floci/gcp/core/storage/ProjectAwareStorageBackend.java
+++ b/src/main/java/io/floci/gcp/core/storage/ProjectAwareStorageBackend.java
@@ -111,6 +111,16 @@ public class ProjectAwareStorageBackend<V> implements StorageBackend<String, V> 
         return result;
     }
 
+    public List<V> scanAllProjects(Predicate<String> keyFilter) {
+        return delegate.keys().stream()
+                .filter(rawKey -> {
+                    int slash = rawKey.indexOf('/');
+                    return slash >= 0 && keyFilter.test(rawKey.substring(slash + 1));
+                })
+                .flatMap(rawKey -> delegate.get(rawKey).stream())
+                .toList();
+    }
+
     // ---
 
     private String projectId() {

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlDataPlane.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlDataPlane.java
@@ -1,0 +1,61 @@
+package io.floci.gcp.services.cloudsql;
+
+import java.util.Map;
+
+interface CloudSqlDataPlane {
+
+    Map<String, Object> startInstance(String project, String instance, Map<String, Object> metadata);
+
+    Map<String, Object> ensureInstance(String project, String instance, Map<String, Object> metadata);
+
+    void stopInstance(String project, String instance, Map<String, Object> metadata, boolean removeStorage);
+
+    void createDatabase(Map<String, Object> instanceMetadata, String database);
+
+    void deleteDatabase(Map<String, Object> instanceMetadata, String database);
+
+    void createOrUpdateUser(Map<String, Object> instanceMetadata, String user, String password);
+
+    void deleteUser(Map<String, Object> instanceMetadata, String user, Iterable<String> databases);
+
+    void grantDatabaseAccess(Map<String, Object> instanceMetadata, String database, String user);
+
+    static CloudSqlDataPlane noop() {
+        return new CloudSqlDataPlane() {
+            @Override
+            public Map<String, Object> startInstance(String project, String instance, Map<String, Object> metadata) {
+                return metadata;
+            }
+
+            @Override
+            public Map<String, Object> ensureInstance(String project, String instance, Map<String, Object> metadata) {
+                return metadata;
+            }
+
+            @Override
+            public void stopInstance(String project, String instance, Map<String, Object> metadata,
+                                     boolean removeStorage) {
+            }
+
+            @Override
+            public void createDatabase(Map<String, Object> instanceMetadata, String database) {
+            }
+
+            @Override
+            public void deleteDatabase(Map<String, Object> instanceMetadata, String database) {
+            }
+
+            @Override
+            public void createOrUpdateUser(Map<String, Object> instanceMetadata, String user, String password) {
+            }
+
+            @Override
+            public void deleteUser(Map<String, Object> instanceMetadata, String user, Iterable<String> databases) {
+            }
+
+            @Override
+            public void grantDatabaseAccess(Map<String, Object> instanceMetadata, String database, String user) {
+            }
+        };
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
@@ -1,0 +1,363 @@
+package io.floci.gcp.services.cloudsql;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.docker.ContainerBuilder;
+import io.floci.gcp.core.common.docker.ContainerDetector;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.EndpointInfo;
+import io.floci.gcp.core.common.docker.ContainerSpec;
+import io.floci.gcp.core.common.docker.ContainerStorageHelper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
+
+    private static final Logger LOG = Logger.getLogger(CloudSqlPostgresDataPlane.class);
+    private static final int POSTGRES_PORT = 5432;
+    private static final String ADMIN_USER = "postgres";
+    private static final String ADMIN_PASSWORD = "postgres";
+    private static final String POSTGRES_DATA_PARENT = "/var/lib/postgresql";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final ContainerDetector containerDetector;
+    private final EmulatorConfig config;
+
+    @Inject
+    public CloudSqlPostgresDataPlane(ContainerBuilder containerBuilder,
+                                     ContainerLifecycleManager lifecycleManager,
+                                     ContainerDetector containerDetector,
+                                     EmulatorConfig config) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.containerDetector = containerDetector;
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, Object> startInstance(String project, String instance, Map<String, Object> metadata) {
+        Map<String, Object> updated = copy(metadata);
+        String image = imageFor(stringValue(updated.get("databaseVersion")));
+        boolean newVolume = stringValue(dataPlane(updated).get("volumeId")) == null;
+        String volumeId = volumeId(updated, project, instance);
+        String containerName = containerName(project, instance);
+        String fallbackId = fallbackId(project, instance);
+
+        LOG.infov("Starting Cloud SQL PostgreSQL instance {0}:{1} using image {2}", project, instance, image);
+        lifecycleManager.removeIfExists(containerName);
+
+        ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
+                .withName(containerName)
+                .withEnv("POSTGRES_USER", ADMIN_USER)
+                .withEnv("POSTGRES_PASSWORD", ADMIN_PASSWORD)
+                .withEnv("POSTGRES_DB", "postgres")
+                .withLogRotation()
+                .withDockerNetwork(config.services().dockerNetwork());
+
+        if (!containerDetector.isRunningInContainer()) {
+            specBuilder.withDynamicPort(POSTGRES_PORT);
+        } else {
+            specBuilder.withExposedPort(POSTGRES_PORT);
+        }
+
+        if (ContainerStorageHelper.isNamedVolumeMode(config)) {
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+                    "cloudsql", volumeId, fallbackId, POSTGRES_DATA_PARENT);
+        } else {
+            String hostDataPath = Path.of(config.storage().hostPersistentPath(), "cloudsql",
+                    sanitize(project), sanitize(instance)).toAbsolutePath().toString();
+            ContainerStorageHelper.ensureHostDir(hostDataPath);
+            specBuilder.withBind(hostDataPath, POSTGRES_DATA_PARENT);
+        }
+
+        ContainerSpec spec = specBuilder.build();
+        String containerId = null;
+        try {
+            containerId = lifecycleManager.create(spec);
+            ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+            EndpointInfo endpoint = info.getEndpoint(POSTGRES_PORT);
+            awaitReady(endpoint, Duration.ofSeconds(config.services().cloudsql().startupTimeoutSeconds()));
+            applyEndpoint(updated, image, volumeId, info.containerId(), endpoint);
+            return updated;
+        } catch (RuntimeException e) {
+            if (containerId != null) {
+                lifecycleManager.stopAndRemove(containerId, null);
+            }
+            if (newVolume && ContainerStorageHelper.isNamedVolumeMode(config)) {
+                lifecycleManager.removeVolume(ContainerStorageHelper.resourceName("cloudsql", volumeId, fallbackId));
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public Map<String, Object> ensureInstance(String project, String instance, Map<String, Object> metadata) {
+        Map<String, Object> dataPlane = dataPlane(metadata);
+        String containerId = stringValue(dataPlane.get("containerId"));
+        if (containerId != null && lifecycleManager.isContainerRunning(containerId)) {
+            EndpointInfo endpoint = lifecycleManager.resolveEndpoint(containerId, POSTGRES_PORT);
+            Map<String, Object> updated = copy(metadata);
+            applyEndpoint(updated, stringValue(dataPlane.get("image")),
+                    volumeId(updated, project, instance), containerId, endpoint);
+            return updated;
+        }
+        return startInstance(project, instance, metadata);
+    }
+
+    @Override
+    public void stopInstance(String project, String instance, Map<String, Object> metadata, boolean removeStorage) {
+        String containerId = stringValue(dataPlane(metadata).get("containerId"));
+        if (containerId != null) {
+            lifecycleManager.stopAndRemove(containerId, null);
+        } else {
+            lifecycleManager.removeIfExists(containerName(project, instance));
+        }
+        if (removeStorage) {
+            String volumeId = stringValue(dataPlane(metadata).get("volumeId"));
+            ContainerStorageHelper.removeStorage(config, lifecycleManager,
+                    "cloudsql", volumeId, fallbackId(project, instance));
+        }
+    }
+
+    @Override
+    public void createDatabase(Map<String, Object> instanceMetadata, String database) {
+        if ("postgres".equals(database)) {
+            return;
+        }
+        try (Connection connection = connect(instanceMetadata, "postgres")) {
+            if (databaseExists(connection, database)) {
+                return;
+            }
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE DATABASE " + quoteIdentifier(database));
+            }
+        } catch (SQLException e) {
+            throw GcpException.unavailable("Could not create PostgreSQL database " + database + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteDatabase(Map<String, Object> instanceMetadata, String database) {
+        if ("postgres".equals(database)) {
+            return;
+        }
+        try (Connection connection = connect(instanceMetadata, "postgres");
+             Statement statement = connection.createStatement()) {
+            statement.execute("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    + "WHERE datname = " + quoteLiteral(database) + " AND pid <> pg_backend_pid()");
+            statement.execute("DROP DATABASE IF EXISTS " + quoteIdentifier(database));
+        } catch (SQLException e) {
+            throw GcpException.unavailable("Could not delete PostgreSQL database " + database + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void createOrUpdateUser(Map<String, Object> instanceMetadata, String user, String password) {
+        try (Connection connection = connect(instanceMetadata, "postgres");
+             Statement statement = connection.createStatement()) {
+            String secret = password == null || password.isBlank() ? ADMIN_PASSWORD : password;
+            if (roleExists(connection, user)) {
+                statement.execute("ALTER ROLE " + quoteIdentifier(user)
+                        + " WITH LOGIN PASSWORD " + quoteLiteral(secret));
+            } else {
+                statement.execute("CREATE ROLE " + quoteIdentifier(user)
+                        + " WITH LOGIN PASSWORD " + quoteLiteral(secret));
+            }
+        } catch (SQLException e) {
+            throw GcpException.unavailable("Could not create PostgreSQL user " + user + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteUser(Map<String, Object> instanceMetadata, String user, Iterable<String> databases) {
+        try {
+            for (String database : databases) {
+                try (Connection connection = connect(instanceMetadata, database);
+                     Statement statement = connection.createStatement()) {
+                    statement.execute("DROP OWNED BY " + quoteIdentifier(user));
+                } catch (SQLException e) {
+                    LOG.debugv("Could not drop objects owned by {0} in database {1}: {2}",
+                            user, database, e.getMessage());
+                }
+            }
+            try (Connection connection = connect(instanceMetadata, "postgres");
+                 Statement statement = connection.createStatement()) {
+                statement.execute("DROP ROLE IF EXISTS " + quoteIdentifier(user));
+            }
+        } catch (SQLException e) {
+            throw GcpException.unavailable("Could not delete PostgreSQL user " + user + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void grantDatabaseAccess(Map<String, Object> instanceMetadata, String database, String user) {
+        try (Connection postgres = connect(instanceMetadata, "postgres");
+             Statement statement = postgres.createStatement()) {
+            statement.execute("GRANT CONNECT, CREATE ON DATABASE " + quoteIdentifier(database)
+                    + " TO " + quoteIdentifier(user));
+        } catch (SQLException e) {
+            throw GcpException.unavailable("Could not grant PostgreSQL database access: " + e.getMessage());
+        }
+
+        try (Connection databaseConnection = connect(instanceMetadata, database);
+             Statement statement = databaseConnection.createStatement()) {
+            statement.execute("GRANT USAGE, CREATE ON SCHEMA public TO " + quoteIdentifier(user));
+        } catch (SQLException e) {
+            throw GcpException.unavailable("Could not grant PostgreSQL schema access: " + e.getMessage());
+        }
+    }
+
+    private void awaitReady(EndpointInfo endpoint, Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        SQLException last = null;
+        while (System.nanoTime() < deadline) {
+            try (Connection ignored = connect(endpoint, "postgres")) {
+                return;
+            } catch (SQLException e) {
+                last = e;
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw GcpException.unavailable("Interrupted while waiting for PostgreSQL startup");
+                }
+            }
+        }
+        String message = last == null ? "unknown error" : last.getMessage();
+        throw GcpException.unavailable("PostgreSQL data plane did not become ready: " + message);
+    }
+
+    private Connection connect(Map<String, Object> instanceMetadata, String database) throws SQLException {
+        Map<String, Object> dataPlane = dataPlane(instanceMetadata);
+        String host = stringValue(dataPlane.get("host"));
+        Object port = dataPlane.get("port");
+        if (host == null || port == null) {
+            throw GcpException.failedPrecondition("Cloud SQL instance has no running PostgreSQL endpoint");
+        }
+        return connect(new EndpointInfo(host, Integer.parseInt(port.toString())), database);
+    }
+
+    private Connection connect(EndpointInfo endpoint, String database) throws SQLException {
+        return DriverManager.getConnection(jdbcUrl(endpoint, database), ADMIN_USER, ADMIN_PASSWORD);
+    }
+
+    private String jdbcUrl(EndpointInfo endpoint, String database) {
+        return "jdbc:postgresql://" + endpoint.host() + ":" + endpoint.port() + "/" + database;
+    }
+
+    private boolean databaseExists(Connection connection, String database) throws SQLException {
+        try (var statement = connection.prepareStatement("SELECT 1 FROM pg_database WHERE datname = ?")) {
+            statement.setString(1, database);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        }
+    }
+
+    private boolean roleExists(Connection connection, String user) throws SQLException {
+        try (var statement = connection.prepareStatement("SELECT 1 FROM pg_roles WHERE rolname = ?")) {
+            statement.setString(1, user);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        }
+    }
+
+    private void applyEndpoint(Map<String, Object> metadata, String image, String volumeId,
+                               String containerId, EndpointInfo endpoint) {
+        metadata.put("ipAddresses", List.of(mapOf(
+                "type", "PRIMARY",
+                "ipAddress", endpoint.host(),
+                "port", endpoint.port())));
+        metadata.put("flociDataPlane", mapOf(
+                "engine", "postgres",
+                "image", image,
+                "containerId", containerId,
+                "host", endpoint.host(),
+                "port", endpoint.port(),
+                "volumeId", volumeId,
+                "status", "RUNNING"));
+    }
+
+    private String imageFor(String databaseVersion) {
+        return switch (databaseVersion) {
+            case "POSTGRES_15" -> config.services().cloudsql().postgres15Image();
+            case "POSTGRES_16" -> config.services().cloudsql().postgres16Image();
+            case "POSTGRES_17" -> config.services().cloudsql().postgres17Image();
+            case "POSTGRES_18" -> config.services().cloudsql().postgres18Image();
+            default -> throw GcpException.invalidArgument("Unsupported PostgreSQL databaseVersion: " + databaseVersion);
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> dataPlane(Map<String, Object> metadata) {
+        Object value = metadata.get("flociDataPlane");
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return Map.of();
+    }
+
+    private String volumeId(Map<String, Object> metadata, String project, String instance) {
+        String existing = stringValue(dataPlane(metadata).get("volumeId"));
+        if (existing != null && !existing.isBlank()) {
+            return existing;
+        }
+        return sanitize(project + "-" + instance) + "-" + String.format("%06x", RANDOM.nextInt(0xFFFFFF));
+    }
+
+    private String containerName(String project, String instance) {
+        return "floci-cloudsql-" + fallbackId(project, instance);
+    }
+
+    private String fallbackId(String project, String instance) {
+        return sanitize(project + "-" + instance);
+    }
+
+    private static String quoteIdentifier(String value) {
+        return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+
+    private static String quoteLiteral(String value) {
+        return "'" + value.replace("'", "''") + "'";
+    }
+
+    private static String sanitize(String value) {
+        String sanitized = value.toLowerCase().replaceAll("[^a-z0-9_.-]", "-");
+        sanitized = sanitized.replaceAll("^-+", "").replaceAll("-+$", "");
+        return sanitized.isBlank() ? "default" : sanitized;
+    }
+
+    private static Map<String, Object> copy(Map<String, Object> value) {
+        return new LinkedHashMap<>(value);
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private static Map<String, Object> mapOf(Object... entries) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        for (int i = 0; i < entries.length; i += 2) {
+            map.put((String) entries[i], entries[i + 1]);
+        }
+        return map;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlService.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlService.java
@@ -8,9 +8,11 @@ import io.floci.gcp.core.common.PageToken;
 import io.floci.gcp.core.common.ServiceDescriptor;
 import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.ProjectAwareStorageBackend;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.quarkus.runtime.StartupEvent;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -38,12 +40,15 @@ public class CloudSqlService {
     private final EmulatorConfig config;
     private final ObjectMapper objectMapper;
     private final String baseUrl;
+    private final CloudSqlDataPlane dataPlane;
+    private final boolean dataPlaneEnabled;
 
     @Inject
     public CloudSqlService(StorageFactory storageFactory,
                            ServiceRegistry serviceRegistry,
                            EmulatorConfig config,
-                           ObjectMapper objectMapper) {
+                           ObjectMapper objectMapper,
+                           CloudSqlPostgresDataPlane dataPlane) {
         this.instanceStore = storageFactory.create("cloudsql", "cloudsql-instances.json",
                 new TypeReference<Map<String, Map<String, Object>>>() {});
         this.databaseStore = storageFactory.create("cloudsql", "cloudsql-databases.json",
@@ -56,6 +61,8 @@ public class CloudSqlService {
         this.config = config;
         this.objectMapper = objectMapper;
         this.baseUrl = config.effectiveBaseUrl();
+        this.dataPlane = dataPlane;
+        this.dataPlaneEnabled = config.services().cloudsql().dataPlaneEnabled();
     }
 
     CloudSqlService(StorageBackend<String, Map<String, Object>> instanceStore,
@@ -64,6 +71,18 @@ public class CloudSqlService {
                     StorageBackend<String, Map<String, Object>> operationStore,
                     ObjectMapper objectMapper,
                     String baseUrl) {
+        this(instanceStore, databaseStore, userStore, operationStore, objectMapper, baseUrl,
+                CloudSqlDataPlane.noop(), false);
+    }
+
+    CloudSqlService(StorageBackend<String, Map<String, Object>> instanceStore,
+                    StorageBackend<String, Map<String, Object>> databaseStore,
+                    StorageBackend<String, Map<String, Object>> userStore,
+                    StorageBackend<String, Map<String, Object>> operationStore,
+                    ObjectMapper objectMapper,
+                    String baseUrl,
+                    CloudSqlDataPlane dataPlane,
+                    boolean dataPlaneEnabled) {
         this.instanceStore = instanceStore;
         this.databaseStore = databaseStore;
         this.userStore = userStore;
@@ -72,6 +91,8 @@ public class CloudSqlService {
         this.config = null;
         this.objectMapper = objectMapper;
         this.baseUrl = baseUrl;
+        this.dataPlane = dataPlane;
+        this.dataPlaneEnabled = dataPlaneEnabled;
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -83,6 +104,23 @@ public class CloudSqlService {
                         CloudSqlLegacyController.class, CloudSqlGlobalController.class,
                         CloudSqlV1Beta4GlobalController.class, CloudSqlLegacyGlobalController.class)
                 .build());
+        if (config.services().cloudsql().enabled() && dataPlaneEnabled) {
+            restartPersistedInstances();
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (!dataPlaneEnabled) {
+            return;
+        }
+        for (Map<String, Object> instance : allInstances()) {
+            String project = stringValue(instance.get("project"));
+            String name = stringValue(instance.get("name"));
+            if (project != null && name != null) {
+                dataPlane.stopInstance(project, name, instance, false);
+            }
+        }
     }
 
     public Map<String, Object> createInstance(String project, Map<String, Object> body) {
@@ -100,7 +138,10 @@ public class CloudSqlService {
         }
 
         Map<String, Object> stored = normalizeInstance(project, instance, request);
-        instanceStore.put(instanceKey(instance), stored);
+        if (dataPlaneEnabled) {
+            stored = dataPlane.startInstance(project, instance, stored);
+        }
+        putInstance(project, instance, stored);
         createDefaultDatabase(project, instance);
 
         LOG.infof("create Cloud SQL PostgreSQL instance project=%s instance=%s", project, instance);
@@ -154,6 +195,9 @@ public class CloudSqlService {
 
     public Map<String, Object> deleteInstance(String project, String instance) {
         Map<String, Object> existing = getInstance(project, instance);
+        if (dataPlaneEnabled) {
+            dataPlane.stopInstance(project, instance, existing, true);
+        }
         instanceStore.delete(instanceKey(instance));
         deleteByPrefix(databaseStore, databasePrefix(instance));
         deleteByPrefix(userStore, userPrefix(instance));
@@ -174,10 +218,12 @@ public class CloudSqlService {
         return mapOf(
                 "kind", "sql#flagsList",
                 "items", List.of(
-                        flag("max_connections", "INTEGER", true, "POSTGRES_15", "POSTGRES_16", "POSTGRES_17"),
-                        flag("cloudsql.iam_authentication", "BOOLEAN", true, "POSTGRES_15", "POSTGRES_16", "POSTGRES_17"),
+                        flag("max_connections", "INTEGER", true,
+                                "POSTGRES_15", "POSTGRES_16", "POSTGRES_17", "POSTGRES_18"),
+                        flag("cloudsql.iam_authentication", "BOOLEAN", true,
+                                "POSTGRES_15", "POSTGRES_16", "POSTGRES_17", "POSTGRES_18"),
                         flag("log_min_duration_statement", "INTEGER", false,
-                                "POSTGRES_15", "POSTGRES_16", "POSTGRES_17")));
+                                "POSTGRES_15", "POSTGRES_16", "POSTGRES_17", "POSTGRES_18")));
     }
 
     public Map<String, Object> getConnectSettings(String project, String instance) {
@@ -215,7 +261,7 @@ public class CloudSqlService {
     }
 
     public Map<String, Object> createDatabase(String project, String instance, Map<String, Object> body) {
-        getInstance(project, instance);
+        Map<String, Object> instanceMetadata = getInstance(project, instance);
         Map<String, Object> request = copy(body);
         String database = stringValue(request.get("name"));
         if (database == null || database.isBlank()) {
@@ -226,6 +272,12 @@ public class CloudSqlService {
             throw GcpException.alreadyExists("Cloud SQL database already exists: " + database);
         }
         Map<String, Object> stored = normalizeDatabase(project, instance, database, request);
+        if (dataPlaneEnabled) {
+            dataPlane.createDatabase(instanceMetadata, database);
+            for (String user : userNames(instance)) {
+                dataPlane.grantDatabaseAccess(instanceMetadata, database, user);
+            }
+        }
         databaseStore.put(key, stored);
         LOG.infof("create Cloud SQL PostgreSQL database project=%s instance=%s database=%s",
                 project, instance, database);
@@ -268,7 +320,14 @@ public class CloudSqlService {
     }
 
     public Map<String, Object> deleteDatabase(String project, String instance, String database) {
+        Map<String, Object> instanceMetadata = getInstance(project, instance);
+        if ("postgres".equals(database)) {
+            throw GcpException.failedPrecondition("Default PostgreSQL database cannot be deleted: postgres");
+        }
         Map<String, Object> existing = getDatabase(project, instance, database);
+        if (dataPlaneEnabled) {
+            dataPlane.deleteDatabase(instanceMetadata, database);
+        }
         databaseStore.delete(databaseKey(instance, database));
         LOG.infof("delete Cloud SQL PostgreSQL database project=%s instance=%s database=%s",
                 project, instance, database);
@@ -276,16 +335,23 @@ public class CloudSqlService {
     }
 
     public Map<String, Object> createUser(String project, String instance, Map<String, Object> body) {
-        getInstance(project, instance);
+        Map<String, Object> instanceMetadata = getInstance(project, instance);
         Map<String, Object> request = copy(body);
         String user = stringValue(request.get("name"));
         if (user == null || user.isBlank()) {
             throw GcpException.invalidArgument("User name is required");
         }
         String host = stringValue(request.get("host"));
+        validatePostgresHost(host);
         String key = userKey(instance, user, host);
         if (userStore.get(key).isPresent()) {
             throw GcpException.alreadyExists("Cloud SQL user already exists: " + user);
+        }
+        if (dataPlaneEnabled) {
+            dataPlane.createOrUpdateUser(instanceMetadata, user, stringValue(request.get("password")));
+            for (String database : databaseNames(instance)) {
+                dataPlane.grantDatabaseAccess(instanceMetadata, database, user);
+            }
         }
         Map<String, Object> stored = normalizeUser(project, instance, user, host, request);
         userStore.put(key, stored);
@@ -307,6 +373,7 @@ public class CloudSqlService {
     public Map<String, Object> getUser(String project, String instance, String user, String host) {
         getInstance(project, instance);
         validateUserName(user);
+        validatePostgresHost(host);
         return userStore.get(userKey(instance, user, host))
                 .map(this::copy)
                 .orElseThrow(() -> GcpException.notFound("Cloud SQL user not found: " + user));
@@ -316,6 +383,13 @@ public class CloudSqlService {
                                           String host, Map<String, Object> body) {
         Map<String, Object> existing = getUser(project, instance, user, host);
         Map<String, Object> update = copy(body);
+        if (dataPlaneEnabled && update.containsKey("password")) {
+            Map<String, Object> instanceMetadata = getInstance(project, instance);
+            dataPlane.createOrUpdateUser(instanceMetadata, user, stringValue(update.get("password")));
+            for (String database : databaseNames(instance)) {
+                dataPlane.grantDatabaseAccess(instanceMetadata, database, user);
+            }
+        }
         merge(existing, update);
         Map<String, Object> stored = normalizeUser(project, instance, user, host, existing);
         userStore.put(userKey(instance, user, host), stored);
@@ -325,11 +399,15 @@ public class CloudSqlService {
     }
 
     public Map<String, Object> deleteUser(String project, String instance, String user, String host) {
-        getInstance(project, instance);
+        Map<String, Object> instanceMetadata = getInstance(project, instance);
         validateUserName(user);
+        validatePostgresHost(host);
         String key = userKey(instance, user, host);
         Map<String, Object> existing = userStore.get(key)
                 .orElseThrow(() -> GcpException.notFound("Cloud SQL user not found: " + user));
+        if (dataPlaneEnabled) {
+            dataPlane.deleteUser(instanceMetadata, user, databaseNames(instance));
+        }
         userStore.delete(key);
         LOG.infof("delete Cloud SQL PostgreSQL user project=%s instance=%s user=%s", project, instance, user);
         return createOperation(project, "DELETE_USER", instance, existing);
@@ -352,6 +430,45 @@ public class CloudSqlService {
         stored.put("connectionName", connectionName(project, stored, instance));
         stored.put("selfLink", instanceSelfLink(project, instance));
         return stored;
+    }
+
+    private void restartPersistedInstances() {
+        for (Map<String, Object> instance : allInstances()) {
+            String project = stringValue(instance.get("project"));
+            String name = stringValue(instance.get("name"));
+            if (project == null || name == null) {
+                continue;
+            }
+            try {
+                Map<String, Object> updated = dataPlane.ensureInstance(project, name, instance);
+                putInstance(project, name, updated);
+            } catch (GcpException e) {
+                LOG.warnf("Cloud SQL PostgreSQL data plane was not restored project=%s instance=%s: %s",
+                        project, name, e.getMessage());
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> allInstances() {
+        if (instanceStore instanceof ProjectAwareStorageBackend<?> projectAware) {
+            return projectAware.scanAllProjects(k -> k.startsWith("instances/")).stream()
+                    .map(v -> copy((Map<String, Object>) v))
+                    .toList();
+        }
+        return instanceStore.scan(k -> k.startsWith("instances/")).stream()
+                .map(this::copy)
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void putInstance(String project, String instance, Map<String, Object> stored) {
+        if (instanceStore instanceof ProjectAwareStorageBackend<?> projectAware) {
+            ((ProjectAwareStorageBackend<Map<String, Object>>) projectAware)
+                    .putForProject(project, instanceKey(instance), stored);
+            return;
+        }
+        instanceStore.put(instanceKey(instance), stored);
     }
 
     private void createDefaultDatabase(String project, String instance) {
@@ -388,6 +505,20 @@ public class CloudSqlService {
         }
         putDefault(stored, "type", "BUILT_IN");
         return stored;
+    }
+
+    private List<String> databaseNames(String instance) {
+        return databaseStore.scan(k -> k.startsWith(databasePrefix(instance))).stream()
+                .map(database -> stringValue(database.get("name")))
+                .filter(name -> name != null && !name.isBlank())
+                .toList();
+    }
+
+    private List<String> userNames(String instance) {
+        return userStore.scan(k -> k.startsWith(userPrefix(instance))).stream()
+                .map(user -> stringValue(user.get("name")))
+                .filter(name -> name != null && !name.isBlank())
+                .toList();
     }
 
     private Map<String, Object> createOperation(String project, String operationType,
@@ -503,6 +634,12 @@ public class CloudSqlService {
     private void validateUserName(String user) {
         if (user == null || user.isBlank()) {
             throw GcpException.invalidArgument("User name is required");
+        }
+    }
+
+    private void validatePostgresHost(String host) {
+        if (host != null && !host.isBlank()) {
+            throw GcpException.invalidArgument("PostgreSQL Cloud SQL users do not support host-qualified identities");
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,12 @@ floci-gcp:
       default-image: "redpandadata/redpanda:latest"
     cloudsql:
       enabled: true
+      data-plane-enabled: true
+      postgres15-image: "postgres:15.18-alpine"
+      postgres16-image: "postgres:16.14-alpine"
+      postgres17-image: "postgres:17.10-alpine"
+      postgres18-image: "postgres:18.4-alpine"
+      startup-timeout-seconds: 90
     cloudtasks:
       enabled: true
     cloudrun:

--- a/src/test/java/io/floci/gcp/core/storage/ProjectAwareStorageBackendTest.java
+++ b/src/test/java/io/floci/gcp/core/storage/ProjectAwareStorageBackendTest.java
@@ -180,4 +180,23 @@ class ProjectAwareStorageBackendTest {
         Map<String, String> all = backend.scanAllProjectsAsMap();
         assertTrue(all.isEmpty());
     }
+
+    @Test
+    void scanAllProjectsPreservesValuesWithSameLogicalKeyAcrossProjects() {
+        delegate.put("proj-a/instances/pg-main", "a");
+        delegate.put("proj-b/instances/pg-main", "b");
+        delegate.put("proj-b/topics/t1", "topic");
+
+        List<String> all = backend.scanAllProjects(k -> k.startsWith("instances/"));
+
+        assertEquals(2, all.size());
+        assertTrue(all.containsAll(List.of("a", "b")));
+    }
+
+    @Test
+    void scanAllProjectsSkipsKeysWithoutSlash() {
+        delegate.put("badkey", "v");
+
+        assertTrue(backend.scanAllProjects(k -> true).isEmpty());
+    }
 }

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlDataPlaneIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlDataPlaneIntegrationTest.java
@@ -1,0 +1,144 @@
+package io.floci.gcp.services.cloudsql;
+
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.sql.DriverManager;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@QuarkusTest
+@TestProfile(CloudSqlDataPlaneIntegrationTest.DataPlaneProfile.class)
+class CloudSqlDataPlaneIntegrationTest {
+
+    private static final RestAssuredConfig DATA_PLANE_TIMEOUT = RestAssuredConfig.config()
+            .httpClient(HttpClientConfig.httpClientConfig()
+                    .setParam("http.connection.timeout", 300_000)
+                    .setParam("http.socket.timeout", 300_000));
+
+    @Test
+    void cloudSqlInstancesReturnUsablePostgresEndpointsForLatestPostgresVersions() throws Exception {
+        for (String databaseVersion : List.of("POSTGRES_16", "POSTGRES_17", "POSTGRES_18")) {
+            cloudSqlInstanceReturnsUsablePostgresEndpoint(databaseVersion);
+        }
+    }
+
+    private void cloudSqlInstanceReturnsUsablePostgresEndpoint(String databaseVersion) throws Exception {
+        assumeTrue(dockerAvailable(), "Docker is required for Cloud SQL PostgreSQL data-plane tests");
+
+        String majorVersion = databaseVersion.substring("POSTGRES_".length());
+        String project = "sql-dataplane-" + majorVersion;
+        String instance = "pg-dataplane-" + majorVersion;
+        String database = "appdb";
+        String user = "app";
+        String password = "secret";
+        String base = "/v1/projects/" + project + "/instances/" + instance;
+
+        try {
+            given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .contentType("application/json")
+                    .body("""
+                            {
+                              "name": "%s",
+                              "databaseVersion": "%s",
+                              "region": "us-central1",
+                              "settings": {"tier": "db-custom-1-3840"}
+                            }
+                            """.formatted(instance, databaseVersion))
+                    .when().post("/v1/projects/" + project + "/instances")
+                    .then()
+                    .statusCode(200)
+                    .body("kind", equalTo("sql#operation"))
+                    .body("status", equalTo("DONE"));
+
+            given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .when().get(base)
+                    .then()
+                    .statusCode(200)
+                    .body("databaseVersion", equalTo(databaseVersion));
+
+            given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .contentType("application/json")
+                    .body("{\"name\":\"" + database + "\"}")
+                    .when().post(base + "/databases")
+                    .then()
+                    .statusCode(200)
+                    .body("operationType", equalTo("CREATE_DATABASE"));
+
+            given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .contentType("application/json")
+                    .body("{\"name\":\"" + user + "\",\"password\":\"" + password + "\"}")
+                    .when().post(base + "/users")
+                    .then()
+                    .statusCode(200)
+                    .body("operationType", equalTo("CREATE_USER"));
+
+            String host = given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .when().get(base + "/connectSettings")
+                    .then()
+                    .statusCode(200)
+                    .body("ipAddresses[0].type", equalTo("PRIMARY"))
+                    .extract().path("ipAddresses[0].ipAddress");
+            Integer port = given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .when().get(base + "/connectSettings")
+                    .then()
+                    .statusCode(200)
+                    .extract().path("ipAddresses[0].port");
+
+            try (var connection = DriverManager.getConnection(
+                    "jdbc:postgresql://" + host + ":" + port + "/" + database, user, password);
+                 var statement = connection.createStatement()) {
+                try (var result = statement.executeQuery("SHOW server_version")) {
+                    assertTrue(result.next(), "expected server version row");
+                    assertTrue(result.getString(1).startsWith(majorVersion + "."));
+                }
+                statement.execute("CREATE TABLE phase2_probe (id INT PRIMARY KEY, note TEXT)");
+                statement.execute("INSERT INTO phase2_probe (id, note) VALUES (1, 'ready')");
+                try (var result = statement.executeQuery("SELECT note FROM phase2_probe WHERE id = 1")) {
+                    assertTrue(result.next(), "expected inserted row");
+                    assertEquals("ready", result.getString(1));
+                }
+            }
+        } finally {
+            given()
+                    .config(DATA_PLANE_TIMEOUT)
+                    .when().delete(base)
+                    .then()
+                    .statusCode(org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(404)));
+        }
+    }
+
+    private static boolean dockerAvailable() {
+        try {
+            Process process = new ProcessBuilder("docker", "info")
+                    .redirectErrorStream(true)
+                    .start();
+            return process.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public static class DataPlaneProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.cloudsql.data-plane-enabled", "true");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlaneTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlaneTest.java
@@ -1,0 +1,88 @@
+package io.floci.gcp.services.cloudsql;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.docker.ContainerBuilder;
+import io.floci.gcp.core.common.docker.ContainerDetector;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.EndpointInfo;
+import io.floci.gcp.core.common.docker.ContainerSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloudSqlPostgresDataPlaneTest {
+
+    @Mock
+    ContainerBuilder containerBuilder;
+
+    @Mock
+    ContainerBuilder.Builder specBuilder;
+
+    @Mock
+    ContainerLifecycleManager lifecycleManager;
+
+    @Mock
+    ContainerDetector containerDetector;
+
+    @Mock
+    EmulatorConfig config;
+
+    @Mock
+    EmulatorConfig.StorageConfig storageConfig;
+
+    @Mock
+    EmulatorConfig.ServicesConfig servicesConfig;
+
+    @Mock
+    EmulatorConfig.CloudSqlServiceConfig cloudSqlConfig;
+
+    @Test
+    void startInstanceCleansUpCreatedContainerAndNewVolumeWhenStartupFails() {
+        ContainerSpec spec = new ContainerSpec("postgres:18.4-alpine");
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.hostPersistentPath()).thenReturn("./data");
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.cloudsql()).thenReturn(cloudSqlConfig);
+        when(servicesConfig.dockerNetwork()).thenReturn(Optional.empty());
+        when(cloudSqlConfig.postgres18Image()).thenReturn("postgres:18.4-alpine");
+        when(cloudSqlConfig.startupTimeoutSeconds()).thenReturn(0);
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(containerBuilder.newContainer("postgres:18.4-alpine")).thenReturn(specBuilder);
+        when(specBuilder.withName("floci-cloudsql-project-a-pg-main")).thenReturn(specBuilder);
+        when(specBuilder.withEnv(any(), any())).thenReturn(specBuilder);
+        when(specBuilder.withLogRotation()).thenReturn(specBuilder);
+        when(specBuilder.withDockerNetwork(Optional.empty())).thenReturn(specBuilder);
+        when(specBuilder.withDynamicPort(5432)).thenReturn(specBuilder);
+        when(specBuilder.withNamedVolume(argThat(name -> name.startsWith("floci-gcp-cloudsql-project-a-pg-main-")),
+                eq("/var/lib/postgresql"))).thenReturn(specBuilder);
+        when(specBuilder.build()).thenReturn(spec);
+        when(lifecycleManager.create(spec)).thenReturn("container-1");
+        when(lifecycleManager.startCreated("container-1", spec)).thenReturn(new ContainerInfo(
+                "container-1",
+                Map.of(5432, new EndpointInfo("localhost", 15432))));
+
+        CloudSqlPostgresDataPlane dataPlane = new CloudSqlPostgresDataPlane(
+                containerBuilder, lifecycleManager, containerDetector, config);
+
+        assertThrows(GcpException.class, () -> dataPlane.startInstance(
+                "project-a", "pg-main", Map.of("name", "pg-main", "databaseVersion", "POSTGRES_18")));
+
+        verify(lifecycleManager).stopAndRemove("container-1", null);
+        verify(lifecycleManager).removeVolume(argThat(name -> name.startsWith(
+                "floci-gcp-cloudsql-project-a-pg-main-")));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlRestIntegrationTest.java
@@ -22,7 +22,7 @@ class CloudSqlRestIntegrationTest {
                 .body("""
                         {
                           "name": "pg-main",
-                          "databaseVersion": "POSTGRES_15",
+                          "databaseVersion": "POSTGRES_18",
                           "region": "us-central1",
                           "settings": {"tier": "db-custom-1-3840"}
                         }
@@ -51,7 +51,7 @@ class CloudSqlRestIntegrationTest {
                 .statusCode(200)
                 .body("kind", equalTo("sql#instance"))
                 .body("name", equalTo(instance))
-                .body("databaseVersion", equalTo("POSTGRES_15"))
+                .body("databaseVersion", equalTo("POSTGRES_18"))
                 .body("state", equalTo("RUNNABLE"))
                 .body("connectionName", equalTo(project + ":us-central1:" + instance))
                 .body("settings.tier", equalTo("db-custom-1-3840"));
@@ -91,6 +91,12 @@ class CloudSqlRestIntegrationTest {
                 .statusCode(200)
                 .body("kind", equalTo("sql#databasesList"))
                 .body("items.name", hasItem("postgres"));
+
+        given()
+                .when().delete(base + "/instances/" + instance + "/databases/postgres")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("FAILED_PRECONDITION"));
 
         given()
                 .contentType("application/json")
@@ -136,6 +142,14 @@ class CloudSqlRestIntegrationTest {
                 .statusCode(200)
                 .body("kind", equalTo("sql#operation"))
                 .body("operationType", equalTo("CREATE_USER"));
+
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"hosted\",\"host\":\"%\",\"password\":\"secret\"}")
+                .when().post(base + "/instances/" + instance + "/users")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
 
         given()
                 .when().get(base + "/instances/" + instance + "/users")
@@ -249,7 +263,7 @@ class CloudSqlRestIntegrationTest {
     void cloudSqlScopesInstancesByProject() {
         given()
                 .contentType("application/json")
-                .body("{\"name\":\"pg-shared\",\"databaseVersion\":\"POSTGRES_15\"}")
+                .body("{\"name\":\"pg-shared\",\"databaseVersion\":\"POSTGRES_18\"}")
                 .when().post("/v1/projects/sql-project-a/instances")
                 .then()
                 .statusCode(200);
@@ -266,7 +280,7 @@ class CloudSqlRestIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("project", equalTo("sql-project-a"))
-                .body("databaseVersion", equalTo("POSTGRES_15"));
+                .body("databaseVersion", equalTo("POSTGRES_18"));
 
         given()
                 .when().get("/v1/projects/sql-project-b/instances/pg-shared")

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlServiceTest.java
@@ -55,7 +55,7 @@ class CloudSqlServiceTest {
         withProject("project-a");
         service.createInstance("project-a", Map.of(
                 "name", "pg-main",
-                "databaseVersion", "POSTGRES_15"));
+                "databaseVersion", "POSTGRES_18"));
 
         withProject("project-b");
         assertThrows(GcpException.class, () -> service.getInstance("project-b", "pg-main"));
@@ -67,7 +67,7 @@ class CloudSqlServiceTest {
         assertEquals("POSTGRES_16", service.getInstance("project-b", "pg-main").get("databaseVersion"));
 
         withProject("project-a");
-        assertEquals("POSTGRES_15", service.getInstance("project-a", "pg-main").get("databaseVersion"));
+        assertEquals("POSTGRES_18", service.getInstance("project-a", "pg-main").get("databaseVersion"));
     }
 
     @Test
@@ -75,7 +75,7 @@ class CloudSqlServiceTest {
         withProject("project-a");
         service.createInstance("project-a", Map.of(
                 "name", "pg-main",
-                "databaseVersion", "POSTGRES_15"));
+                "databaseVersion", "POSTGRES_18"));
         service.createDatabase("project-a", "pg-main", Map.of("name", "appdb"));
         service.createUser("project-a", "pg-main", Map.of("name", "app", "password", "secret"));
 
@@ -91,7 +91,7 @@ class CloudSqlServiceTest {
         withProject("project-a");
         service.createInstance("project-a", Map.of(
                 "name", "pg-main",
-                "databaseVersion", "POSTGRES_15",
+                "databaseVersion", "POSTGRES_18",
                 "settings", Map.of("tier", "db-custom-1-3840")));
         service.createDatabase("project-a", "pg-main", Map.of("name", "appdb"));
 
@@ -121,5 +121,173 @@ class CloudSqlServiceTest {
         Map<String, Object> flags = service.listFlags();
         assertEquals("sql#flagsList", flags.get("kind"));
         assertFalse(((List<?>) flags.get("items")).isEmpty());
+    }
+
+    @Test
+    void dataPlaneReceivesInstanceDatabaseAndUserLifecycleEvents() {
+        withProject("project-a");
+        RecordingDataPlane dataPlane = new RecordingDataPlane();
+        CloudSqlService dataPlaneService = new CloudSqlService(
+                projectAwareStore(),
+                projectAwareStore(),
+                projectAwareStore(),
+                projectAwareStore(),
+                new ObjectMapper(),
+                "http://localhost:4588",
+                dataPlane,
+                true);
+
+        dataPlaneService.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_18"));
+        dataPlaneService.createDatabase("project-a", "pg-main", Map.of("name", "appdb"));
+        dataPlaneService.createUser("project-a", "pg-main", Map.of("name", "app", "password", "secret"));
+        dataPlaneService.updateUser("project-a", "pg-main", "app", null, Map.of("password", "new-secret"));
+        dataPlaneService.deleteUser("project-a", "pg-main", "app", null);
+        dataPlaneService.deleteDatabase("project-a", "pg-main", "appdb");
+        dataPlaneService.deleteInstance("project-a", "pg-main");
+
+        assertEquals(List.of(
+                "start:project-a/pg-main",
+                "create-db:appdb",
+                "create-user:app:secret",
+                "grant:postgres:app",
+                "grant:appdb:app",
+                "create-user:app:new-secret",
+                "grant:postgres:app",
+                "grant:appdb:app",
+                "delete-user:app:postgres,appdb",
+                "delete-db:appdb",
+                "stop:project-a/pg-main:true"), dataPlane.events);
+    }
+
+    @Test
+    void dataPlaneShutdownStopsSameInstanceNameAcrossProjects() {
+        RecordingDataPlane dataPlane = new RecordingDataPlane();
+        CloudSqlService dataPlaneService = new CloudSqlService(
+                projectAwareStore(),
+                projectAwareStore(),
+                projectAwareStore(),
+                projectAwareStore(),
+                new ObjectMapper(),
+                "http://localhost:4588",
+                dataPlane,
+                true);
+
+        withProject("project-a");
+        dataPlaneService.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_18"));
+        withProject("project-b");
+        dataPlaneService.createInstance("project-b", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_18"));
+
+        dataPlane.events.clear();
+        dataPlaneService.shutdown();
+
+        assertEquals(2, dataPlane.events.size());
+        assertTrue(dataPlane.events.containsAll(List.of(
+                "stop:project-a/pg-main:false",
+                "stop:project-b/pg-main:false")));
+    }
+
+    @Test
+    void deleteDefaultPostgresDatabaseIsRejected() {
+        withProject("project-a");
+        service.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_18"));
+
+        GcpException error = assertThrows(GcpException.class,
+                () -> service.deleteDatabase("project-a", "pg-main", "postgres"));
+
+        assertEquals("FAILED_PRECONDITION", error.getGcpStatus());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals("postgres", service.getDatabase("project-a", "pg-main", "postgres").get("name"));
+    }
+
+    @Test
+    void deleteDefaultPostgresDatabaseOnMissingInstanceReturnsNotFound() {
+        withProject("project-a");
+
+        GcpException error = assertThrows(GcpException.class,
+                () -> service.deleteDatabase("project-a", "missing", "postgres"));
+
+        assertEquals("NOT_FOUND", error.getGcpStatus());
+    }
+
+    @Test
+    void hostQualifiedPostgresUsersAreRejected() {
+        withProject("project-a");
+        service.createInstance("project-a", Map.of(
+                "name", "pg-main",
+                "databaseVersion", "POSTGRES_18"));
+
+        GcpException createError = assertThrows(GcpException.class,
+                () -> service.createUser("project-a", "pg-main",
+                        Map.of("name", "app", "host", "%", "password", "secret")));
+        assertEquals("INVALID_ARGUMENT", createError.getGcpStatus());
+
+        service.createUser("project-a", "pg-main", Map.of("name", "app", "password", "secret"));
+
+        GcpException getError = assertThrows(GcpException.class,
+                () -> service.getUser("project-a", "pg-main", "app", "%"));
+        assertEquals("INVALID_ARGUMENT", getError.getGcpStatus());
+
+        GcpException updateError = assertThrows(GcpException.class,
+                () -> service.updateUser("project-a", "pg-main", "app", "%",
+                        Map.of("password", "new-secret")));
+        assertEquals("INVALID_ARGUMENT", updateError.getGcpStatus());
+
+        GcpException deleteError = assertThrows(GcpException.class,
+                () -> service.deleteUser("project-a", "pg-main", "app", "%"));
+        assertEquals("INVALID_ARGUMENT", deleteError.getGcpStatus());
+    }
+
+    private static class RecordingDataPlane implements CloudSqlDataPlane {
+        private final List<String> events = new java.util.ArrayList<>();
+
+        @Override
+        public Map<String, Object> startInstance(String project, String instance, Map<String, Object> metadata) {
+            events.add("start:" + project + "/" + instance);
+            return metadata;
+        }
+
+        @Override
+        public Map<String, Object> ensureInstance(String project, String instance, Map<String, Object> metadata) {
+            events.add("ensure:" + project + "/" + instance);
+            return metadata;
+        }
+
+        @Override
+        public void stopInstance(String project, String instance, Map<String, Object> metadata, boolean removeStorage) {
+            events.add("stop:" + project + "/" + instance + ":" + removeStorage);
+        }
+
+        @Override
+        public void createDatabase(Map<String, Object> instanceMetadata, String database) {
+            events.add("create-db:" + database);
+        }
+
+        @Override
+        public void deleteDatabase(Map<String, Object> instanceMetadata, String database) {
+            events.add("delete-db:" + database);
+        }
+
+        @Override
+        public void createOrUpdateUser(Map<String, Object> instanceMetadata, String user, String password) {
+            events.add("create-user:" + user + ":" + password);
+        }
+
+        @Override
+        public void deleteUser(Map<String, Object> instanceMetadata, String user, Iterable<String> databases) {
+            events.add("delete-user:" + user + ":" + String.join(",", databases));
+        }
+
+        @Override
+        public void grantDatabaseAccess(Map<String, Object> instanceMetadata, String database, String user) {
+            events.add("grant:" + database + ":" + user);
+        }
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,7 @@ floci-gcp:
       mock: true
     cloudsql:
       enabled: true
+      data-plane-enabled: false
     cloudtasks:
       enabled: true
     cloudrun:


### PR DESCRIPTION
## Summary

- Add a Docker-backed PostgreSQL data plane for Cloud SQL instances, including lifecycle management, endpoint metadata, and database/user synchronization.
- Wire Cloud SQL data-plane configuration, storage behavior, restart/shutdown handling, and cleanup on startup failure.
- Extend REST, service, data-plane, Terraform/OpenTofu, and Java SDK compatibility tests, including PostgreSQL 16/17/18 matrix coverage.
- Update README and service/configuration docs for the Cloud SQL PostgreSQL data plane.

## Validation

- `rtk env JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=ProjectAwareStorageBackendTest,CloudSqlServiceTest,CloudSqlPostgresDataPlaneTest,CloudSqlRestIntegrationTest,CloudSqlDisabledRestIntegrationTest` - passed, 34 tests.
- `git diff --check upstream/main...HEAD` - passed.
- Post-rebase `CloudSqlDataPlaneIntegrationTest` command completed with Docker-dependent matrix skipped because Docker Desktop was not running (`docker info` could not connect to the daemon).
- Before the rebase, while Docker was available, `CloudSqlDataPlaneIntegrationTest` passed against `POSTGRES_16`, `POSTGRES_17`, and `POSTGRES_18`; Java SDK `CloudSqlAdminTest` also passed against a local emulator for the same version matrix.

## Notes

This branch is rebased onto `main` after phase 1 merged in #50.
