### PR TITLE
docs: add Cloud Tasks page and document Cloud SQL, Logging and KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Managed Kafka | ✅ | ❌ |
 | Cloud Run | ✅ | ❌ |
 | Cloud Functions | ✅ | ❌ |
+| Cloud SQL for PostgreSQL | ✅ | ❌ |
+| Cloud Tasks | ✅ | ❌ |
 | Native binary | ✅ | ❌ |
 
 ## Architecture Overview
@@ -150,11 +152,11 @@ flowchart LR
         Router["HTTP/2 Router\nALPN negotiation"]
 
         subgraph GRPC ["gRPC services"]
-            A["Pub/Sub\nFirestore\nSecret Manager\nCloud Logging\nCloud KMS"]
+            A["Pub/Sub\nFirestore\nSecret Manager\nCloud Logging\nCloud KMS\nCloud Tasks"]
         end
 
         subgraph REST ["REST services"]
-            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions"]
+            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions\nCloud SQL"]
         end
 
         subgraph Docker ["Docker-backed"]
@@ -182,6 +184,8 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Messaging | Pub/Sub, Managed Kafka |
 | Security and identity | Secret Manager, Cloud KMS, IAM |
 | Serverless control planes | Cloud Run, Cloud Functions |
+| Task scheduling | Cloud Tasks |
+| Databases | Cloud SQL for PostgreSQL |
 | Observability | Cloud Logging |
 
 <details>
@@ -200,6 +204,8 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Managed Kafka** | REST JSON | Clusters, topics, consumer groups; Redpanda-backed or mock mode |
 | **Cloud Run** | REST JSON | Services, IAM policies, revisions, long-running operations; control plane by default, experimental Docker-backed invocation when enabled |
 | **Cloud Functions** | REST JSON | Functions, source upload URL generation, long-running operations; control plane only, no runtime invocation |
+| **Cloud SQL for PostgreSQL** | REST JSON | Instances (Postgres), control-plane lifecycle, long-running operations |
+| **Cloud Tasks** | gRPC | Queues (rate limits, retry config, pause/resume/purge), tasks (HTTP and App Engine targets, schedule time), `RunTask`; control plane only, tasks are tracked but not dispatched |
 
 </details>
 
@@ -576,6 +582,7 @@ All settings are overridable via environment variables (`FLOCI_GCP_` prefix).
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED` | `false` | Enable experimental Docker-backed Cloud Run execution |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_MOCK` | `false` | Keep Cloud Run execution metadata-only without Docker |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Enable/disable Cloud Functions |
+| `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Enable/disable Cloud Tasks |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Enable/disable Managed Kafka |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL instances for Cloud SQL |

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,10 +19,14 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | **Firestore** | gRPC | Documents, collections, queries, field transforms, aggregation, transactions, real-time listeners |
 | **Datastore** | HTTP/protobuf | Entities, structured queries, GQL queries, aggregation, transactions |
 | **Secret Manager** | gRPC | Secrets, versions, access, disable/enable/destroy, IAM bindings |
+| **Cloud Logging** | gRPC + REST | Structured log ingestion (`WriteLogEntries`), read-back (`ListLogEntries`) with filter subset, `ListLogs`, `DeleteLog` |
+| **Cloud KMS** | gRPC + REST | Key rings, crypto keys, versions, symmetric encrypt/decrypt, asymmetric sign/decrypt, `GenerateRandomBytes` |
 | **IAM** | REST | Service accounts, RSA-2048 keys, policy bindings, SignBlob (V4 signed URLs) |
 | **Managed Kafka** | REST | Clusters, topics, consumer groups (Redpanda-backed or mock mode) |
 | **Cloud Run** | REST | Service create/get/list/delete, IAM policy operations, revisions, LRO polling; control plane by default, experimental Docker-backed invocation and GCS volume mounts when enabled |
 | **Cloud Functions** | REST | Function create/get/list/delete, upload URL generation, LRO polling; control plane only |
+| **Cloud SQL for PostgreSQL** | REST | Instance lifecycle (Postgres), LRO polling; control plane only |
+| **Cloud Tasks** | gRPC | Queues (rate limits, retry, pause/resume/purge), tasks (HTTP/App Engine targets), `RunTask`; control plane only |
 
 ## Why floci-gcp?
 

--- a/docs/services/cloud-tasks.md
+++ b/docs/services/cloud-tasks.md
@@ -1,0 +1,153 @@
+# Cloud Tasks
+
+floci-gcp emulates Google Cloud Tasks over gRPC using the real
+`google.cloud.tasks.v2.CloudTasks` protocol. It implements the control plane for queues and tasks —
+creating queues, enqueuing tasks, listing, pausing/resuming, and purging — with state tracked in the
+configured storage backend.
+
+!!! note "Control plane only"
+    floci-gcp **stores and tracks** queues and tasks but does **not dispatch** them. `RunTask`
+    increments the task's `dispatchCount` and returns the task; it does not deliver the HTTP or
+    App Engine request to its target. Use this to validate enqueue/management flows, not real task
+    execution.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Enable/disable Cloud Tasks |
+
+## Endpoint
+
+Cloud Tasks has **no `*_EMULATOR_HOST` convention**. Point the client at floci-gcp by overriding the
+transport channel to `localhost:4588` over plaintext and disabling credentials (see Quick Start).
+
+## Quick Start
+
+=== "Java"
+
+    ```java
+    CloudTasksClient client = CloudTasksClient.create(
+        CloudTasksSettings.newBuilder()
+            .setTransportChannelProvider(
+                InstantiatingGrpcChannelProvider.newBuilder()
+                    .setEndpoint("localhost:4588")
+                    .setChannelConfigurator(b -> b.usePlaintext())
+                    .build())
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build());
+
+    LocationName parent = LocationName.of("floci-local", "us-central1");
+    Queue queue = client.createQueue(parent, Queue.newBuilder()
+        .setName(QueueName.of("floci-local", "us-central1", "my-queue").toString())
+        .build());
+
+    Task task = client.createTask(queue.getName(), Task.newBuilder()
+        .setHttpRequest(HttpRequest.newBuilder()
+            .setUrl("https://example.com/handler")
+            .setHttpMethod(HttpMethod.POST)
+            .setBody(ByteString.copyFromUtf8("payload"))
+            .build())
+        .build());
+
+    client.runTask(task.getName());
+    ```
+
+=== "Python"
+
+    ```python
+    import grpc
+    from google.cloud import tasks_v2
+    from google.cloud.tasks_v2.services.cloud_tasks.transports.grpc import (
+        CloudTasksGrpcTransport,
+    )
+
+    transport = CloudTasksGrpcTransport(channel=grpc.insecure_channel("localhost:4588"))
+    client = tasks_v2.CloudTasksClient(transport=transport)
+
+    parent = "projects/floci-local/locations/us-central1"
+    queue = client.create_queue(request={
+        "parent": parent,
+        "queue": {"name": f"{parent}/queues/my-queue"},
+    })
+
+    task = client.create_task(request={
+        "parent": queue.name,
+        "task": {
+            "http_request": {
+                "url": "https://example.com/handler",
+                "http_method": tasks_v2.HttpMethod.POST,
+                "body": b"payload",
+            }
+        },
+    })
+
+    client.run_task(request={"name": task.name})
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    import { CloudTasksClient } from "@google-cloud/tasks";
+    import * as grpc from "@grpc/grpc-js";
+
+    const client = new CloudTasksClient({
+        servicePath: "localhost",
+        port: 4588,
+        sslCreds: grpc.credentials.createInsecure(),
+    });
+
+    const parent = "projects/floci-local/locations/us-central1";
+    const [queue] = await client.createQueue({
+        parent,
+        queue: { name: `${parent}/queues/my-queue` },
+    });
+
+    const [task] = await client.createTask({
+        parent: queue.name,
+        task: {
+            httpRequest: {
+                url: "https://example.com/handler",
+                httpMethod: "POST",
+                body: Buffer.from("payload"),
+            },
+        },
+    });
+
+    await client.runTask({ name: task.name });
+    ```
+
+## Queues
+
+`CreateQueue` stores a queue under `projects/{project}/locations/{location}/queues/{queue}`. The
+following fields are honored:
+
+- **Rate limits** — `max_dispatches_per_second`, `max_concurrent_dispatches`
+- **Retry config** — `max_attempts`
+- **State** — `PauseQueue` / `ResumeQueue` toggle the queue state; `PurgeQueue` clears its tasks
+
+`UpdateQueue` applies the same rate-limit and retry fields.
+
+## Tasks
+
+`CreateTask` accepts both task target shapes:
+
+- **HTTP target** (`http_request`) — `url`, `http_method`, `headers`, `body`
+- **App Engine target** (`app_engine_http_request`) — `relative_uri`, `http_method`, `headers`, `body`
+
+`schedule_time` is stored when provided. Tasks with neither target default to an HTTP-typed task.
+
+## Supported Operations
+
+- `ListQueues`, `GetQueue`, `CreateQueue`, `UpdateQueue`, `DeleteQueue`
+- `PurgeQueue`, `PauseQueue`, `ResumeQueue`
+- `ListTasks`, `GetTask`, `CreateTask`, `DeleteTask`, `RunTask`
+- `GetIamPolicy`, `SetIamPolicy`, `TestIamPermissions` (accepted but not persisted/enforced — see below)
+
+## Not Yet Supported
+
+- **Actual task dispatch** — `RunTask` and queue processing do not deliver requests to HTTP or
+  App Engine targets; tasks are tracked, not executed.
+- **IAM enforcement** — `GetIamPolicy` returns an empty policy, `SetIamPolicy` echoes the request,
+  and `TestIamPermissions` echoes the requested permissions; nothing is stored or enforced.
+- Automatic retry/backoff scheduling, `BufferTask`, and queue-level routing overrides.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -18,6 +18,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud SQL for PostgreSQL](cloud-sql-postgres.md) | REST JSON | `/v1/projects/{project}/instances` |
 | [Cloud Run](cloud-run.md) | REST JSON | `/v2/projects/{project}/locations/{location}/services` |
 | [Cloud Functions](cloud-functions.md) | REST JSON | `/v2/projects/{project}/locations/{location}/functions` |
+| [Cloud Tasks](cloud-tasks.md) | gRPC | `google.cloud.tasks.v2.CloudTasks` |
 
 ## Single-Port Design
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,4 +80,5 @@ nav:
     - Cloud SQL for PostgreSQL: services/cloud-sql-postgres.md
     - Cloud Run: services/cloud-run.md
     - Cloud Functions: services/cloud-functions.md
+    - Cloud Tasks: services/cloud-tasks.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary

Several shipped services were missing from the docs. Adds a Cloud Tasks service page (gRPC `google.cloud.tasks.v2`, control-plane only) with nav, service-matrix and README entries, and surfaces Cloud SQL for PostgreSQL, Cloud Logging and Cloud KMS in the README and docs home tables.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

N/A — documentation only. Content was verified against the implementation (Cloud Tasks is gRPC `CloudTasksGrpc.CloudTasksImplBase` with `RunTask`, control plane only).

## Checklist

- [x] `./mvnw test` passes locally — N/A (docs only)
- [ ] New or updated integration test added — N/A, documentation only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)