### PR TITLE
feat(scheduler): implement Cloud Scheduler (gRPC + REST)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Cloud Functions | ✅ | ❌ |
 | Cloud SQL for PostgreSQL | ✅ | ❌ |
 | Cloud Tasks | ✅ | ❌ |
+| Cloud Scheduler | ✅ | ❌ |
 | Native binary | ✅ | ❌ |
 
 ## Architecture Overview
@@ -184,7 +185,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Messaging | Pub/Sub, Managed Kafka |
 | Security and identity | Secret Manager, Cloud KMS, IAM |
 | Serverless control planes | Cloud Run, Cloud Functions |
-| Task scheduling | Cloud Tasks |
+| Task scheduling | Cloud Tasks, Cloud Scheduler |
 | Databases | Cloud SQL for PostgreSQL |
 | Observability | Cloud Logging |
 
@@ -206,6 +207,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Cloud Functions** | REST JSON | Functions, source upload URL generation, long-running operations; control plane only, no runtime invocation |
 | **Cloud SQL for PostgreSQL** | REST JSON | Instances (Postgres), control-plane lifecycle, long-running operations |
 | **Cloud Tasks** | gRPC | Queues (rate limits, retry config, pause/resume/purge), tasks (HTTP and App Engine targets, schedule time), `RunTask`; control plane only, tasks are tracked but not dispatched |
+| **Cloud Scheduler** | gRPC + REST JSON | Cron jobs with Pub/Sub, HTTP, and App Engine targets; `Pause`/`Resume`/`RunJob`; unix-cron + time zones; background tick fires due jobs (Pub/Sub publishes into the local backend) |
 
 </details>
 

--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -43,7 +43,7 @@ just test-all-iac
 
 ## Test Coverage
 
-### SDK tests — 226 tests total
+### SDK tests — 233 tests total
 
 | Test class | GCP service | Java | Python | Node | Go |
 |---|---|:---:|:---:|:---:|:---:|
@@ -57,7 +57,8 @@ just test-all-iac
 | `IamTest` | IAM | 7 | 5 | 7 | 7 |
 | `KafkaTest` | Managed Kafka | 11 | 9 | 11 | 11 |
 | `CloudSqlAdminTest` | Cloud SQL for PostgreSQL | 4 | 0 | 0 | 0 |
-| **Total** | | **61** | **48** | **59** | **58** |
+| `SchedulerTest` | Cloud Scheduler | 7 | 0 | 0 | 0 |
+| **Total** | | **68** | **48** | **59** | **58** |
 
 ### IaC tests
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -62,6 +62,10 @@
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-scheduler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-run</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -23,6 +23,8 @@ import com.google.cloud.kms.v1.KeyManagementServiceClient;
 import com.google.cloud.kms.v1.KeyManagementServiceSettings;
 import com.google.cloud.tasks.v2.CloudTasksClient;
 import com.google.cloud.tasks.v2.CloudTasksSettings;
+import com.google.cloud.scheduler.v1.CloudSchedulerClient;
+import com.google.cloud.scheduler.v1.CloudSchedulerSettings;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.sqladmin.SQLAdmin;
@@ -237,5 +239,26 @@ public final class TestFixtures {
                 .build();
 
         return com.google.cloud.monitoring.v3.MetricServiceClient.create(settings);
+    }
+
+    /**
+     * Creates a Cloud Scheduler client pointing at the emulator.
+     * No standard emulator env var exists; configure explicitly via plaintext gRPC channel.
+     */
+    public static CloudSchedulerClient cloudSchedulerClient() throws IOException {
+        URI uri = URI.create(endpoint());
+        String host = uri.getHost();
+        int port = uri.getPort() > 0 ? uri.getPort() : 4588;
+
+        CloudSchedulerSettings settings = CloudSchedulerSettings.newBuilder()
+                .setTransportChannelProvider(
+                        InstantiatingGrpcChannelProvider.newBuilder()
+                                .setEndpoint(host + ":" + port)
+                                .setChannelConfigurator(builder -> builder.usePlaintext())
+                                .build())
+                .setCredentialsProvider(NoCredentialsProvider.create())
+                .build();
+
+        return CloudSchedulerClient.create(settings);
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/SchedulerTest.java
@@ -1,0 +1,176 @@
+package io.floci.gcp.test;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.cloud.scheduler.v1.CloudSchedulerClient;
+import com.google.cloud.scheduler.v1.Job;
+import com.google.cloud.scheduler.v1.PubsubTarget;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.FieldMask;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.ReceivedMessage;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SchedulerTest {
+
+    private static final String PROJECT_ID = TestFixtures.projectId();
+    private static final String LOCATION = "us-central1";
+    private static final String PARENT = "projects/" + PROJECT_ID + "/locations/" + LOCATION;
+
+    private static final String JOB_ID = TestFixtures.uniqueName("test-job");
+    private static final String JOB_NAME = PARENT + "/jobs/" + JOB_ID;
+    private static final String TOPIC_ID = TestFixtures.uniqueName("sched-topic");
+    private static final String SUB_ID = TestFixtures.uniqueName("sched-sub");
+    private static final String PAYLOAD = "scheduled-tick";
+
+    private static CloudSchedulerClient schedulerClient;
+    private static ManagedChannel channel;
+    private static TransportChannelProvider channelProvider;
+    private static TopicAdminClient topicAdminClient;
+    private static SubscriptionAdminClient subscriptionAdminClient;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        String emulatorHost = System.getenv().getOrDefault("PUBSUB_EMULATOR_HOST", "localhost:4588");
+        channel = ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
+        channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+        NoCredentialsProvider creds = NoCredentialsProvider.create();
+
+        schedulerClient = TestFixtures.cloudSchedulerClient();
+        topicAdminClient = TopicAdminClient.create(TopicAdminSettings.newBuilder()
+                .setTransportChannelProvider(channelProvider).setCredentialsProvider(creds).build());
+        subscriptionAdminClient = SubscriptionAdminClient.create(SubscriptionAdminSettings.newBuilder()
+                .setTransportChannelProvider(channelProvider).setCredentialsProvider(creds).build());
+
+        topicAdminClient.createTopic(ProjectTopicName.of(PROJECT_ID, TOPIC_ID));
+        subscriptionAdminClient.createSubscription(
+                ProjectSubscriptionName.of(PROJECT_ID, SUB_ID),
+                ProjectTopicName.of(PROJECT_ID, TOPIC_ID),
+                PushConfig.getDefaultInstance(), 10);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (schedulerClient != null) schedulerClient.close();
+        if (subscriptionAdminClient != null) subscriptionAdminClient.close();
+        if (topicAdminClient != null) topicAdminClient.close();
+        if (channel != null) {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static String topicName() {
+        return ProjectTopicName.of(PROJECT_ID, TOPIC_ID).toString();
+    }
+
+    @Test
+    @Order(1)
+    void createJobWithPubsubTarget() {
+        Job job = schedulerClient.createJob(PARENT, Job.newBuilder()
+                .setName(JOB_NAME)
+                .setSchedule("*/5 * * * *")
+                .setPubsubTarget(PubsubTarget.newBuilder()
+                        .setTopicName(topicName())
+                        .setData(ByteString.copyFromUtf8(PAYLOAD))
+                        .build())
+                .build());
+
+        assertThat(job.getName()).isEqualTo(JOB_NAME);
+        assertThat(job.getState()).isEqualTo(Job.State.ENABLED);
+        assertThat(job.getPubsubTarget().getTopicName()).isEqualTo(topicName());
+    }
+
+    @Test
+    @Order(2)
+    void getJob() {
+        Job job = schedulerClient.getJob(JOB_NAME);
+        assertThat(job.getSchedule()).isEqualTo("*/5 * * * *");
+        assertThat(job.getPubsubTarget().getData().toStringUtf8()).isEqualTo(PAYLOAD);
+    }
+
+    @Test
+    @Order(3)
+    void listJobsContainsCreated() {
+        List<String> names = new ArrayList<>();
+        schedulerClient.listJobs(PARENT).iterateAll().forEach(j -> names.add(j.getName()));
+        assertThat(names).contains(JOB_NAME);
+    }
+
+    @Test
+    @Order(4)
+    void pauseThenResume() {
+        assertThat(schedulerClient.pauseJob(JOB_NAME).getState()).isEqualTo(Job.State.PAUSED);
+        assertThat(schedulerClient.resumeJob(JOB_NAME).getState()).isEqualTo(Job.State.ENABLED);
+    }
+
+    @Test
+    @Order(5)
+    void runJobPublishesToPubsub() throws IOException {
+        schedulerClient.runJob(JOB_NAME);
+
+        SubscriberStubSettings settings = SubscriberStubSettings.newBuilder()
+                .setTransportChannelProvider(channelProvider)
+                .setCredentialsProvider(NoCredentialsProvider.create())
+                .build();
+        try (GrpcSubscriberStub stub = GrpcSubscriberStub.create(settings)) {
+            String sub = ProjectSubscriptionName.of(PROJECT_ID, SUB_ID).toString();
+            PullResponse resp = stub.pullCallable().call(PullRequest.newBuilder()
+                    .setSubscription(sub).setMaxMessages(10).build());
+
+            List<String> contents = resp.getReceivedMessagesList().stream()
+                    .map(m -> m.getMessage().getData().toStringUtf8()).toList();
+            assertThat(contents).contains(PAYLOAD);
+
+            List<String> ackIds = resp.getReceivedMessagesList().stream()
+                    .map(ReceivedMessage::getAckId).toList();
+            stub.acknowledgeCallable().call(AcknowledgeRequest.newBuilder()
+                    .setSubscription(sub).addAllAckIds(ackIds).build());
+        }
+    }
+
+    @Test
+    @Order(6)
+    void updateJobDescription() {
+        Job updated = schedulerClient.updateJob(
+                Job.newBuilder().setName(JOB_NAME).setDescription("updated").build(),
+                FieldMask.newBuilder().addPaths("description").build());
+        assertThat(updated.getDescription()).isEqualTo("updated");
+    }
+
+    @Test
+    @Order(7)
+    void deleteJob() {
+        schedulerClient.deleteJob(JOB_NAME);
+        assertThatThrownBy(() -> schedulerClient.getJob(JOB_NAME)).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -19,6 +19,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud Run](cloud-run.md) | REST JSON | `/v2/projects/{project}/locations/{location}/services` |
 | [Cloud Functions](cloud-functions.md) | REST JSON | `/v2/projects/{project}/locations/{location}/functions` |
 | [Cloud Tasks](cloud-tasks.md) | gRPC | `google.cloud.tasks.v2.CloudTasks` |
+| [Cloud Scheduler](scheduler.md) | gRPC + REST JSON | `google.cloud.scheduler.v1.CloudScheduler`, `/v1/projects/{project}/locations/{location}/jobs` |
 
 ## Single-Port Design
 

--- a/docs/services/scheduler.md
+++ b/docs/services/scheduler.md
@@ -1,0 +1,67 @@
+# Cloud Scheduler
+
+floci-gcp emulates Google Cloud Scheduler over gRPC and REST using the real
+`google.cloud.scheduler.v1.CloudScheduler` protocol. Create cron **jobs** that dispatch to
+**Pub/Sub**, **HTTP**, or **App Engine** targets; a lightweight background tick fires due jobs and
+`RunJob` triggers one immediately.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_SCHEDULER_ENABLED` | `true` | Enable/disable Cloud Scheduler |
+| `FLOCI_GCP_SERVICES_SCHEDULER_INVOCATION_ENABLED` | `true` | When `false`, the background dispatcher never auto-fires jobs (`RunJob` still works) |
+| `FLOCI_GCP_SERVICES_SCHEDULER_TICK_INTERVAL_SECONDS` | `10` | Interval between dispatcher ticks |
+
+## Endpoint
+
+Cloud Scheduler has **no `*_EMULATOR_HOST` convention**. Point the client at floci-gcp by
+overriding the API endpoint / transport channel and disabling credentials:
+
+- **gRPC** (Java/Python/Go/Node): build the v1 client with a plaintext channel to `localhost:4588`
+  and anonymous/no credentials (see Quick Start).
+- **REST**: `/v1/projects/{project}/locations/{location}/jobs` (+ `:pause`, `:resume`, `:run`).
+
+## Scope
+
+- Jobs: `CreateJob`, `GetJob`, `ListJobs`, `UpdateJob`, `DeleteJob`, `PauseJob`, `ResumeJob`, `RunJob`.
+- Targets: `PubsubTarget` (publishes into the local Pub/Sub backend), `HttpTarget` (real outbound
+  HTTP request), `AppEngineHttpTarget` (recorded — there is no App Engine backend to dispatch to).
+- `schedule` is standard five-field unix-cron, interpreted in `time_zone` (default UTC).
+- Output-only `state`, `schedule_time`, `last_attempt_time`, and `status` are populated.
+
+## Quick Start
+
+=== "Java"
+
+    ```java
+    CloudSchedulerClient client = CloudSchedulerClient.create(
+        CloudSchedulerSettings.newBuilder()
+            .setTransportChannelProvider(
+                InstantiatingGrpcChannelProvider.newBuilder()
+                    .setEndpoint("localhost:4588")
+                    .setChannelConfigurator(b -> b.usePlaintext())
+                    .build())
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build());
+
+    String parent = "projects/floci-local/locations/us-central1";
+    Job job = client.createJob(parent, Job.newBuilder()
+        .setName(parent + "/jobs/my-job")
+        .setSchedule("*/5 * * * *")
+        .setPubsubTarget(PubsubTarget.newBuilder()
+            .setTopicName("projects/floci-local/topics/my-topic")
+            .setData(ByteString.copyFromUtf8("tick"))
+            .build())
+        .build());
+
+    // Fire immediately (publishes to the topic now):
+    client.runJob(job.getName());
+    ```
+
+## Notes
+
+- `RunJob` dispatches synchronously; the background dispatcher fires ENABLED jobs whose cron time
+  has passed. `PauseJob` stops auto-firing; `ResumeJob` re-enables it.
+- `PubsubTarget.topic_name` must reference an existing Pub/Sub topic in the same emulator.
+- `RetryConfig`/`attempt_deadline` are stored and returned but retries are not yet simulated.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,4 +81,5 @@ nav:
     - Cloud Run: services/cloud-run.md
     - Cloud Functions: services/cloud-functions.md
     - Cloud Tasks: services/cloud-tasks.md
+    - Cloud Scheduler: services/scheduler.md
   - Contributing: contributing.md

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
             <artifactId>grpc-google-cloud-tasks-v2</artifactId>
         </dependency>
 
+        <!-- Cloud Scheduler gRPC stubs (CloudSchedulerGrpc ImplBase) -->
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>grpc-google-cloud-scheduler-v1</artifactId>
+        </dependency>
+
         <!-- Firestore gRPC stubs (FirestoreGrpc ImplBase) -->
         <dependency>
             <groupId>com.google.api.grpc</groupId>
@@ -134,6 +140,13 @@
         <dependency>
             <groupId>com.google.api.grpc</groupId>
             <artifactId>proto-google-cloud-datastore-v1</artifactId>
+        </dependency>
+
+        <!-- cron-utils for Cloud Scheduler unix-cron schedule parsing -->
+        <dependency>
+            <groupId>com.cronutils</groupId>
+            <artifactId>cron-utils</artifactId>
+            <version>9.2.1</version>
         </dependency>
 
         <!-- Jackson -->

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -100,6 +100,8 @@ public interface EmulatorConfig {
         CloudFunctionsServiceConfig cloudfunctions();
 
         MonitoringServiceConfig monitoring();
+
+        SchedulerServiceConfig scheduler();
     }
 
     interface GcsServiceConfig {
@@ -226,6 +228,19 @@ public interface EmulatorConfig {
     interface MonitoringServiceConfig {
         @WithDefault("true")
         boolean enabled();
+    }
+
+    interface SchedulerServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /** When false, the background dispatcher does not fire due jobs (RunJob still works). */
+        @WithDefault("true")
+        boolean invocationEnabled();
+
+        /** Interval between scheduler dispatcher ticks. */
+        @WithDefault("10")
+        long tickIntervalSeconds();
     }
 
     interface DockerConfig {

--- a/src/main/java/io/floci/gcp/services/scheduler/ScheduleDispatcher.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/ScheduleDispatcher.java
@@ -1,0 +1,119 @@
+package io.floci.gcp.services.scheduler;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.services.scheduler.model.StoredJob;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Fires Cloud Scheduler jobs when their unix-cron schedule is due.
+ *
+ * A single background daemon thread ticks on a fixed interval, scans all persisted jobs, and
+ * dispatches any ENABLED job whose next computed fire time has passed. Per-job "last fire"
+ * state is kept in memory (by job name); restarts reset it, matching the emulator's loose
+ * durability expectations. {@code RunJob} dispatches immediately via {@link SchedulerService}
+ * independently of this tick.
+ */
+@ApplicationScoped
+public class ScheduleDispatcher {
+
+    private static final Logger LOG = Logger.getLogger(ScheduleDispatcher.class);
+
+    private final SchedulerService schedulerService;
+    private final long tickIntervalSeconds;
+    private final boolean enabled;
+    private final ScheduledExecutorService executor;
+    private final ConcurrentHashMap<String, Instant> lastFireByName = new ConcurrentHashMap<>();
+
+    @Inject
+    public ScheduleDispatcher(SchedulerService schedulerService, EmulatorConfig config) {
+        this.schedulerService = schedulerService;
+        this.tickIntervalSeconds = config.services().scheduler().tickIntervalSeconds();
+        this.enabled = config.services().scheduler().enabled()
+                && config.services().scheduler().invocationEnabled();
+        this.executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "scheduler-dispatcher");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    void onStart(@Observes StartupEvent ignored) {
+        if (!enabled) {
+            LOG.info("Scheduler dispatcher disabled by configuration");
+            return;
+        }
+        executor.scheduleAtFixedRate(this::tickSafely, tickIntervalSeconds, tickIntervalSeconds, TimeUnit.SECONDS);
+        LOG.infov("Scheduler dispatcher started (tick every {0}s)", tickIntervalSeconds);
+    }
+
+    void onStop(@Observes ShutdownEvent ignored) {
+        executor.shutdownNow();
+    }
+
+    void tickSafely() {
+        try {
+            tick(Instant.now());
+        } catch (Throwable t) {
+            LOG.warnv("Scheduler dispatcher tick failed: {0}", t.getMessage());
+        }
+    }
+
+    void tick(Instant now) {
+        List<StoredJob> jobs = schedulerService.listAllJobs();
+        for (StoredJob job : jobs) {
+            try {
+                evaluate(job, now);
+            } catch (Exception e) {
+                LOG.warnv("Failed to evaluate job {0}: {1}", job.getName(), e.getMessage());
+            }
+        }
+    }
+
+    private void evaluate(StoredJob job, Instant now) {
+        if (!"ENABLED".equalsIgnoreCase(job.getState())) {
+            return;
+        }
+        if (job.getSchedule() == null || job.getSchedule().isBlank() || job.getTargetType() == null) {
+            return;
+        }
+
+        Instant base = lastFireByName.computeIfAbsent(job.getName(), n -> seedBase(job, now));
+        Instant nextFire;
+        try {
+            nextFire = SchedulerExpressionParser.nextCronFire(job.getSchedule(), base, job.getTimeZone());
+        } catch (IllegalArgumentException e) {
+            LOG.warnv("Unsupported schedule on job {0}: {1}", job.getName(), job.getSchedule());
+            return;
+        }
+        if (now.isBefore(nextFire)) {
+            return;
+        }
+
+        lastFireByName.put(job.getName(), now);
+        LOG.infov("Firing job {0} (scheduled {1})", job.getName(), nextFire);
+        schedulerService.fireJob(job, nextFire);
+    }
+
+    private static Instant seedBase(StoredJob job, Instant now) {
+        if (job.getCreateTime() != null) {
+            try {
+                return Instant.parse(job.getCreateTime());
+            } catch (Exception ignored) {
+                // fall through
+            }
+        }
+        return now.minusSeconds(1);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/ScheduleInvoker.java
@@ -1,0 +1,137 @@
+package io.floci.gcp.services.scheduler;
+
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import io.floci.gcp.services.pubsub.PubSubService;
+import io.floci.gcp.services.scheduler.model.StoredJob;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Delivers a Cloud Scheduler job to its configured target when the job fires (either via the
+ * background {@link ScheduleDispatcher} tick or an explicit {@code RunJob}).
+ *
+ * <ul>
+ *   <li>{@code PubsubTarget} publishes a message into the local Pub/Sub backend
+ *       ({@link PubSubService#publish}), so end-to-end pull works.</li>
+ *   <li>{@code HttpTarget} performs a real outbound HTTP request.</li>
+ *   <li>{@code AppEngineHttpTarget} is best-effort/recorded — there is no App Engine backend
+ *       in the emulator.</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class ScheduleInvoker {
+
+    private static final Logger LOG = Logger.getLogger(ScheduleInvoker.class);
+
+    // google.rpc.Code values used for the job's last-attempt status.
+    private static final int CODE_OK = 0;
+    private static final int CODE_UNKNOWN = 2;
+
+    private final PubSubService pubSubService;
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    @Inject
+    public ScheduleInvoker(PubSubService pubSubService) {
+        this.pubSubService = pubSubService;
+    }
+
+    // Test constructor.
+    ScheduleInvoker(PubSubService pubSubService, boolean ignored) {
+        this.pubSubService = pubSubService;
+    }
+
+    /** Result of a dispatch attempt, mapped onto the job's google.rpc.Status. */
+    public record InvokeResult(int code, String message) {
+        static InvokeResult ok() {
+            return new InvokeResult(CODE_OK, "");
+        }
+
+        static InvokeResult error(String message) {
+            return new InvokeResult(CODE_UNKNOWN, message);
+        }
+    }
+
+    public InvokeResult invoke(StoredJob job) {
+        String targetType = job.getTargetType();
+        if (targetType == null) {
+            return InvokeResult.error("Job has no target");
+        }
+        try {
+            return switch (targetType) {
+                case "PUBSUB" -> invokePubsub(job);
+                case "HTTP" -> invokeHttp(job);
+                case "APP_ENGINE" -> invokeAppEngine(job);
+                default -> InvokeResult.error("Unknown target type: " + targetType);
+            };
+        } catch (Exception e) {
+            LOG.warnf("Job %s dispatch failed: %s", job.getName(), e.getMessage());
+            return InvokeResult.error(e.getMessage());
+        }
+    }
+
+    private InvokeResult invokePubsub(StoredJob job) {
+        PubsubMessage.Builder msg = PubsubMessage.newBuilder();
+        if (job.getPubsubData() != null) {
+            msg.setData(ByteString.copyFrom(job.getPubsubData()));
+        }
+        if (job.getPubsubAttributes() != null) {
+            msg.putAllAttributes(job.getPubsubAttributes());
+        }
+        pubSubService.publish(job.getPubsubTopic(), List.of(msg.build()));
+        LOG.infof("Job %s published to topic %s", job.getName(), job.getPubsubTopic());
+        return InvokeResult.ok();
+    }
+
+    private InvokeResult invokeHttp(StoredJob job) throws Exception {
+        String method = (job.getHttpMethod() == null || job.getHttpMethod().isBlank()
+                || "HTTP_METHOD_UNSPECIFIED".equals(job.getHttpMethod()))
+                ? "POST" : job.getHttpMethod();
+        byte[] body = job.getHttpBody();
+        HttpRequest.BodyPublisher publisher = (body != null && body.length > 0)
+                ? HttpRequest.BodyPublishers.ofByteArray(body)
+                : HttpRequest.BodyPublishers.noBody();
+
+        HttpRequest.Builder req = HttpRequest.newBuilder()
+                .uri(URI.create(job.getHttpUri()))
+                .timeout(Duration.ofSeconds(attemptDeadlineOr(job, 180)))
+                .method(method, publisher);
+        if (job.getHttpHeaders() != null) {
+            for (Map.Entry<String, String> h : job.getHttpHeaders().entrySet()) {
+                try {
+                    req.header(h.getKey(), h.getValue());
+                } catch (IllegalArgumentException ignored) {
+                    // java.net.http disallows some headers (Host, Content-Length, …); skip them.
+                }
+            }
+        }
+        HttpResponse<Void> resp = httpClient.send(req.build(), HttpResponse.BodyHandlers.discarding());
+        int status = resp.statusCode();
+        LOG.infof("Job %s dispatched to %s -> HTTP %d", job.getName(), job.getHttpUri(), status);
+        return (status >= 200 && status < 300)
+                ? InvokeResult.ok()
+                : InvokeResult.error("HTTP " + status);
+    }
+
+    private InvokeResult invokeAppEngine(StoredJob job) {
+        // No App Engine backend exists in the emulator; record the attempt as a no-op.
+        LOG.infof("Job %s app-engine target recorded (dispatch not emulated)", job.getName());
+        return InvokeResult.ok();
+    }
+
+    private static long attemptDeadlineOr(StoredJob job, long fallbackSeconds) {
+        long d = job.getAttemptDeadlineSeconds();
+        return d > 0 ? d : fallbackSeconds;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/SchedulerController.java
@@ -1,0 +1,357 @@
+package io.floci.gcp.services.scheduler;
+
+import com.google.cloud.scheduler.v1.AppEngineHttpTarget;
+import com.google.cloud.scheduler.v1.AppEngineRouting;
+import com.google.cloud.scheduler.v1.CloudSchedulerGrpc;
+import com.google.cloud.scheduler.v1.CreateJobRequest;
+import com.google.cloud.scheduler.v1.DeleteJobRequest;
+import com.google.cloud.scheduler.v1.GetJobRequest;
+import com.google.cloud.scheduler.v1.HttpMethod;
+import com.google.cloud.scheduler.v1.HttpTarget;
+import com.google.cloud.scheduler.v1.Job;
+import com.google.cloud.scheduler.v1.ListJobsRequest;
+import com.google.cloud.scheduler.v1.ListJobsResponse;
+import com.google.cloud.scheduler.v1.PauseJobRequest;
+import com.google.cloud.scheduler.v1.PubsubTarget;
+import com.google.cloud.scheduler.v1.ResumeJobRequest;
+import com.google.cloud.scheduler.v1.RetryConfig;
+import com.google.cloud.scheduler.v1.RunJobRequest;
+import com.google.cloud.scheduler.v1.UpdateJobRequest;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
+import com.google.protobuf.Timestamp;
+import io.floci.gcp.core.common.GcpGrpcController;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.services.scheduler.model.StoredJob;
+import io.grpc.stub.StreamObserver;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+
+public class SchedulerController extends CloudSchedulerGrpc.CloudSchedulerImplBase {
+
+    private static final Logger LOG = Logger.getLogger(SchedulerController.class);
+
+    private final SchedulerService service;
+
+    SchedulerController(SchedulerService service) {
+        this.service = service;
+    }
+
+    @Override
+    public void listJobs(ListJobsRequest request, StreamObserver<ListJobsResponse> responseObserver) {
+        LOG.debugf("listJobs parent=%s", request.getParent());
+        try {
+            String[] parts = parseParent(request.getParent());
+            List<StoredJob> all = service.listJobs(parts[0], parts[1]);
+            PageToken.Page<StoredJob> page = PageToken.paginate(all,
+                    request.getPageSize(), request.getPageToken());
+            ListJobsResponse.Builder response = ListJobsResponse.newBuilder();
+            for (StoredJob j : page.items()) {
+                response.addJobs(toJobProto(j));
+            }
+            if (page.nextPageToken() != null) {
+                response.setNextPageToken(page.nextPageToken());
+            }
+            responseObserver.onNext(response.build());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("listJobs failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void getJob(GetJobRequest request, StreamObserver<Job> responseObserver) {
+        LOG.debugf("getJob name=%s", request.getName());
+        try {
+            StoredJob job = service.getJob(request.getName());
+            responseObserver.onNext(toJobProto(job));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("getJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void createJob(CreateJobRequest request, StreamObserver<Job> responseObserver) {
+        LOG.infof("createJob parent=%s", request.getParent());
+        try {
+            StoredJob stored = service.createJob(request.getParent(), fromJobProto(request.getJob()));
+            responseObserver.onNext(toJobProto(stored));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("createJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void updateJob(UpdateJobRequest request, StreamObserver<Job> responseObserver) {
+        LOG.infof("updateJob name=%s", request.getJob().getName());
+        try {
+            List<String> mask = request.hasUpdateMask()
+                    ? request.getUpdateMask().getPathsList() : List.of();
+            StoredJob stored = service.updateJob(fromJobProto(request.getJob()), mask);
+            responseObserver.onNext(toJobProto(stored));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("updateJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void deleteJob(DeleteJobRequest request, StreamObserver<Empty> responseObserver) {
+        LOG.infof("deleteJob name=%s", request.getName());
+        try {
+            service.deleteJob(request.getName());
+            responseObserver.onNext(Empty.getDefaultInstance());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("deleteJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void pauseJob(PauseJobRequest request, StreamObserver<Job> responseObserver) {
+        LOG.infof("pauseJob name=%s", request.getName());
+        try {
+            responseObserver.onNext(toJobProto(service.pauseJob(request.getName())));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("pauseJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void resumeJob(ResumeJobRequest request, StreamObserver<Job> responseObserver) {
+        LOG.infof("resumeJob name=%s", request.getName());
+        try {
+            responseObserver.onNext(toJobProto(service.resumeJob(request.getName())));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("resumeJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void runJob(RunJobRequest request, StreamObserver<Job> responseObserver) {
+        LOG.infof("runJob name=%s", request.getName());
+        try {
+            responseObserver.onNext(toJobProto(service.runJob(request.getName())));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("runJob failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    // ── Mapping ──────────────────────────────────────────────────────────────────
+
+    static StoredJob fromJobProto(Job proto) {
+        StoredJob job = new StoredJob();
+        job.setName(proto.getName());
+        job.setDescription(emptyToNull(proto.getDescription()));
+        job.setSchedule(emptyToNull(proto.getSchedule()));
+        job.setTimeZone(emptyToNull(proto.getTimeZone()));
+
+        if (proto.hasPubsubTarget()) {
+            PubsubTarget t = proto.getPubsubTarget();
+            job.setTargetType("PUBSUB");
+            job.setPubsubTopic(t.getTopicName());
+            job.setPubsubData(t.getData().toByteArray());
+            if (!t.getAttributesMap().isEmpty()) {
+                job.setPubsubAttributes(t.getAttributesMap());
+            }
+        } else if (proto.hasHttpTarget()) {
+            HttpTarget t = proto.getHttpTarget();
+            job.setTargetType("HTTP");
+            job.setHttpUri(t.getUri());
+            job.setHttpMethod(t.getHttpMethod().name());
+            if (!t.getHeadersMap().isEmpty()) {
+                job.setHttpHeaders(t.getHeadersMap());
+            }
+            job.setHttpBody(t.getBody().toByteArray());
+        } else if (proto.hasAppEngineHttpTarget()) {
+            AppEngineHttpTarget t = proto.getAppEngineHttpTarget();
+            job.setTargetType("APP_ENGINE");
+            job.setAppEngineHttpMethod(t.getHttpMethod().name());
+            job.setAppEngineRelativeUri(t.getRelativeUri());
+            if (!t.getHeadersMap().isEmpty()) {
+                job.setAppEngineHeaders(t.getHeadersMap());
+            }
+            job.setAppEngineBody(t.getBody().toByteArray());
+            AppEngineRouting r = t.getAppEngineRouting();
+            job.setAppEngineService(emptyToNull(r.getService()));
+            job.setAppEngineVersion(emptyToNull(r.getVersion()));
+            job.setAppEngineInstance(emptyToNull(r.getInstance()));
+            job.setAppEngineHost(emptyToNull(r.getHost()));
+        }
+
+        if (proto.hasRetryConfig()) {
+            RetryConfig rc = proto.getRetryConfig();
+            job.setRetryCount(rc.getRetryCount());
+            job.setMaxRetryDurationSeconds(rc.getMaxRetryDuration().getSeconds());
+            job.setMinBackoffSeconds(rc.getMinBackoffDuration().getSeconds());
+            job.setMaxBackoffSeconds(rc.getMaxBackoffDuration().getSeconds());
+            job.setMaxDoublings(rc.getMaxDoublings());
+        }
+        if (proto.hasAttemptDeadline()) {
+            job.setAttemptDeadlineSeconds(proto.getAttemptDeadline().getSeconds());
+        }
+        return job;
+    }
+
+    static Job toJobProto(StoredJob stored) {
+        Job.Builder b = Job.newBuilder().setName(stored.getName());
+        if (stored.getDescription() != null) {
+            b.setDescription(stored.getDescription());
+        }
+        if (stored.getSchedule() != null) {
+            b.setSchedule(stored.getSchedule());
+        }
+        if (stored.getTimeZone() != null) {
+            b.setTimeZone(stored.getTimeZone());
+        }
+
+        if ("PUBSUB".equals(stored.getTargetType())) {
+            PubsubTarget.Builder t = PubsubTarget.newBuilder();
+            if (stored.getPubsubTopic() != null) {
+                t.setTopicName(stored.getPubsubTopic());
+            }
+            if (stored.getPubsubData() != null) {
+                t.setData(ByteString.copyFrom(stored.getPubsubData()));
+            }
+            if (stored.getPubsubAttributes() != null) {
+                t.putAllAttributes(stored.getPubsubAttributes());
+            }
+            b.setPubsubTarget(t.build());
+        } else if ("HTTP".equals(stored.getTargetType())) {
+            HttpTarget.Builder t = HttpTarget.newBuilder();
+            if (stored.getHttpUri() != null) {
+                t.setUri(stored.getHttpUri());
+            }
+            t.setHttpMethod(parseHttpMethod(stored.getHttpMethod()));
+            if (stored.getHttpHeaders() != null) {
+                t.putAllHeaders(stored.getHttpHeaders());
+            }
+            if (stored.getHttpBody() != null) {
+                t.setBody(ByteString.copyFrom(stored.getHttpBody()));
+            }
+            b.setHttpTarget(t.build());
+        } else if ("APP_ENGINE".equals(stored.getTargetType())) {
+            AppEngineHttpTarget.Builder t = AppEngineHttpTarget.newBuilder();
+            t.setHttpMethod(parseHttpMethod(stored.getAppEngineHttpMethod()));
+            if (stored.getAppEngineRelativeUri() != null) {
+                t.setRelativeUri(stored.getAppEngineRelativeUri());
+            }
+            if (stored.getAppEngineHeaders() != null) {
+                t.putAllHeaders(stored.getAppEngineHeaders());
+            }
+            if (stored.getAppEngineBody() != null) {
+                t.setBody(ByteString.copyFrom(stored.getAppEngineBody()));
+            }
+            AppEngineRouting.Builder r = AppEngineRouting.newBuilder();
+            if (stored.getAppEngineService() != null) {
+                r.setService(stored.getAppEngineService());
+            }
+            if (stored.getAppEngineVersion() != null) {
+                r.setVersion(stored.getAppEngineVersion());
+            }
+            if (stored.getAppEngineInstance() != null) {
+                r.setInstance(stored.getAppEngineInstance());
+            }
+            if (stored.getAppEngineHost() != null) {
+                r.setHost(stored.getAppEngineHost());
+            }
+            t.setAppEngineRouting(r.build());
+            b.setAppEngineHttpTarget(t.build());
+        }
+
+        b.setRetryConfig(RetryConfig.newBuilder()
+                .setRetryCount(stored.getRetryCount())
+                .setMaxRetryDuration(seconds(stored.getMaxRetryDurationSeconds()))
+                .setMinBackoffDuration(seconds(stored.getMinBackoffSeconds()))
+                .setMaxBackoffDuration(seconds(stored.getMaxBackoffSeconds()))
+                .setMaxDoublings(stored.getMaxDoublings())
+                .build());
+        if (stored.getAttemptDeadlineSeconds() > 0) {
+            b.setAttemptDeadline(seconds(stored.getAttemptDeadlineSeconds()));
+        }
+
+        b.setState(parseState(stored.getState()));
+        if (stored.getUserUpdateTime() != null) {
+            b.setUserUpdateTime(toTimestamp(stored.getUserUpdateTime()));
+        }
+        if (stored.getScheduleTime() != null) {
+            b.setScheduleTime(toTimestamp(stored.getScheduleTime()));
+        }
+        if (stored.getLastAttemptTime() != null) {
+            b.setLastAttemptTime(toTimestamp(stored.getLastAttemptTime()));
+        }
+        if (stored.getStatusCode() != 0 || (stored.getStatusMessage() != null && !stored.getStatusMessage().isBlank())) {
+            b.setStatus(com.google.rpc.Status.newBuilder()
+                    .setCode(stored.getStatusCode())
+                    .setMessage(stored.getStatusMessage() == null ? "" : stored.getStatusMessage())
+                    .build());
+        }
+        return b.build();
+    }
+
+    private static HttpMethod parseHttpMethod(String name) {
+        if (name == null || name.isBlank()) {
+            return HttpMethod.HTTP_METHOD_UNSPECIFIED;
+        }
+        try {
+            return HttpMethod.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return HttpMethod.HTTP_METHOD_UNSPECIFIED;
+        }
+    }
+
+    private static Job.State parseState(String state) {
+        if (state == null) {
+            return Job.State.STATE_UNSPECIFIED;
+        }
+        try {
+            return Job.State.valueOf(state);
+        } catch (IllegalArgumentException e) {
+            return Job.State.STATE_UNSPECIFIED;
+        }
+    }
+
+    private static Duration seconds(long s) {
+        return Duration.newBuilder().setSeconds(s).build();
+    }
+
+    private static Timestamp toTimestamp(String isoTime) {
+        try {
+            Instant instant = Instant.parse(isoTime);
+            return Timestamp.newBuilder()
+                    .setSeconds(instant.getEpochSecond())
+                    .setNanos(instant.getNano())
+                    .build();
+        } catch (Exception e) {
+            return Timestamp.getDefaultInstance();
+        }
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.isEmpty()) ? null : s;
+    }
+
+    private static String[] parseParent(String parent) {
+        // parent = "projects/{project}/locations/{location}"
+        String[] parts = parent.split("/");
+        String project = parts.length > 1 ? parts[1] : parent;
+        String location = parts.length > 3 ? parts[3] : "us-central1";
+        return new String[]{project, location};
+    }
+}

--- a/src/main/java/io/floci/gcp/services/scheduler/SchedulerExpressionParser.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/SchedulerExpressionParser.java
@@ -1,0 +1,62 @@
+package io.floci.gcp.services.scheduler;
+
+import com.cronutils.model.CronType;
+import com.cronutils.model.Cron;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * Parses Cloud Scheduler {@code schedule} expressions and computes next fire times.
+ *
+ * Cloud Scheduler uses standard five-field unix-cron ({@code minute hour day-of-month
+ * month day-of-week}), interpreted in the job's {@code time_zone} (default UTC, with the
+ * proto-documented {@code "utc"} alias). The English-like schedule syntax (e.g.
+ * "every 2 hours") is not yet supported.
+ */
+public final class SchedulerExpressionParser {
+
+    private static final CronParser UNIX_PARSER =
+            new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
+
+    private SchedulerExpressionParser() {}
+
+    /**
+     * Returns the next fire instant strictly after {@code from} for a unix-cron expression
+     * evaluated in {@code timeZone} (default UTC).
+     */
+    public static Instant nextCronFire(String schedule, Instant from, String timeZone) {
+        if (schedule == null || schedule.isBlank()) {
+            throw new IllegalArgumentException("Schedule expression is empty");
+        }
+        Cron cron = UNIX_PARSER.parse(schedule.trim());
+        cron.validate();
+        ExecutionTime exec = ExecutionTime.forCron(cron);
+
+        ZonedDateTime zdt = from.atZone(resolveZone(timeZone));
+        return exec.nextExecution(zdt)
+                .map(ZonedDateTime::toInstant)
+                .orElseThrow(() -> new IllegalStateException(
+                        "No next fire time for schedule: " + schedule));
+    }
+
+    /** Validates a unix-cron expression, throwing IllegalArgumentException if malformed. */
+    public static void validate(String schedule) {
+        if (schedule == null || schedule.isBlank()) {
+            throw new IllegalArgumentException("Schedule expression is empty");
+        }
+        UNIX_PARSER.parse(schedule.trim()).validate();
+    }
+
+    private static ZoneId resolveZone(String timeZone) {
+        if (timeZone == null || timeZone.isBlank() || timeZone.equalsIgnoreCase("utc")) {
+            return ZoneOffset.UTC;
+        }
+        return ZoneId.of(timeZone);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/scheduler/SchedulerHttpController.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/SchedulerHttpController.java
@@ -1,0 +1,127 @@
+package io.floci.gcp.services.scheduler;
+
+import com.google.cloud.scheduler.v1.Job;
+import com.google.cloud.scheduler.v1.ListJobsResponse;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.ProtoJson;
+import io.floci.gcp.services.scheduler.model.StoredJob;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * REST (JSON) controller for the Cloud Scheduler v1 API, mirroring the {@code google.api.http}
+ * mappings in cloudscheduler.proto so gcloud / REST clients work unchanged. The gRPC path
+ * ({@link SchedulerController}) is the primary transport; this reuses the same proto&lt;-&gt;model
+ * mapping and {@link ProtoJson}. The {@code /jobs} paths don't collide with the other {@code /v1}
+ * controllers (KMS {@code /keyRings}, Secret Manager {@code /secrets}).
+ */
+@Path("/v1/projects/{project}/locations/{location}")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SchedulerHttpController {
+
+    @Inject
+    SchedulerService service;
+
+    @POST
+    @Path("/jobs")
+    public Response createJob(@PathParam("project") String project,
+            @PathParam("location") String location, String body) {
+        Job job = ProtoJson.merge(body, Job.newBuilder()).build();
+        StoredJob stored = service.createJob(parent(project, location), SchedulerController.fromJobProto(job));
+        return json(SchedulerController.toJobProto(stored));
+    }
+
+    @GET
+    @Path("/jobs")
+    public Response listJobs(@PathParam("project") String project,
+            @PathParam("location") String location,
+            @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+            @QueryParam("pageToken") String pageToken) {
+        List<StoredJob> all = service.listJobs(project, location);
+        PageToken.Page<StoredJob> page = PageToken.paginate(all, pageSize, pageToken);
+        ListJobsResponse.Builder resp = ListJobsResponse.newBuilder();
+        for (StoredJob j : page.items()) {
+            resp.addJobs(SchedulerController.toJobProto(j));
+        }
+        if (page.nextPageToken() != null) {
+            resp.setNextPageToken(page.nextPageToken());
+        }
+        return json(resp.build());
+    }
+
+    @GET
+    @Path("/jobs/{jobId}")
+    public Response getJob(@PathParam("project") String project,
+            @PathParam("location") String location, @PathParam("jobId") String jobId) {
+        return json(SchedulerController.toJobProto(service.getJob(jobName(project, location, jobId))));
+    }
+
+    @PATCH
+    @Path("/jobs/{jobId}")
+    public Response updateJob(@PathParam("project") String project,
+            @PathParam("location") String location, @PathParam("jobId") String jobId,
+            @QueryParam("updateMask") String updateMask, String body) {
+        Job job = ProtoJson.merge(body, Job.newBuilder().setName(jobName(project, location, jobId))).build();
+        List<String> mask = (updateMask == null || updateMask.isBlank())
+                ? List.of() : Arrays.asList(updateMask.split(","));
+        return json(SchedulerController.toJobProto(service.updateJob(SchedulerController.fromJobProto(job), mask)));
+    }
+
+    @DELETE
+    @Path("/jobs/{jobId}")
+    public Response deleteJob(@PathParam("project") String project,
+            @PathParam("location") String location, @PathParam("jobId") String jobId) {
+        service.deleteJob(jobName(project, location, jobId));
+        return Response.ok("{}", MediaType.APPLICATION_JSON).build();
+    }
+
+    @POST
+    @Path("/jobs/{jobId}:pause")
+    public Response pauseJob(@PathParam("project") String project,
+            @PathParam("location") String location, @PathParam("jobId") String jobId) {
+        return json(SchedulerController.toJobProto(service.pauseJob(jobName(project, location, jobId))));
+    }
+
+    @POST
+    @Path("/jobs/{jobId}:resume")
+    public Response resumeJob(@PathParam("project") String project,
+            @PathParam("location") String location, @PathParam("jobId") String jobId) {
+        return json(SchedulerController.toJobProto(service.resumeJob(jobName(project, location, jobId))));
+    }
+
+    @POST
+    @Path("/jobs/{jobId}:run")
+    public Response runJob(@PathParam("project") String project,
+            @PathParam("location") String location, @PathParam("jobId") String jobId) {
+        return json(SchedulerController.toJobProto(service.runJob(jobName(project, location, jobId))));
+    }
+
+    private static Response json(com.google.protobuf.MessageOrBuilder message) {
+        return Response.ok(ProtoJson.print(message), MediaType.APPLICATION_JSON).build();
+    }
+
+    private static String parent(String project, String location) {
+        return "projects/" + project + "/locations/" + location;
+    }
+
+    private static String jobName(String project, String location, String jobId) {
+        return parent(project, location) + "/jobs/" + jobId;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/SchedulerService.java
@@ -1,0 +1,258 @@
+package io.floci.gcp.services.scheduler;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.lifecycle.GrpcServerManager;
+import io.floci.gcp.services.scheduler.model.StoredJob;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class SchedulerService {
+
+    private static final Logger LOG = Logger.getLogger(SchedulerService.class);
+
+    private final StorageBackend<String, StoredJob> jobStore;
+    private final ScheduleInvoker invoker;
+
+    private final ServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+    private final GrpcServerManager grpcServerManager;
+
+    @Inject
+    public SchedulerService(ServiceRegistry serviceRegistry, EmulatorConfig config,
+            StorageFactory storageFactory, GrpcServerManager grpcServerManager,
+            ScheduleInvoker invoker) {
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+        this.grpcServerManager = grpcServerManager;
+        this.invoker = invoker;
+        this.jobStore = storageFactory.createGlobal("cloudscheduler-jobs", "cloudscheduler-jobs.json",
+                new TypeReference<Map<String, StoredJob>>() {});
+    }
+
+    SchedulerService(StorageBackend<String, StoredJob> jobStore, ScheduleInvoker invoker) {
+        this.jobStore = jobStore;
+        this.invoker = invoker;
+        this.serviceRegistry = null;
+        this.config = null;
+        this.grpcServerManager = null;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("scheduler")
+                .enabled(config.services().scheduler().enabled())
+                .storageKey("cloudscheduler")
+                .protocol(ServiceProtocol.GRPC)
+                .resourceClasses(SchedulerController.class)
+                .build());
+        grpcServerManager.bind(new SchedulerController(this));
+    }
+
+    // ── CRUD ─────────────────────────────────────────────────────────────────────
+
+    public StoredJob createJob(String parent, StoredJob job) {
+        String jobId = lastSegment(job.getName());
+        if (jobId == null || jobId.isBlank()) {
+            jobId = UUID.randomUUID().toString();
+        }
+        String name = parent + "/jobs/" + jobId;
+        LOG.infof("createJob name=%s", name);
+        if (jobStore.get(name).isPresent()) {
+            throw GcpException.alreadyExists("Job already exists: " + name);
+        }
+        validateSchedule(job.getSchedule());
+
+        String now = Instant.now().toString();
+        job.setName(name);
+        job.setState("ENABLED");
+        job.setCreateTime(now);
+        job.setUserUpdateTime(now);
+        job.setScheduleTime(computeNextScheduleTime(job, Instant.now()));
+        jobStore.put(name, job);
+        return job;
+    }
+
+    public StoredJob getJob(String name) {
+        LOG.debugf("getJob name=%s", name);
+        return jobStore.get(name)
+                .orElseThrow(() -> GcpException.notFound("Job not found: " + name));
+    }
+
+    public List<StoredJob> listJobs(String project, String location) {
+        LOG.debugf("listJobs project=%s location=%s", project, location);
+        String prefix = "projects/" + project + "/locations/" + location + "/jobs/";
+        return jobStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public List<StoredJob> listAllJobs() {
+        return jobStore.scan(k -> true);
+    }
+
+    public StoredJob updateJob(StoredJob incoming, List<String> updateMask) {
+        String name = incoming.getName();
+        LOG.infof("updateJob name=%s mask=%s", name, updateMask);
+        StoredJob existing = jobStore.get(name)
+                .orElseThrow(() -> GcpException.notFound("Job not found: " + name));
+
+        boolean all = updateMask == null || updateMask.isEmpty();
+        if (all || maskHas(updateMask, "description")) {
+            existing.setDescription(incoming.getDescription());
+        }
+        if (all || maskHas(updateMask, "schedule")) {
+            validateSchedule(incoming.getSchedule());
+            existing.setSchedule(incoming.getSchedule());
+        }
+        if (all || maskHas(updateMask, "time_zone", "timeZone")) {
+            existing.setTimeZone(incoming.getTimeZone());
+        }
+        if (all || maskHas(updateMask, "retry_config", "retryConfig")) {
+            existing.setRetryCount(incoming.getRetryCount());
+            existing.setMaxRetryDurationSeconds(incoming.getMaxRetryDurationSeconds());
+            existing.setMinBackoffSeconds(incoming.getMinBackoffSeconds());
+            existing.setMaxBackoffSeconds(incoming.getMaxBackoffSeconds());
+            existing.setMaxDoublings(incoming.getMaxDoublings());
+        }
+        if (all || maskHas(updateMask, "attempt_deadline", "attemptDeadline")) {
+            existing.setAttemptDeadlineSeconds(incoming.getAttemptDeadlineSeconds());
+        }
+        if (all || maskHasTargetUpdate(updateMask)) {
+            copyTarget(incoming, existing);
+        }
+
+        existing.setUserUpdateTime(Instant.now().toString());
+        existing.setScheduleTime(computeNextScheduleTime(existing, Instant.now()));
+        jobStore.put(name, existing);
+        return existing;
+    }
+
+    public void deleteJob(String name) {
+        LOG.infof("deleteJob name=%s", name);
+        if (jobStore.get(name).isEmpty()) {
+            throw GcpException.notFound("Job not found: " + name);
+        }
+        jobStore.delete(name);
+    }
+
+    // ── State + run ────────────────────────────────────────────────────────────────
+
+    public StoredJob pauseJob(String name) {
+        LOG.infof("pauseJob name=%s", name);
+        StoredJob job = getJob(name);
+        job.setState("PAUSED");
+        jobStore.put(name, job);
+        return job;
+    }
+
+    public StoredJob resumeJob(String name) {
+        LOG.infof("resumeJob name=%s", name);
+        StoredJob job = getJob(name);
+        job.setState("ENABLED");
+        job.setScheduleTime(computeNextScheduleTime(job, Instant.now()));
+        jobStore.put(name, job);
+        return job;
+    }
+
+    public StoredJob runJob(String name) {
+        LOG.infof("runJob name=%s", name);
+        StoredJob job = getJob(name);
+        recordAttempt(job, invoker.invoke(job));
+        jobStore.put(name, job);
+        return job;
+    }
+
+    /** Used by the background dispatcher to fire a due job and persist the attempt result. */
+    public void fireJob(StoredJob job, Instant scheduledFor) {
+        recordAttempt(job, invoker.invoke(job));
+        job.setScheduleTime(computeNextScheduleTime(job, scheduledFor));
+        jobStore.put(job.getName(), job);
+    }
+
+    private void recordAttempt(StoredJob job, ScheduleInvoker.InvokeResult result) {
+        job.setLastAttemptTime(Instant.now().toString());
+        job.setStatusCode(result.code());
+        job.setStatusMessage(result.message());
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────────
+
+    private void validateSchedule(String schedule) {
+        if (schedule == null || schedule.isBlank()) {
+            return; // schedule is required except on UpdateJob; leave enforcement to GCP-parity tests
+        }
+        try {
+            SchedulerExpressionParser.validate(schedule);
+        } catch (Exception e) {
+            throw GcpException.invalidArgument("Invalid schedule: " + schedule);
+        }
+    }
+
+    private String computeNextScheduleTime(StoredJob job, Instant from) {
+        if (job.getSchedule() == null || job.getSchedule().isBlank()) {
+            return null;
+        }
+        try {
+            return SchedulerExpressionParser.nextCronFire(job.getSchedule(), from, job.getTimeZone()).toString();
+        } catch (Exception e) {
+            LOG.warnf("Failed to compute next schedule time for %s: %s", job.getName(), e.getMessage());
+            return null;
+        }
+    }
+
+    private static void copyTarget(StoredJob from, StoredJob to) {
+        to.setTargetType(from.getTargetType());
+        to.setPubsubTopic(from.getPubsubTopic());
+        to.setPubsubData(from.getPubsubData());
+        to.setPubsubAttributes(from.getPubsubAttributes());
+        to.setHttpUri(from.getHttpUri());
+        to.setHttpMethod(from.getHttpMethod());
+        to.setHttpHeaders(from.getHttpHeaders());
+        to.setHttpBody(from.getHttpBody());
+        to.setAppEngineHttpMethod(from.getAppEngineHttpMethod());
+        to.setAppEngineRelativeUri(from.getAppEngineRelativeUri());
+        to.setAppEngineHeaders(from.getAppEngineHeaders());
+        to.setAppEngineBody(from.getAppEngineBody());
+        to.setAppEngineService(from.getAppEngineService());
+        to.setAppEngineVersion(from.getAppEngineVersion());
+        to.setAppEngineInstance(from.getAppEngineInstance());
+        to.setAppEngineHost(from.getAppEngineHost());
+    }
+
+    private static boolean maskHas(List<String> mask, String... paths) {
+        for (String p : mask) {
+            for (String want : paths) {
+                if (p.equals(want)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean maskHasTargetUpdate(List<String> mask) {
+        return maskHas(mask, "pubsub_target", "pubsubTarget", "http_target", "httpTarget",
+                "app_engine_http_target", "appEngineHttpTarget");
+    }
+
+    private static String lastSegment(String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        int idx = name.lastIndexOf('/');
+        return idx >= 0 ? name.substring(idx + 1) : name;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/scheduler/model/StoredJob.java
+++ b/src/main/java/io/floci/gcp/services/scheduler/model/StoredJob.java
@@ -1,0 +1,164 @@
+package io.floci.gcp.services.scheduler.model;
+
+
+import java.util.Map;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+
+public class StoredJob {
+
+    private String name;
+    private String description;
+
+    // "PUBSUB", "HTTP" or "APP_ENGINE"
+    private String targetType;
+
+    // PubsubTarget fields
+    private String pubsubTopic;
+    private byte[] pubsubData;
+    private Map<String, String> pubsubAttributes;
+
+    // HttpTarget fields
+    private String httpUri;
+    private String httpMethod;
+    private Map<String, String> httpHeaders;
+    private byte[] httpBody;
+
+    // AppEngineHttpTarget fields
+    private String appEngineHttpMethod;
+    private String appEngineRelativeUri;
+    private Map<String, String> appEngineHeaders;
+    private byte[] appEngineBody;
+    private String appEngineService;
+    private String appEngineVersion;
+    private String appEngineInstance;
+    private String appEngineHost;
+
+    private String schedule;
+    private String timeZone;
+
+    // "ENABLED", "PAUSED", "DISABLED", "UPDATE_FAILED"
+    private String state;
+
+    // RetryConfig fields
+    private int retryCount;
+    private long maxRetryDurationSeconds;
+    private long minBackoffSeconds;
+    private long maxBackoffSeconds;
+    private int maxDoublings;
+
+    private long attemptDeadlineSeconds;
+
+    // Timestamps (ISO-8601)
+    private String createTime;
+    private String userUpdateTime;
+    private String scheduleTime;
+    private String lastAttemptTime;
+
+    // Last attempt result (google.rpc.Status)
+    private int statusCode;
+    private String statusMessage;
+
+    public StoredJob() {
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String d) { this.description = d; }
+
+    public String getTargetType() { return targetType; }
+    public void setTargetType(String t) { this.targetType = t; }
+
+    public String getPubsubTopic() { return pubsubTopic; }
+    public void setPubsubTopic(String t) { this.pubsubTopic = t; }
+
+    public byte[] getPubsubData() { return pubsubData; }
+    public void setPubsubData(byte[] d) { this.pubsubData = d; }
+
+    public Map<String, String> getPubsubAttributes() { return pubsubAttributes; }
+    public void setPubsubAttributes(Map<String, String> a) { this.pubsubAttributes = a; }
+
+    public String getHttpUri() { return httpUri; }
+    public void setHttpUri(String u) { this.httpUri = u; }
+
+    public String getHttpMethod() { return httpMethod; }
+    public void setHttpMethod(String m) { this.httpMethod = m; }
+
+    public Map<String, String> getHttpHeaders() { return httpHeaders; }
+    public void setHttpHeaders(Map<String, String> h) { this.httpHeaders = h; }
+
+    public byte[] getHttpBody() { return httpBody; }
+    public void setHttpBody(byte[] b) { this.httpBody = b; }
+
+    public String getAppEngineHttpMethod() { return appEngineHttpMethod; }
+    public void setAppEngineHttpMethod(String m) { this.appEngineHttpMethod = m; }
+
+    public String getAppEngineRelativeUri() { return appEngineRelativeUri; }
+    public void setAppEngineRelativeUri(String u) { this.appEngineRelativeUri = u; }
+
+    public Map<String, String> getAppEngineHeaders() { return appEngineHeaders; }
+    public void setAppEngineHeaders(Map<String, String> h) { this.appEngineHeaders = h; }
+
+    public byte[] getAppEngineBody() { return appEngineBody; }
+    public void setAppEngineBody(byte[] b) { this.appEngineBody = b; }
+
+    public String getAppEngineService() { return appEngineService; }
+    public void setAppEngineService(String s) { this.appEngineService = s; }
+
+    public String getAppEngineVersion() { return appEngineVersion; }
+    public void setAppEngineVersion(String v) { this.appEngineVersion = v; }
+
+    public String getAppEngineInstance() { return appEngineInstance; }
+    public void setAppEngineInstance(String i) { this.appEngineInstance = i; }
+
+    public String getAppEngineHost() { return appEngineHost; }
+    public void setAppEngineHost(String h) { this.appEngineHost = h; }
+
+    public String getSchedule() { return schedule; }
+    public void setSchedule(String s) { this.schedule = s; }
+
+    public String getTimeZone() { return timeZone; }
+    public void setTimeZone(String t) { this.timeZone = t; }
+
+    public String getState() { return state; }
+    public void setState(String s) { this.state = s; }
+
+    public int getRetryCount() { return retryCount; }
+    public void setRetryCount(int n) { this.retryCount = n; }
+
+    public long getMaxRetryDurationSeconds() { return maxRetryDurationSeconds; }
+    public void setMaxRetryDurationSeconds(long s) { this.maxRetryDurationSeconds = s; }
+
+    public long getMinBackoffSeconds() { return minBackoffSeconds; }
+    public void setMinBackoffSeconds(long s) { this.minBackoffSeconds = s; }
+
+    public long getMaxBackoffSeconds() { return maxBackoffSeconds; }
+    public void setMaxBackoffSeconds(long s) { this.maxBackoffSeconds = s; }
+
+    public int getMaxDoublings() { return maxDoublings; }
+    public void setMaxDoublings(int n) { this.maxDoublings = n; }
+
+    public long getAttemptDeadlineSeconds() { return attemptDeadlineSeconds; }
+    public void setAttemptDeadlineSeconds(long s) { this.attemptDeadlineSeconds = s; }
+
+    public String getCreateTime() { return createTime; }
+    public void setCreateTime(String t) { this.createTime = t; }
+
+    public String getUserUpdateTime() { return userUpdateTime; }
+    public void setUserUpdateTime(String t) { this.userUpdateTime = t; }
+
+    public String getScheduleTime() { return scheduleTime; }
+    public void setScheduleTime(String t) { this.scheduleTime = t; }
+
+    public String getLastAttemptTime() { return lastAttemptTime; }
+    public void setLastAttemptTime(String t) { this.lastAttemptTime = t; }
+
+    public int getStatusCode() { return statusCode; }
+    public void setStatusCode(int c) { this.statusCode = c; }
+
+    public String getStatusMessage() { return statusMessage; }
+    public void setStatusMessage(String m) { this.statusMessage = m; }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ quarkus:
       - --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32
       - --initialize-at-run-time=io.floci.gcp.services.cloudkms.KmsCrypto
       - --initialize-at-run-time=io.floci.gcp.services.cloudsql.CloudSqlPostgresDataPlane
+      - --initialize-at-run-time=io.floci.gcp.services.scheduler.SchedulerExpressionParser
 
 floci-gcp:
   port: 4588
@@ -89,6 +90,10 @@ floci-gcp:
       enabled: true
     monitoring:
       enabled: true
+    scheduler:
+      enabled: true
+      invocation-enabled: true
+      tick-interval-seconds: 10
   dns:
     extra-suffixes:
   docker:

--- a/src/test/java/io/floci/gcp/services/scheduler/SchedulerExpressionParserTest.java
+++ b/src/test/java/io/floci/gcp/services/scheduler/SchedulerExpressionParserTest.java
@@ -1,0 +1,35 @@
+package io.floci.gcp.services.scheduler;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchedulerExpressionParserTest {
+
+    @Test
+    void nextCronFireIsStrictlyAfterFrom() {
+        Instant from = Instant.parse("2026-01-01T00:00:00Z");
+        Instant next = SchedulerExpressionParser.nextCronFire("*/5 * * * *", from, "utc");
+        assertEquals(Instant.parse("2026-01-01T00:05:00Z"), next);
+    }
+
+    @Test
+    void nextCronFireHonoursTimeZone() {
+        // "0 9 * * *" = 09:00 local; in America/New_York that is 14:00Z (standard time, Jan).
+        Instant from = Instant.parse("2026-01-01T00:00:00Z");
+        Instant next = SchedulerExpressionParser.nextCronFire("0 9 * * *", from, "America/New_York");
+        assertEquals(Instant.parse("2026-01-01T14:00:00Z"), next);
+    }
+
+    @Test
+    void validateRejectsGarbage() {
+        assertThrows(RuntimeException.class, () -> SchedulerExpressionParser.validate("not a cron"));
+    }
+
+    @Test
+    void validateAcceptsStandardUnixCron() {
+        assertDoesNotThrow(() -> SchedulerExpressionParser.validate("0 */2 * * *"));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/scheduler/SchedulerServiceTest.java
@@ -1,0 +1,109 @@
+package io.floci.gcp.services.scheduler;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.scheduler.model.StoredJob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchedulerServiceTest {
+
+    private static final String PARENT = "projects/p1/locations/us-central1";
+    private static final String NAME = PARENT + "/jobs/j1";
+
+    private SchedulerService service;
+
+    @BeforeEach
+    void setUp() {
+        // ScheduleInvoker with a null Pub/Sub backend; only the HTTP/no-op paths are exercised
+        // here, and invoke() never throws (it records failures as a status instead).
+        service = new SchedulerService(new InMemoryStorage<>(), new ScheduleInvoker(null, true));
+    }
+
+    private StoredJob pubsubJob(String jobId) {
+        StoredJob job = new StoredJob();
+        job.setName(jobId);
+        job.setSchedule("*/5 * * * *");
+        job.setTargetType("PUBSUB");
+        job.setPubsubTopic("projects/p1/topics/t1");
+        job.setPubsubData("hi".getBytes());
+        return job;
+    }
+
+    @Test
+    void createJobDefaultsToEnabledAndComputesScheduleTime() {
+        StoredJob created = service.createJob(PARENT, pubsubJob("j1"));
+        assertEquals(NAME, created.getName());
+        assertEquals("ENABLED", created.getState());
+        assertNotNull(created.getCreateTime());
+        assertNotNull(created.getScheduleTime(), "next schedule time should be computed from cron");
+    }
+
+    @Test
+    void createJobDuplicateThrowsAlreadyExists() {
+        service.createJob(PARENT, pubsubJob("j1"));
+        GcpException ex = assertThrows(GcpException.class, () -> service.createJob(PARENT, pubsubJob("j1")));
+        assertEquals("ALREADY_EXISTS", ex.getGcpStatus());
+    }
+
+    @Test
+    void createJobInvalidScheduleThrowsInvalidArgument() {
+        StoredJob job = pubsubJob("bad");
+        job.setSchedule("not a cron");
+        GcpException ex = assertThrows(GcpException.class, () -> service.createJob(PARENT, job));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void getJobMissingThrowsNotFound() {
+        GcpException ex = assertThrows(GcpException.class, () -> service.getJob(NAME));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void listJobsReturnsCreated() {
+        service.createJob(PARENT, pubsubJob("j1"));
+        service.createJob(PARENT, pubsubJob("j2"));
+        List<StoredJob> jobs = service.listJobs("p1", "us-central1");
+        assertEquals(2, jobs.size());
+    }
+
+    @Test
+    void pauseThenResumeFlipsState() {
+        service.createJob(PARENT, pubsubJob("j1"));
+        assertEquals("PAUSED", service.pauseJob(NAME).getState());
+        assertEquals("ENABLED", service.resumeJob(NAME).getState());
+    }
+
+    @Test
+    void updateJobAppliesDescriptionViaMask() {
+        service.createJob(PARENT, pubsubJob("j1"));
+        StoredJob incoming = new StoredJob();
+        incoming.setName(NAME);
+        incoming.setDescription("updated");
+        StoredJob updated = service.updateJob(incoming, List.of("description"));
+        assertEquals("updated", updated.getDescription());
+    }
+
+    @Test
+    void deleteJobRemovesIt() {
+        service.createJob(PARENT, pubsubJob("j1"));
+        service.deleteJob(NAME);
+        GcpException ex = assertThrows(GcpException.class, () -> service.getJob(NAME));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void runJobRecordsAttempt() {
+        StoredJob job = pubsubJob("j1");
+        job.setTargetType("HTTP");
+        job.setHttpUri("http://127.0.0.1:1/"); // connection refused -> recorded as failed attempt
+        service.createJob(PARENT, job);
+        StoredJob ran = service.runJob(NAME);
+        assertNotNull(ran.getLastAttemptTime(), "runJob must record a last-attempt time");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,5 +37,9 @@ floci-gcp:
       enabled: true
     monitoring:
       enabled: true
+    scheduler:
+      enabled: true
+      invocation-enabled: true
+      tick-interval-seconds: 1
   docker:
     api-timeout: 30s


### PR DESCRIPTION
## Summary

Implements Cloud Scheduler using the real `google.cloud.scheduler.v1` wire protocol on port 4588, over **gRPC** (`CloudSchedulerImplBase`) and **REST JSON** (`/v1/projects/{project}/locations/{location}/jobs`).

- Full job control plane: create, get, list, update, delete, pause, resume, run.
- Cron schedules parsed by `SchedulerExpressionParser`; jobs persisted as `StoredJob` via `StorageFactory`.
- Background `ScheduleDispatcher` fires due jobs each tick (configurable), gated by `services.scheduler.invocation-enabled`; `RunJob` always dispatches. `ScheduleInvoker` delivers `PubsubTarget` to the local Pub/Sub backend, performs real outbound `HttpTarget` requests, and records `AppEngineHttpTarget` best-effort (no App Engine backend).
- Config: `services.scheduler.enabled` / `invocation-enabled` / `tick-interval-seconds`, wired through `EmulatorConfig` and `application.yml`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Implements `google.cloud.scheduler.v1.CloudScheduler`. Verified with the Google Cloud Java SDK (`CloudSchedulerClient`) via the `sdk-test-java` compatibility suite (`SchedulerTest`), plus unit coverage of the cron parser and service logic.

## Checklist

- [x] `./mvnw test` passes locally (13 scheduler unit tests; full project compiles — pre-existing Docker ITs excepted)
- [x] New or updated integration test added (CloudScheduler SDK compat test + service/parser unit tests; matches the monitoring service's test bar)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)