### PR TITLE
feat(config)!: standardize root-level mock flag for container services

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -100,7 +100,7 @@ jobs:
             -e FLOCI_GCP_HOSTNAME=floci-gcp \
             -e FLOCI_GCP_SERVICES_DOCKER_NETWORK=compat-net \
             -e FLOCI_GCP_SERVICES_KAFKA_MOCK="$KAFKA_MOCK" \
-            -e FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED=true \
+            -e FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=false \
             floci-gcp:test
 
       - name: Wait for floci-gcp to be ready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,19 @@ When adding functionality:
 7. Add tests
 8. Update documentation
 
+### Services with container sidecars
+
+If the service launches real Docker containers (sidecars / data planes), it
+**must** expose a single root-level `mock` flag on its `*ServiceConfig`
+(`boolean mock();`) that keeps the service metadata-only without Docker —
+mirroring `kafka.mock`, `cloudsql.mock`, and `cloudrun.mock` (env var
+`FLOCI_GCP_SERVICES_<SVC>_MOCK`). Gate every container interaction in the
+service layer on `!mock()` (keep the Docker driver/manager class free of the
+flag). Do not add a separate `enabled`-style opt-in for the container path — the
+`mock` flag is the only toggle, defaulting to `false` (`kafka.mock`,
+`cloudsql.mock`, `cloudrun.mock` all default `false`). Always set `mock: true`
+in `src/test/resources/application.yml` so the suite never starts containers.
+
 ---
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -581,13 +581,12 @@ All settings are overridable via environment variables (`FLOCI_GCP_` prefix).
 | `FLOCI_GCP_SERVICES_IAM_ENABLED` | `true` | Enable/disable IAM |
 | `FLOCI_GCP_SERVICES_SECRETMANAGER_ENABLED` | `true` | Enable/disable Secret Manager |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Enable/disable Cloud Run |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED` | `false` | Enable experimental Docker-backed Cloud Run execution |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_MOCK` | `false` | Keep Cloud Run execution metadata-only without Docker |
+| `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK` | `false` | Use mock mode (no Docker; Cloud Run control plane only, no execution containers) |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Enable/disable Cloud Functions |
 | `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Enable/disable Cloud Tasks |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Enable/disable Managed Kafka |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
-| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL instances for Cloud SQL |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` | `false` | Use mock mode (no Docker; Cloud SQL control plane only, no PostgreSQL containers) |
 | `FLOCI_GCP_SERVICES_KAFKA_MOCK` | `false` | Use mock mode (no Docker; returns `ACTIVE` immediately) |
 | `FLOCI_GCP_DNS_EXTRA_SUFFIXES` | *(unset)* | Extra DNS suffixes for embedded DNS (comma-separated) |
 

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -85,7 +85,7 @@ floci-gcp:
 
     cloudsql:
       enabled: true
-      data-plane-enabled: true
+      mock: false
       postgres15-image: "postgres:15.18-alpine"
       postgres16-image: "postgres:16.14-alpine"
       postgres17-image: "postgres:17.10-alpine"

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -61,10 +61,9 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Cloud Tasks |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Managed Service for Apache Kafka |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Cloud SQL for PostgreSQL |
-| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL data-plane instances |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` | `false` | Mock mode — no Docker-backed PostgreSQL data-plane instances |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Cloud Run |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED` | `false` | Experimental Cloud Run service execution |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_MOCK` | `false` | Keep execution-mode services metadata-only without starting Docker containers |
+| `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK` | `false` | Mock mode — control plane only, no Docker-backed execution containers |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_DEFAULT_PORT` | `8080` | Default Cloud Run runtime container port |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_STARTUP_TIMEOUT` | `240s` | Cloud Run runtime startup timeout |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_REQUEST_TIMEOUT` | `300s` | Cloud Run invocation proxy timeout |
@@ -94,7 +93,7 @@ Some services (e.g. Managed Kafka) start real sidecar containers via the host Do
 
 | Variable | Default | Description |
 |---|---|---|
-| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | When `true`, Cloud SQL instances start Docker-backed PostgreSQL containers |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` | `false` | When `true`, emulate the Cloud SQL control plane only — no Docker-backed PostgreSQL containers are started |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES15_IMAGE` | `postgres:15.18-alpine` | Docker image used for `POSTGRES_15` instances |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES16_IMAGE` | `postgres:16.14-alpine` | Docker image used for `POSTGRES_16` instances |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES17_IMAGE` | `postgres:17.10-alpine` | Docker image used for `POSTGRES_17` instances |

--- a/docs/services/cloud-run.md
+++ b/docs/services/cloud-run.md
@@ -5,8 +5,7 @@ floci-gcp emulates the Cloud Run Admin API v2 control plane over REST JSON using
 | Config | Default | Description |
 |---|---|---|
 | `FLOCI_GCP_SERVICES_CLOUDRUN_ENABLED` | `true` | Enable/disable Cloud Run |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED` | `false` | Enable experimental image-based service execution |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_MOCK` | `false` | Keep execution-mode services metadata-only without starting Docker containers |
+| `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK` | `false` | Mock mode — control plane only, no Docker-backed image-based service execution |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_DEFAULT_PORT` | `8080` | Container port used when the service template omits a port |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_STARTUP_TIMEOUT` | `240s` | Time to wait for the container TCP port to become reachable |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_REQUEST_TIMEOUT` | `300s` | Default invocation proxy timeout |
@@ -34,9 +33,9 @@ When execution is disabled, create, update, and delete return completed `google.
 
 ## Behavior
 
-By default Cloud Run services are metadata only. Creating a service synthesizes the service URL, timestamps, etag, ready condition, traffic status, latest revision fields, and one read-only revision. No container image is pulled and no request-serving runtime is started.
+In mock mode (`FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=true`) Cloud Run services are metadata only. Creating a service synthesizes the service URL, timestamps, etag, ready condition, traffic status, latest revision fields, and one read-only revision. No container image is pulled and no request-serving runtime is started.
 
-Execution is experimental and opt-in with `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED=true`. Set `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_MOCK=true` to keep services metadata-only even when the execution flag is enabled. Mock execution does not start Docker containers or apply execution-mode template validation. In non-mock execution mode, image-based service creation starts one Docker container for the created revision, injects `PORT`, `K_SERVICE`, `K_REVISION`, and `K_CONFIGURATION`, waits for the ingress TCP port, and returns a deterministic app-root invocation URL on the floci-gcp front door:
+Image-based service execution runs by default (`FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=false`); set `mock=true` to keep services metadata-only — no Docker containers and no execution-mode template validation. In execution mode, image-based service creation starts one Docker container for the created revision, injects `PORT`, `K_SERVICE`, `K_REVISION`, and `K_CONFIGURATION`, waits for the ingress TCP port, and returns a deterministic app-root invocation URL on the floci-gcp front door:
 
 ```text
 http://{service}-{project-token}.{location}.run.localhost.floci.io:4588

--- a/docs/services/cloud-sql-postgres.md
+++ b/docs/services/cloud-sql-postgres.md
@@ -6,7 +6,7 @@ data-plane instances in Docker-backed `postgres` containers.
 | Config | Default | Description |
 |---|---|---|
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Enable/disable Cloud SQL for PostgreSQL |
-| `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` | `true` | Start Docker-backed PostgreSQL instances for Cloud SQL resources |
+| `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` | `false` | Mock mode — emulate Cloud SQL resources without Docker-backed PostgreSQL instances |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES15_IMAGE` | `postgres:15.18-alpine` | Docker image for `POSTGRES_15` instances |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES16_IMAGE` | `postgres:16.14-alpine` | Docker image for `POSTGRES_16` instances |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES17_IMAGE` | `postgres:17.10-alpine` | Docker image for `POSTGRES_17` instances |

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -161,8 +161,8 @@ public interface EmulatorConfig {
         @WithDefault("true")
         boolean enabled();
 
-        @WithDefault("true")
-        boolean dataPlaneEnabled();
+        @WithDefault("false")
+        boolean mock();
 
         @WithDefault("postgres:15.18-alpine")
         String postgres15Image();
@@ -189,15 +189,12 @@ public interface EmulatorConfig {
         @WithDefault("true")
         boolean enabled();
 
+        @WithDefault("false")
+        boolean mock();
+
         ExecutionConfig execution();
 
         interface ExecutionConfig {
-            @WithDefault("false")
-            boolean enabled();
-
-            @WithDefault("false")
-            boolean mock();
-
             @WithDefault("8080")
             int defaultPort();
 

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeService.java
@@ -99,7 +99,7 @@ public class CloudRunRuntimeService {
                                          com.google.cloud.run.v2.Service service,
                                          Revision revision) {
         validateSupported(revision);
-        if (config.services().cloudrun().execution().mock()) {
+        if (config.services().cloudrun().mock()) {
             throw GcpException.unimplemented("Cloud Run execution mock mode does not start runtime containers");
         }
 

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -738,8 +738,7 @@ public class CloudRunService {
     private boolean executionEnabled() {
         return config != null
                 && runtimeService != null
-                && config.services().cloudrun().execution().enabled()
-                && !config.services().cloudrun().execution().mock();
+                && !config.services().cloudrun().mock();
     }
 
     private Duration operationTimeout() {

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlService.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlService.java
@@ -62,7 +62,7 @@ public class CloudSqlService {
         this.objectMapper = objectMapper;
         this.baseUrl = config.effectiveBaseUrl();
         this.dataPlane = dataPlane;
-        this.dataPlaneEnabled = config.services().cloudsql().dataPlaneEnabled();
+        this.dataPlaneEnabled = !config.services().cloudsql().mock();
     }
 
     CloudSqlService(StorageBackend<String, Map<String, Object>> instanceStore,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ floci-gcp:
       default-image: "redpandadata/redpanda:latest"
     cloudsql:
       enabled: true
-      data-plane-enabled: true
+      mock: false
       postgres15-image: "postgres:15.18-alpine"
       postgres16-image: "postgres:16.14-alpine"
       postgres17-image: "postgres:17.10-alpine"
@@ -76,9 +76,8 @@ floci-gcp:
       enabled: true
     cloudrun:
       enabled: true
+      mock: false
       execution:
-        enabled: false
-        mock: false
         default-port: 8080
         startup-timeout: 240s
         request-timeout: 300s

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunExecutionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunExecutionRestIntegrationTest.java
@@ -402,7 +402,7 @@ class CloudRunExecutionRestIntegrationTest {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "floci-gcp.services.cloudrun.execution.enabled", "true",
+                    "floci-gcp.services.cloudrun.mock", "false",
                     "floci-gcp.services.cloudrun.execution.startup-timeout", "60s");
         }
     }

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeServiceTest.java
@@ -47,7 +47,7 @@ class CloudRunRuntimeServiceTest {
     void setUp() {
         config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
         when(config.services().dockerNetwork()).thenReturn(Optional.empty());
-        when(config.services().cloudrun().execution().mock()).thenReturn(false);
+        when(config.services().cloudrun().mock()).thenReturn(false);
         when(config.services().cloudrun().execution().defaultPort()).thenReturn(8080);
         when(config.services().cloudrun().execution().startupTimeout()).thenReturn(Duration.ofSeconds(1));
         when(config.services().cloudrun().execution().requestTimeout()).thenReturn(Duration.ofSeconds(300));

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
@@ -621,8 +621,7 @@ class CloudRunServiceTest {
 
     private static EmulatorConfig cloudRunConfig(boolean executionEnabled, Duration operationTimeout, boolean mockMode) {
         EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
-        when(config.services().cloudrun().execution().enabled()).thenReturn(executionEnabled);
-        when(config.services().cloudrun().execution().mock()).thenReturn(mockMode);
+        when(config.services().cloudrun().mock()).thenReturn(!executionEnabled || mockMode);
         when(config.services().cloudrun().execution().operationTimeout()).thenReturn(operationTimeout);
         when(config.services().cloudrun().execution().cleanupTimeout()).thenReturn(Duration.ofSeconds(15));
         when(config.effectiveBaseUrl()).thenReturn("http://localhost:4588");

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlDataPlaneIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlDataPlaneIntegrationTest.java
@@ -138,7 +138,7 @@ class CloudSqlDataPlaneIntegrationTest {
     public static class DataPlaneProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
-            return Map.of("floci-gcp.services.cloudsql.data-plane-enabled", "true");
+            return Map.of("floci-gcp.services.cloudsql.mock", "false");
         }
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,14 +18,13 @@ floci-gcp:
       mock: true
     cloudsql:
       enabled: true
-      data-plane-enabled: false
+      mock: true
     cloudtasks:
       enabled: true
     cloudrun:
       enabled: true
+      mock: true
       execution:
-        enabled: false
-        mock: false
         default-port: 8080
         startup-timeout: 240s
         request-timeout: 300s


### PR DESCRIPTION
## Summary

Standardizes a single root-level `mock` flag (`FLOCI_GCP_SERVICES_<SVC>_MOCK`, default `false`) across all three container-sidecar services so they behave uniformly:

- **Cloud SQL**: `cloudsql.data-plane-enabled` (default true) → `cloudsql.mock` (default false, inverted). Behavior unchanged.
- **Cloud Run**: `cloudrun.execution.mock` moved to the service root as `cloudrun.mock`, and the separate `cloudrun.execution.enabled` opt-in removed — Docker-backed execution is now gated solely by `!mock()`.
- **Managed Kafka**: already used `kafka.mock`.

Test config sets `mock: true` for all three so the suite never starts containers; CI compat enables Cloud Run execution via `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=false`. The convention is documented in `AGENTS.md` for future sidecar services.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [x] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Config-only; no wire-protocol change. Cloud SQL behavior is identical (pure rename/inversion). **Cloud Run image-based execution now defaults ON** (gated by `cloudrun.mock`, default `false`); set `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=true` for control-plane-only behavior. CI compat sets `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=false`.

### Breaking changes (env vars renamed, no aliases)

- `FLOCI_GCP_SERVICES_CLOUDSQL_DATA_PLANE_ENABLED` → `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` (inverted value)
- `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_MOCK` → `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK`
- `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_ENABLED` removed — Cloud Run execution is now controlled by `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK`

## Checklist

- [x] `./mvnw test` passes locally (64 Cloud Run + Cloud SQL tests; Docker-backed `*ExecutionRestIntegrationTest` / `*DataPlaneIntegrationTest` need Docker — pre-existing failures on `main`)
- [x] New or updated integration test added (existing tests updated for the new flags)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)