### PR TITLE
feat: add Pub/Sub REST API

### DIFF
--- a/docs/services/pubsub.md
+++ b/docs/services/pubsub.md
@@ -1,6 +1,7 @@
 # Pub/Sub
 
 floci-gcp emulates Google Cloud Pub/Sub over gRPC using the real `google.pubsub.v1` protocol.
+It also exposes the Pub/Sub REST v1 JSON surface used by tools such as Terraform.
 
 ## Configuration
 
@@ -15,6 +16,32 @@ export PUBSUB_EMULATOR_HOST=localhost:4588
 ```
 
 GCP Pub/Sub SDK clients use this variable to route requests to floci-gcp instead of `pubsub.googleapis.com`.
+
+## REST / Terraform Endpoint
+
+Terraform's Google provider can use the REST endpoint with:
+
+```hcl
+provider "google" {
+  pubsub_custom_endpoint = "http://localhost:4588/v1/"
+}
+```
+
+The REST surface supports topic and subscription create/read/list/update/delete, publish, pull, and acknowledge:
+
+- `PUT /v1/projects/{project}/topics/{topic}`
+- `GET /v1/projects/{project}/topics/{topic}`
+- `GET /v1/projects/{project}/topics`
+- `PATCH /v1/projects/{project}/topics/{topic}?updateMask=...`
+- `DELETE /v1/projects/{project}/topics/{topic}`
+- `POST /v1/projects/{project}/topics/{topic}:publish`
+- `PUT /v1/projects/{project}/subscriptions/{subscription}`
+- `GET /v1/projects/{project}/subscriptions/{subscription}`
+- `GET /v1/projects/{project}/subscriptions`
+- `PATCH /v1/projects/{project}/subscriptions/{subscription}?updateMask=...`
+- `DELETE /v1/projects/{project}/subscriptions/{subscription}`
+- `POST /v1/projects/{project}/subscriptions/{subscription}:pull`
+- `POST /v1/projects/{project}/subscriptions/{subscription}:acknowledge`
 
 ## Quick Start
 

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
@@ -1,0 +1,426 @@
+package io.floci.gcp.services.pubsub;
+
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.ReceivedMessage;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.services.pubsub.model.StoredSubscription;
+import io.floci.gcp.services.pubsub.model.StoredTopic;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Path("/v1/projects/{project}")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PubSubRestController {
+
+    private static final Logger LOG = Logger.getLogger(PubSubRestController.class);
+
+    private final PubSubService service;
+
+    PubSubRestController() {
+        this.service = null;
+    }
+
+    @Inject
+    public PubSubRestController(PubSubService service) {
+        this.service = service;
+    }
+
+    @PUT
+    @Path("/topics/{topic}")
+    public Response createTopic(@PathParam("project") String project,
+                                @PathParam("topic") String topicId,
+                                Map<String, Object> body) {
+        String name = topicName(project, topicId);
+        LOG.infof("REST create Pub/Sub topic name=%s", name);
+        StoredTopic topic = service.createTopic(name, stringMap(body, "labels"),
+                stringValue(body, "messageRetentionDuration"));
+        return Response.ok(topicResponse(topic)).build();
+    }
+
+    @GET
+    @Path("/topics/{topic}")
+    public Response getTopic(@PathParam("project") String project,
+                             @PathParam("topic") String topicId) {
+        return Response.ok(topicResponse(service.getTopic(topicName(project, topicId)))).build();
+    }
+
+    @GET
+    @Path("/topics")
+    public Response listTopics(@PathParam("project") String project,
+                               @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                               @QueryParam("pageToken") String pageToken) {
+        PageToken.Page<StoredTopic> page = PageToken.paginate(
+                service.listTopics(project), pageSize, pageToken);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("topics", page.items().stream()
+                .map(PubSubRestController::topicResponse)
+                .toList());
+        if (page.nextPageToken() != null) {
+            response.put("nextPageToken", page.nextPageToken());
+        }
+        return Response.ok(response).build();
+    }
+
+    @PATCH
+    @Path("/topics/{topic}")
+    public Response updateTopic(@PathParam("project") String project,
+                                @PathParam("topic") String topicId,
+                                @QueryParam("updateMask") String updateMask,
+                                Map<String, Object> body) {
+        StoredTopic topic = service.updateTopic(topicName(project, topicId),
+                stringMap(body, "labels"), stringValue(body, "messageRetentionDuration"),
+                updateMaskPaths(updateMask));
+        return Response.ok(topicResponse(topic)).build();
+    }
+
+    @DELETE
+    @Path("/topics/{topic}")
+    @Consumes(MediaType.WILDCARD)
+    public Response deleteTopic(@PathParam("project") String project,
+                                @PathParam("topic") String topicId) {
+        service.deleteTopic(topicName(project, topicId));
+        return Response.ok(Map.of()).build();
+    }
+
+    @POST
+    @Path("/topics/{topic}:publish")
+    public Response publish(@PathParam("project") String project,
+                            @PathParam("topic") String topicId,
+                            Map<String, Object> body) {
+        List<PubsubMessage> messages = messages(body);
+        List<String> ids = service.publish(topicName(project, topicId), messages);
+        return Response.ok(Map.of("messageIds", ids)).build();
+    }
+
+    @PUT
+    @Path("/subscriptions/{subscription}")
+    public Response createSubscription(@PathParam("project") String project,
+                                       @PathParam("subscription") String subscriptionId,
+                                       Map<String, Object> body) {
+        String name = subscriptionName(project, subscriptionId);
+        String topic = stringValue(body, "topic");
+        LOG.infof("REST create Pub/Sub subscription name=%s topic=%s", name, topic);
+        StoredSubscription subscription = service.createSubscription(
+                name,
+                topic,
+                intValue(body, "ackDeadlineSeconds"),
+                stringMap(body, "labels"),
+                booleanValue(body, "retainAckedMessages"),
+                stringValue(body, "messageRetentionDuration"),
+                stringValue(body, "filter"),
+                pushEndpoint(body),
+                objectMap(body, "bigqueryConfig"),
+                objectMap(body, "expirationPolicy"),
+                objectMap(body, "retryPolicy"),
+                deadLetterTopic(body),
+                maxDeliveryAttempts(body),
+                booleanValue(body, "enableMessageOrdering"),
+                booleanValue(body, "enableExactlyOnceDelivery"));
+        return Response.ok(subscriptionResponse(subscription)).build();
+    }
+
+    @GET
+    @Path("/subscriptions/{subscription}")
+    public Response getSubscription(@PathParam("project") String project,
+                                    @PathParam("subscription") String subscriptionId) {
+        return Response.ok(subscriptionResponse(
+                service.getSubscription(subscriptionName(project, subscriptionId)))).build();
+    }
+
+    @GET
+    @Path("/subscriptions")
+    public Response listSubscriptions(@PathParam("project") String project,
+                                      @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                                      @QueryParam("pageToken") String pageToken) {
+        PageToken.Page<StoredSubscription> page = PageToken.paginate(
+                service.listSubscriptions(project), pageSize, pageToken);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("subscriptions", page.items().stream()
+                .map(PubSubRestController::subscriptionResponse)
+                .toList());
+        if (page.nextPageToken() != null) {
+            response.put("nextPageToken", page.nextPageToken());
+        }
+        return Response.ok(response).build();
+    }
+
+    @PATCH
+    @Path("/subscriptions/{subscription}")
+    public Response updateSubscription(@PathParam("project") String project,
+                                       @PathParam("subscription") String subscriptionId,
+                                       @QueryParam("updateMask") String updateMask,
+                                       Map<String, Object> body) {
+        StoredSubscription subscription = service.updateSubscription(
+                subscriptionName(project, subscriptionId),
+                intValue(body, "ackDeadlineSeconds"),
+                stringMap(body, "labels"),
+                optionalBooleanValue(body, "retainAckedMessages"),
+                stringValue(body, "messageRetentionDuration"),
+                stringValue(body, "filter"),
+                pushEndpoint(body),
+                objectMap(body, "bigqueryConfig"),
+                objectMap(body, "expirationPolicy"),
+                objectMap(body, "retryPolicy"),
+                deadLetterTopic(body),
+                maxDeliveryAttempts(body) == 0 ? null : maxDeliveryAttempts(body),
+                optionalBooleanValue(body, "enableMessageOrdering"),
+                optionalBooleanValue(body, "enableExactlyOnceDelivery"),
+                updateMaskPaths(updateMask));
+        return Response.ok(subscriptionResponse(subscription)).build();
+    }
+
+    @DELETE
+    @Path("/subscriptions/{subscription}")
+    @Consumes(MediaType.WILDCARD)
+    public Response deleteSubscription(@PathParam("project") String project,
+                                       @PathParam("subscription") String subscriptionId) {
+        service.deleteSubscription(subscriptionName(project, subscriptionId));
+        return Response.ok(Map.of()).build();
+    }
+
+    @POST
+    @Path("/subscriptions/{subscription}:pull")
+    public Response pull(@PathParam("project") String project,
+                         @PathParam("subscription") String subscriptionId,
+                         Map<String, Object> body) {
+        int maxMessages = intValue(body, "maxMessages");
+        List<Map<String, Object>> messages = service.pull(
+                        subscriptionName(project, subscriptionId), maxMessages > 0 ? maxMessages : 1)
+                .stream()
+                .map(PubSubRestController::receivedMessageResponse)
+                .toList();
+        return Response.ok(Map.of("receivedMessages", messages)).build();
+    }
+
+    @POST
+    @Path("/subscriptions/{subscription}:acknowledge")
+    public Response acknowledge(@PathParam("project") String project,
+                                @PathParam("subscription") String subscriptionId,
+                                Map<String, Object> body) {
+        service.acknowledge(subscriptionName(project, subscriptionId), stringList(body, "ackIds"));
+        return Response.ok(Map.of()).build();
+    }
+
+    private static String topicName(String project, String topicId) {
+        return "projects/" + project + "/topics/" + topicId;
+    }
+
+    private static String subscriptionName(String project, String subscriptionId) {
+        return "projects/" + project + "/subscriptions/" + subscriptionId;
+    }
+
+    private static Map<String, Object> topicResponse(StoredTopic topic) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("name", topic.getName());
+        if (topic.getLabels() != null) {
+            response.put("labels", topic.getLabels());
+        }
+        if (topic.getMessageRetentionDuration() != null) {
+            response.put("messageRetentionDuration", topic.getMessageRetentionDuration());
+        }
+        return response;
+    }
+
+    private static Map<String, Object> subscriptionResponse(StoredSubscription subscription) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("name", subscription.getName());
+        response.put("topic", subscription.getTopic());
+        response.put("ackDeadlineSeconds", subscription.getAckDeadlineSeconds());
+        response.put("retainAckedMessages", subscription.isRetainAckedMessages());
+        response.put("enableMessageOrdering", subscription.isEnableMessageOrdering());
+        response.put("enableExactlyOnceDelivery", subscription.isEnableExactlyOnceDelivery());
+        response.put("detached", subscription.isDetached());
+        if (subscription.getLabels() != null) {
+            response.put("labels", subscription.getLabels());
+        }
+        if (subscription.getMessageRetentionDuration() != null) {
+            response.put("messageRetentionDuration", subscription.getMessageRetentionDuration());
+        }
+        if (subscription.getFilter() != null) {
+            response.put("filter", subscription.getFilter());
+        }
+        if (subscription.getPushEndpoint() != null) {
+            response.put("pushConfig", Map.of("pushEndpoint", subscription.getPushEndpoint()));
+        }
+        if (subscription.getBigQueryConfig() != null) {
+            Map<String, Object> bigQueryConfig = new LinkedHashMap<>(subscription.getBigQueryConfig());
+            bigQueryConfig.putIfAbsent("state", "ACTIVE");
+            response.put("bigqueryConfig", bigQueryConfig);
+        }
+        if (subscription.getExpirationPolicy() != null) {
+            response.put("expirationPolicy", subscription.getExpirationPolicy());
+        }
+        if (subscription.getRetryPolicy() != null) {
+            response.put("retryPolicy", subscription.getRetryPolicy());
+        }
+        if (subscription.getDeadLetterTopic() != null) {
+            response.put("deadLetterPolicy", Map.of(
+                    "deadLetterTopic", subscription.getDeadLetterTopic(),
+                    "maxDeliveryAttempts", subscription.getMaxDeliveryAttempts()));
+        }
+        return response;
+    }
+
+    private static Map<String, Object> receivedMessageResponse(ReceivedMessage received) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("ackId", received.getAckId());
+        response.put("message", messageResponse(received.getMessage()));
+        return response;
+    }
+
+    private static Map<String, Object> messageResponse(PubsubMessage message) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("messageId", message.getMessageId());
+        response.put("data", Base64.getEncoder().encodeToString(message.getData().toByteArray()));
+        if (!message.getAttributesMap().isEmpty()) {
+            response.put("attributes", message.getAttributesMap());
+        }
+        if (!message.getOrderingKey().isEmpty()) {
+            response.put("orderingKey", message.getOrderingKey());
+        }
+        return response;
+    }
+
+    private static List<PubsubMessage> messages(Map<String, Object> body) {
+        Object raw = value(body, "messages");
+        if (!(raw instanceof List<?> list)) {
+            return List.of();
+        }
+        List<PubsubMessage> messages = new ArrayList<>();
+        for (Object item : list) {
+            if (item instanceof Map<?, ?> map) {
+                PubsubMessage.Builder builder = PubsubMessage.newBuilder();
+                String data = stringValue(map, "data");
+                if (data != null) {
+                    builder.setData(ByteString.copyFrom(Base64.getDecoder().decode(data)));
+                }
+                Map<String, String> attributes = stringMap(map, "attributes");
+                if (attributes != null) {
+                    builder.putAllAttributes(attributes);
+                }
+                String orderingKey = stringValue(map, "orderingKey");
+                if (orderingKey != null) {
+                    builder.setOrderingKey(orderingKey);
+                }
+                messages.add(builder.build());
+            }
+        }
+        return messages;
+    }
+
+    private static List<String> updateMaskPaths(String updateMask) {
+        if (updateMask == null || updateMask.isBlank()) {
+            return List.of();
+        }
+        return java.util.Arrays.stream(updateMask.split(","))
+                .map(String::trim)
+                .filter(path -> !path.isEmpty())
+                .toList();
+    }
+
+    private static String pushEndpoint(Map<String, Object> body) {
+        Map<String, Object> pushConfig = objectMap(body, "pushConfig");
+        return pushConfig == null ? null : stringValue(pushConfig, "pushEndpoint");
+    }
+
+    private static int maxDeliveryAttempts(Map<String, Object> body) {
+        Map<String, Object> deadLetterPolicy = objectMap(body, "deadLetterPolicy");
+        return deadLetterPolicy == null ? 0 : intValue(deadLetterPolicy, "maxDeliveryAttempts");
+    }
+
+    private static String deadLetterTopic(Map<String, Object> body) {
+        Map<String, Object> deadLetterPolicy = objectMap(body, "deadLetterPolicy");
+        return deadLetterPolicy == null ? null : stringValue(deadLetterPolicy, "deadLetterTopic");
+    }
+
+    private static Map<String, String> stringMap(Map<?, ?> body, String key) {
+        Object raw = value(body, key);
+        if (!(raw instanceof Map<?, ?> map) || map.isEmpty()) {
+            return null;
+        }
+        Map<String, String> out = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                out.put(entry.getKey().toString(), entry.getValue().toString());
+            }
+        }
+        return out;
+    }
+
+    private static Map<String, Object> objectMap(Map<String, Object> body, String key) {
+        Object raw = value(body, key);
+        if (!(raw instanceof Map<?, ?> map) || map.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> out = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getKey() != null) {
+                out.put(entry.getKey().toString(), entry.getValue());
+            }
+        }
+        return out;
+    }
+
+    private static List<String> stringList(Map<String, Object> body, String key) {
+        Object raw = value(body, key);
+        if (!(raw instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream()
+                .filter(item -> item != null)
+                .map(Object::toString)
+                .toList();
+    }
+
+    private static String stringValue(Map<?, ?> body, String key) {
+        Object value = value(body, key);
+        return value == null ? null : value.toString();
+    }
+
+    private static int intValue(Map<String, Object> body, String key) {
+        Object value = value(body, key);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String string && !string.isBlank()) {
+            return Integer.parseInt(string);
+        }
+        return 0;
+    }
+
+    private static boolean booleanValue(Map<String, Object> body, String key) {
+        return Boolean.TRUE.equals(value(body, key));
+    }
+
+    private static Boolean optionalBooleanValue(Map<String, Object> body, String key) {
+        Object value = value(body, key);
+        return value instanceof Boolean bool ? bool : null;
+    }
+
+    private static Object value(Map<?, ?> body, String key) {
+        return body == null ? null : body.get(key);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
@@ -90,9 +90,10 @@ public class PubSubRestController {
                                 @PathParam("topic") String topicId,
                                 @QueryParam("updateMask") String updateMask,
                                 Map<String, Object> body) {
+        Map<String, Object> topicBody = updateResource(body, "topic");
         StoredTopic topic = service.updateTopic(topicName(project, topicId),
-                stringMap(body, "labels"), stringValue(body, "messageRetentionDuration"),
-                updateMaskPaths(updateMask));
+                stringMap(topicBody, "labels"), stringValue(topicBody, "messageRetentionDuration"),
+                updateMaskPaths(updateMask(updateMask, body)));
         return Response.ok(topicResponse(topic)).build();
     }
 
@@ -173,22 +174,23 @@ public class PubSubRestController {
                                        @PathParam("subscription") String subscriptionId,
                                        @QueryParam("updateMask") String updateMask,
                                        Map<String, Object> body) {
+        Map<String, Object> subscriptionBody = updateResource(body, "subscription");
         StoredSubscription subscription = service.updateSubscription(
                 subscriptionName(project, subscriptionId),
-                intValue(body, "ackDeadlineSeconds"),
-                stringMap(body, "labels"),
-                optionalBooleanValue(body, "retainAckedMessages"),
-                stringValue(body, "messageRetentionDuration"),
-                stringValue(body, "filter"),
-                pushEndpoint(body),
-                objectMap(body, "bigqueryConfig"),
-                objectMap(body, "expirationPolicy"),
-                objectMap(body, "retryPolicy"),
-                deadLetterTopic(body),
-                maxDeliveryAttempts(body) == 0 ? null : maxDeliveryAttempts(body),
-                optionalBooleanValue(body, "enableMessageOrdering"),
-                optionalBooleanValue(body, "enableExactlyOnceDelivery"),
-                updateMaskPaths(updateMask));
+                intValue(subscriptionBody, "ackDeadlineSeconds"),
+                stringMap(subscriptionBody, "labels"),
+                optionalBooleanValue(subscriptionBody, "retainAckedMessages"),
+                stringValue(subscriptionBody, "messageRetentionDuration"),
+                stringValue(subscriptionBody, "filter"),
+                pushEndpoint(subscriptionBody),
+                objectMap(subscriptionBody, "bigqueryConfig"),
+                objectMap(subscriptionBody, "expirationPolicy"),
+                objectMap(subscriptionBody, "retryPolicy"),
+                deadLetterTopic(subscriptionBody),
+                maxDeliveryAttempts(subscriptionBody) == 0 ? null : maxDeliveryAttempts(subscriptionBody),
+                optionalBooleanValue(subscriptionBody, "enableMessageOrdering"),
+                optionalBooleanValue(subscriptionBody, "enableExactlyOnceDelivery"),
+                updateMaskPaths(updateMask(updateMask, body)));
         return Response.ok(subscriptionResponse(subscription)).build();
     }
 
@@ -339,6 +341,15 @@ public class PubSubRestController {
                 .map(String::trim)
                 .filter(path -> !path.isEmpty())
                 .toList();
+    }
+
+    private static String updateMask(String queryParam, Map<String, Object> body) {
+        return queryParam == null || queryParam.isBlank() ? stringValue(body, "updateMask") : queryParam;
+    }
+
+    private static Map<String, Object> updateResource(Map<String, Object> body, String key) {
+        Map<String, Object> nested = objectMap(body, key);
+        return nested == null ? body : nested;
     }
 
     private static String pushEndpoint(Map<String, Object> body) {

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -25,6 +25,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -79,7 +80,8 @@ public class PubSubService {
                 .enabled(config.services().pubsub().enabled())
                 .storageKey("pubsub")
                 .protocol(ServiceProtocol.GRPC)
-                .resourceClasses(PubSubPublisherController.class, PubSubSubscriberController.class)
+                .resourceClasses(PubSubPublisherController.class, PubSubSubscriberController.class,
+                        PubSubRestController.class)
                 .build());
         grpcServerManager.bind(new PubSubPublisherController(this));
         grpcServerManager.bind(new PubSubSubscriberController(this));
@@ -88,12 +90,18 @@ public class PubSubService {
     // ── Topics ─────────────────────────────────────────────────────────────────
 
     public StoredTopic createTopic(String name) {
+        return createTopic(name, null, null);
+    }
+
+    public StoredTopic createTopic(String name, Map<String, String> labels, String messageRetentionDuration) {
         LOG.infof("createTopic name=%s", name);
         if (topicStore.get(name).isPresent()) {
             LOG.warnf("createTopic failed: topic already exists name=%s", name);
             throw GcpException.alreadyExists("Topic already exists: " + name);
         }
         StoredTopic topic = new StoredTopic(name);
+        topic.setLabels(emptyToNull(labels));
+        topic.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
         topicStore.put(name, topic);
         return topic;
     }
@@ -132,6 +140,21 @@ public class PubSubService {
         return stored;
     }
 
+    public StoredTopic updateTopic(String name, Map<String, String> labels,
+            String messageRetentionDuration, List<String> updateMaskPaths) {
+        LOG.infof("updateTopic name=%s", name);
+        StoredTopic stored = getTopic(name);
+        boolean replaceAll = updateMaskPaths == null || updateMaskPaths.isEmpty();
+        if (replaceAll || masked(updateMaskPaths, "labels")) {
+            stored.setLabels(emptyToNull(labels));
+        }
+        if (replaceAll || masked(updateMaskPaths, "message_retention_duration")) {
+            stored.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
+        }
+        topicStore.put(name, stored);
+        return stored;
+    }
+
     public void deleteTopic(String name) {
         LOG.infof("deleteTopic name=%s", name);
         if (topicStore.get(name).isEmpty()) {
@@ -144,6 +167,25 @@ public class PubSubService {
     // ── Subscriptions ──────────────────────────────────────────────────────────
 
     public StoredSubscription createSubscription(String name, String topicName, int ackDeadlineSeconds) {
+        return createSubscription(name, topicName, ackDeadlineSeconds, null, false, null,
+                null, null, null, null, null, null, 0, false, false);
+    }
+
+    public StoredSubscription createSubscription(String name,
+            String topicName,
+            int ackDeadlineSeconds,
+            Map<String, String> labels,
+            boolean retainAckedMessages,
+            String messageRetentionDuration,
+            String filter,
+            String pushEndpoint,
+            Map<String, Object> bigQueryConfig,
+            Map<String, Object> expirationPolicy,
+            Map<String, Object> retryPolicy,
+            String deadLetterTopic,
+            int maxDeliveryAttempts,
+            boolean enableMessageOrdering,
+            boolean enableExactlyOnceDelivery) {
         LOG.infof("createSubscription name=%s topic=%s ackDeadline=%d", name, topicName, ackDeadlineSeconds);
         if (subStore.get(name).isPresent()) {
             LOG.warnf("createSubscription failed: subscription already exists name=%s", name);
@@ -155,6 +197,18 @@ public class PubSubService {
         }
         int deadline = ackDeadlineSeconds > 0 ? ackDeadlineSeconds : 10;
         StoredSubscription sub = new StoredSubscription(name, topicName, deadline);
+        sub.setLabels(emptyToNull(labels));
+        sub.setRetainAckedMessages(retainAckedMessages);
+        sub.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
+        sub.setFilter(blankToNull(filter));
+        sub.setPushEndpoint(blankToNull(pushEndpoint));
+        sub.setBigQueryConfig(emptyObjectMapToNull(bigQueryConfig));
+        sub.setExpirationPolicy(emptyObjectMapToNull(expirationPolicy));
+        sub.setRetryPolicy(emptyObjectMapToNull(retryPolicy));
+        sub.setDeadLetterTopic(blankToNull(deadLetterTopic));
+        sub.setMaxDeliveryAttempts(maxDeliveryAttempts);
+        sub.setEnableMessageOrdering(enableMessageOrdering);
+        sub.setEnableExactlyOnceDelivery(enableExactlyOnceDelivery);
         subStore.put(name, sub);
         queues.put(name, new ConcurrentLinkedDeque<>());
         delivered.put(name, new ConcurrentHashMap<>());
@@ -182,6 +236,8 @@ public class PubSubService {
         for (String path : updateMask.getPathsList()) {
             switch (path) {
                 case "ack_deadline_seconds" -> stored.setAckDeadlineSeconds(subProto.getAckDeadlineSeconds());
+                case "labels" -> stored.setLabels(subProto.getLabelsMap().isEmpty() ? null
+                        : new java.util.HashMap<>(subProto.getLabelsMap()));
                 case "filter" -> stored.setFilter(subProto.getFilter().isEmpty() ? null : subProto.getFilter());
                 case "retain_acked_messages" -> stored.setRetainAckedMessages(subProto.getRetainAckedMessages());
                 case "message_retention_duration" -> {
@@ -190,6 +246,10 @@ public class PubSubService {
                                 subProto.getMessageRetentionDuration().getSeconds() + "s");
                     }
                 }
+                case "enable_message_ordering" -> stored.setEnableMessageOrdering(
+                        subProto.getEnableMessageOrdering());
+                case "enable_exactly_once_delivery" -> stored.setEnableExactlyOnceDelivery(
+                        subProto.getEnableExactlyOnceDelivery());
                 case "push_config" -> stored.setPushEndpoint(
                         subProto.getPushConfig().getPushEndpoint().isEmpty() ? null
                                 : subProto.getPushConfig().getPushEndpoint());
@@ -202,6 +262,75 @@ public class PubSubService {
             }
         }
         subStore.put(subProto.getName(), stored);
+        return stored;
+    }
+
+    public StoredSubscription updateSubscription(String name,
+            int ackDeadlineSeconds,
+            Map<String, String> labels,
+            Boolean retainAckedMessages,
+            String messageRetentionDuration,
+            String filter,
+            String pushEndpoint,
+            Map<String, Object> bigQueryConfig,
+            Map<String, Object> expirationPolicy,
+            Map<String, Object> retryPolicy,
+            String deadLetterTopic,
+            Integer maxDeliveryAttempts,
+            Boolean enableMessageOrdering,
+            Boolean enableExactlyOnceDelivery,
+            List<String> updateMaskPaths) {
+        LOG.infof("updateSubscription name=%s", name);
+        StoredSubscription stored = getSubscription(name);
+        boolean replaceAll = updateMaskPaths == null || updateMaskPaths.isEmpty();
+
+        if (replaceAll || masked(updateMaskPaths, "ack_deadline_seconds")) {
+            if (ackDeadlineSeconds > 0) {
+                stored.setAckDeadlineSeconds(ackDeadlineSeconds);
+            }
+        }
+        if (replaceAll || masked(updateMaskPaths, "labels")) {
+            stored.setLabels(emptyToNull(labels));
+        }
+        if (replaceAll || masked(updateMaskPaths, "retain_acked_messages")) {
+            if (retainAckedMessages != null) {
+                stored.setRetainAckedMessages(retainAckedMessages);
+            }
+        }
+        if (replaceAll || masked(updateMaskPaths, "message_retention_duration")) {
+            stored.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
+        }
+        if (replaceAll || masked(updateMaskPaths, "filter")) {
+            stored.setFilter(blankToNull(filter));
+        }
+        if (replaceAll || masked(updateMaskPaths, "push_config")) {
+            stored.setPushEndpoint(blankToNull(pushEndpoint));
+        }
+        if (replaceAll || masked(updateMaskPaths, "bigquery_config")) {
+            stored.setBigQueryConfig(emptyObjectMapToNull(bigQueryConfig));
+        }
+        if (replaceAll || masked(updateMaskPaths, "expiration_policy")) {
+            stored.setExpirationPolicy(emptyObjectMapToNull(expirationPolicy));
+        }
+        if (replaceAll || masked(updateMaskPaths, "retry_policy")) {
+            stored.setRetryPolicy(emptyObjectMapToNull(retryPolicy));
+        }
+        if (replaceAll || masked(updateMaskPaths, "dead_letter_policy")) {
+            stored.setDeadLetterTopic(blankToNull(deadLetterTopic));
+            stored.setMaxDeliveryAttempts(maxDeliveryAttempts == null ? 0 : maxDeliveryAttempts);
+        }
+        if (replaceAll || masked(updateMaskPaths, "enable_message_ordering")) {
+            if (enableMessageOrdering != null) {
+                stored.setEnableMessageOrdering(enableMessageOrdering);
+            }
+        }
+        if (replaceAll || masked(updateMaskPaths, "enable_exactly_once_delivery")) {
+            if (enableExactlyOnceDelivery != null) {
+                stored.setEnableExactlyOnceDelivery(enableExactlyOnceDelivery);
+            }
+        }
+
+        subStore.put(name, stored);
         return stored;
     }
 
@@ -413,5 +542,42 @@ public class PubSubService {
         } catch (Exception e) {
             return Timestamp.getDefaultInstance();
         }
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    private static Map<String, String> emptyToNull(Map<String, String> value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return new LinkedHashMap<>(value);
+    }
+
+    private static Map<String, Object> emptyObjectMapToNull(Map<String, Object> value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return new LinkedHashMap<>(value);
+    }
+
+    private static boolean masked(List<String> updateMaskPaths, String path) {
+        return updateMaskPaths.stream()
+                .map(PubSubService::jsonMaskToProtoMask)
+                .anyMatch(mask -> mask.equals(path) || mask.startsWith(path + "."));
+    }
+
+    private static String jsonMaskToProtoMask(String path) {
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (Character.isUpperCase(c)) {
+                out.append('_').append(Character.toLowerCase(c));
+            } else {
+                out.append(c);
+            }
+        }
+        return out.toString();
     }
 }

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
@@ -325,12 +325,39 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
     }
 
     private static Subscription buildSubscription(StoredSubscription stored) {
-        return Subscription.newBuilder()
+        Subscription.Builder builder = Subscription.newBuilder()
                 .setName(stored.getName())
                 .setTopic(stored.getTopic())
                 .setAckDeadlineSeconds(stored.getAckDeadlineSeconds())
-                .setDetached(stored.isDetached())
-                .build();
+                .setRetainAckedMessages(stored.isRetainAckedMessages())
+                .setEnableMessageOrdering(stored.isEnableMessageOrdering())
+                .setEnableExactlyOnceDelivery(stored.isEnableExactlyOnceDelivery())
+                .setDetached(stored.isDetached());
+        if (stored.getLabels() != null) {
+            builder.putAllLabels(stored.getLabels());
+        }
+        if (stored.getFilter() != null) {
+            builder.setFilter(stored.getFilter());
+        }
+        if (stored.getPushEndpoint() != null) {
+            builder.setPushConfig(PushConfig.newBuilder().setPushEndpoint(stored.getPushEndpoint()).build());
+        }
+        if (stored.getMessageRetentionDuration() != null
+                && stored.getMessageRetentionDuration().endsWith("s")) {
+            try {
+                long seconds = Long.parseLong(stored.getMessageRetentionDuration()
+                        .substring(0, stored.getMessageRetentionDuration().length() - 1));
+                builder.setMessageRetentionDuration(
+                        com.google.protobuf.Duration.newBuilder().setSeconds(seconds).build());
+            } catch (NumberFormatException ignored) {}
+        }
+        if (stored.getDeadLetterTopic() != null) {
+            builder.setDeadLetterPolicy(DeadLetterPolicy.newBuilder()
+                    .setDeadLetterTopic(stored.getDeadLetterTopic())
+                    .setMaxDeliveryAttempts(stored.getMaxDeliveryAttempts())
+                    .build());
+        }
+        return builder.build();
     }
 
     private static String extractProjectId(String parent) {

--- a/src/main/java/io/floci/gcp/services/pubsub/model/StoredSubscription.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/model/StoredSubscription.java
@@ -3,6 +3,8 @@ package io.floci.gcp.services.pubsub.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.Map;
+
 @RegisterForReflection
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StoredSubscription {
@@ -10,12 +12,18 @@ public class StoredSubscription {
     private String name;
     private String topic;
     private int ackDeadlineSeconds = 10;
+    private Map<String, String> labels;
     private String filter;
     private String pushEndpoint;
     private boolean retainAckedMessages;
     private String messageRetentionDuration;
+    private Map<String, Object> bigQueryConfig;
+    private Map<String, Object> expirationPolicy;
+    private Map<String, Object> retryPolicy;
     private String deadLetterTopic;
     private int maxDeliveryAttempts;
+    private boolean enableMessageOrdering;
+    private boolean enableExactlyOnceDelivery;
     private boolean detached;
 
     public StoredSubscription() {}
@@ -35,6 +43,9 @@ public class StoredSubscription {
     public int getAckDeadlineSeconds() { return ackDeadlineSeconds; }
     public void setAckDeadlineSeconds(int ackDeadlineSeconds) { this.ackDeadlineSeconds = ackDeadlineSeconds; }
 
+    public Map<String, String> getLabels() { return labels; }
+    public void setLabels(Map<String, String> labels) { this.labels = labels; }
+
     public String getFilter() { return filter; }
     public void setFilter(String filter) { this.filter = filter; }
 
@@ -47,11 +58,30 @@ public class StoredSubscription {
     public String getMessageRetentionDuration() { return messageRetentionDuration; }
     public void setMessageRetentionDuration(String d) { this.messageRetentionDuration = d; }
 
+    public Map<String, Object> getBigQueryConfig() { return bigQueryConfig; }
+    public void setBigQueryConfig(Map<String, Object> bigQueryConfig) { this.bigQueryConfig = bigQueryConfig; }
+
+    public Map<String, Object> getExpirationPolicy() { return expirationPolicy; }
+    public void setExpirationPolicy(Map<String, Object> expirationPolicy) { this.expirationPolicy = expirationPolicy; }
+
+    public Map<String, Object> getRetryPolicy() { return retryPolicy; }
+    public void setRetryPolicy(Map<String, Object> retryPolicy) { this.retryPolicy = retryPolicy; }
+
     public String getDeadLetterTopic() { return deadLetterTopic; }
     public void setDeadLetterTopic(String deadLetterTopic) { this.deadLetterTopic = deadLetterTopic; }
 
     public int getMaxDeliveryAttempts() { return maxDeliveryAttempts; }
     public void setMaxDeliveryAttempts(int maxDeliveryAttempts) { this.maxDeliveryAttempts = maxDeliveryAttempts; }
+
+    public boolean isEnableMessageOrdering() { return enableMessageOrdering; }
+    public void setEnableMessageOrdering(boolean enableMessageOrdering) {
+        this.enableMessageOrdering = enableMessageOrdering;
+    }
+
+    public boolean isEnableExactlyOnceDelivery() { return enableExactlyOnceDelivery; }
+    public void setEnableExactlyOnceDelivery(boolean enableExactlyOnceDelivery) {
+        this.enableExactlyOnceDelivery = enableExactlyOnceDelivery;
+    }
 
     public boolean isDetached() { return detached; }
     public void setDetached(boolean detached) { this.detached = detached; }

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubDisabledRestIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.pubsub;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(PubSubDisabledRestIntegrationTest.DisabledPubSubProfile.class)
+class PubSubDisabledRestIntegrationTest {
+
+    @Test
+    void disabledPubSubRestServiceReturnsUnavailableWrapper() {
+        given()
+                .when().get("/v1/projects/pubsub-disabled/topics")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service pubsub is not enabled."));
+    }
+
+    public static class DisabledPubSubProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.pubsub.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
@@ -1,0 +1,142 @@
+package io.floci.gcp.services.pubsub;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+@QuarkusTest
+class PubSubRestIntegrationTest {
+
+    @Test
+    void terraformStylePubSubRestCrudAndPublishPullWork() {
+        String project = "pubsub-rest-it";
+        String topic = "orders-events";
+        String subscription = "orders-events-to-bigquery";
+        String topicName = "projects/" + project + "/topics/" + topic;
+        String subscriptionName = "projects/" + project + "/subscriptions/" + subscription;
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "labels": {"app": "orders", "env": "local"},
+                          "messageRetentionDuration": "604800s"
+                        }
+                        """)
+                .when().put("/v1/projects/" + project + "/topics/" + topic)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(topicName))
+                .body("labels.app", equalTo("orders"))
+                .body("messageRetentionDuration", equalTo("604800s"));
+
+        given()
+                .when().get("/v1/projects/" + project + "/topics")
+                .then()
+                .statusCode(200)
+                .body("topics.name", hasItem(topicName));
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "topic": "%s",
+                          "ackDeadlineSeconds": 10,
+                          "messageRetentionDuration": "604800s",
+                          "labels": {"app": "orders", "sink": "bigquery"},
+                          "bigqueryConfig": {
+                            "table": "%s.orders_analytics.order_events",
+                            "useTableSchema": true,
+                            "writeMetadata": false,
+                            "dropUnknownFields": true
+                          }
+                        }
+                        """.formatted(topicName, project))
+                .when().put("/v1/projects/" + project + "/subscriptions/" + subscription)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(subscriptionName))
+                .body("topic", equalTo(topicName))
+                .body("ackDeadlineSeconds", equalTo(10))
+                .body("labels.sink", equalTo("bigquery"))
+                .body("bigqueryConfig.table", equalTo(project + ".orders_analytics.order_events"))
+                .body("bigqueryConfig.state", equalTo("ACTIVE"));
+
+        given()
+                .contentType("application/json")
+                .queryParam("updateMask", "labels,ackDeadlineSeconds")
+                .body("""
+                        {
+                          "ackDeadlineSeconds": 20,
+                          "labels": {"app": "orders", "sink": "worker"}
+                        }
+                        """)
+                .when().patch("/v1/projects/" + project + "/subscriptions/" + subscription)
+                .then()
+                .statusCode(200)
+                .body("ackDeadlineSeconds", equalTo(20))
+                .body("labels.sink", equalTo("worker"))
+                .body("bigqueryConfig.table", equalTo(project + ".orders_analytics.order_events"));
+
+        String payload = Base64.getEncoder().encodeToString("hello from rest".getBytes());
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "messages": [
+                            {"data": "%s", "attributes": {"event_type": "created"}}
+                          ]
+                        }
+                        """.formatted(payload))
+                .when().post("/v1/projects/" + project + "/topics/" + topic + ":publish")
+                .then()
+                .statusCode(200)
+                .body("messageIds.size()", equalTo(1));
+
+        String ackId = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"maxMessages\": 1}")
+                .when().post("/v1/projects/" + project + "/subscriptions/" + subscription + ":pull")
+                .then()
+                .statusCode(200)
+                .body("receivedMessages.size()", equalTo(1))
+                .body("receivedMessages[0].message.data", equalTo(payload))
+                .body("receivedMessages[0].message.attributes.event_type", equalTo("created"))
+                .extract().path("receivedMessages[0].ackId");
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"ackIds\": [\"" + ackId + "\"]}")
+                .when().post("/v1/projects/" + project + "/subscriptions/" + subscription + ":acknowledge")
+                .then()
+                .statusCode(200)
+                .body("$", anEmptyMap());
+
+        given()
+                .when().get("/v1/projects/" + project + "/subscriptions")
+                .then()
+                .statusCode(200)
+                .body("subscriptions.name", hasItem(subscriptionName));
+
+        given()
+                .when().delete("/v1/projects/" + project + "/subscriptions/" + subscription)
+                .then()
+                .statusCode(200)
+                .body("$", anEmptyMap());
+
+        given()
+                .when().delete("/v1/projects/" + project + "/topics/" + topic)
+                .then()
+                .statusCode(200)
+                .body("$", anEmptyMap());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
@@ -46,6 +46,23 @@ class PubSubRestIntegrationTest {
                 .contentType("application/json")
                 .body("""
                         {
+                          "topic": {
+                            "labels": {"app": "orders", "env": "patched"},
+                            "messageRetentionDuration": "1200s"
+                          },
+                          "updateMask": "labels,messageRetentionDuration"
+                        }
+                        """)
+                .when().patch("/v1/projects/" + project + "/topics/" + topic)
+                .then()
+                .statusCode(200)
+                .body("labels.env", equalTo("patched"))
+                .body("messageRetentionDuration", equalTo("1200s"));
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
                           "topic": "%s",
                           "ackDeadlineSeconds": 10,
                           "messageRetentionDuration": "604800s",
@@ -83,6 +100,31 @@ class PubSubRestIntegrationTest {
                 .body("ackDeadlineSeconds", equalTo(20))
                 .body("labels.sink", equalTo("worker"))
                 .body("bigqueryConfig.table", equalTo(project + ".orders_analytics.order_events"));
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "subscription": {
+                            "ackDeadlineSeconds": 30,
+                            "labels": {"app": "orders", "sink": "canonical"},
+                            "retainAckedMessages": true,
+                            "bigqueryConfig": {
+                              "table": "%s.orders_analytics.order_events_v2",
+                              "useTableSchema": true
+                            }
+                          },
+                          "updateMask": "ackDeadlineSeconds,labels,retainAckedMessages,bigqueryConfig"
+                        }
+                        """.formatted(project))
+                .when().patch("/v1/projects/" + project + "/subscriptions/" + subscription)
+                .then()
+                .statusCode(200)
+                .body("ackDeadlineSeconds", equalTo(30))
+                .body("labels.sink", equalTo("canonical"))
+                .body("retainAckedMessages", equalTo(true))
+                .body("bigqueryConfig.table", equalTo(project + ".orders_analytics.order_events_v2"))
+                .body("bigqueryConfig.state", equalTo("ACTIVE"));
 
         String payload = Base64.getEncoder().encodeToString("hello from rest".getBytes());
         given()


### PR DESCRIPTION
## Summary

- Add REST JSON endpoints for Pub/Sub topics and subscriptions.
- Add REST publish/pull support for Terraform-style provider flows.
- Register the REST controller with the Pub/Sub service descriptor.
- Document REST coverage and add enabled/disabled REST integration tests.

## Validation

- JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=PubSubRestIntegrationTest,PubSubDisabledRestIntegrationTest
- JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw clean package
