### PR TITLE
fix(kafka): seed named volumes from the image instead of nocopy

### DIFF
--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerBuilder.java
@@ -170,12 +170,20 @@ public class ContainerBuilder {
         }
 
         public Builder withNamedVolume(String volumeName, String containerPath, boolean readOnly) {
-            this.mounts.add(new Mount()
+            Mount mount = new Mount()
                     .withType(MountType.VOLUME)
                     .withSource(volumeName)
                     .withTarget(containerPath)
-                    .withReadOnly(readOnly)
-                    .withVolumeOptions(new VolumeOptions().withNoCopy(true)));
+                    .withReadOnly(readOnly);
+            // Read-only volumes are pre-populated (e.g. Cloud Run GCS snapshots), so don't
+            // seed them from the image. Read-write data volumes (Kafka, Cloud SQL) instead
+            // need the image's initialized directory and ownership, so they must be seeded:
+            // a non-root image cannot write to an empty root-owned volume and crashes on
+            // startup otherwise.
+            if (readOnly) {
+                mount.withVolumeOptions(new VolumeOptions().withNoCopy(true));
+            }
+            this.mounts.add(mount);
             return this;
         }
 


### PR DESCRIPTION
## Summary

`ContainerBuilder.withNamedVolume` mounted named volumes with `VolumeOptions.withNoCopy(true)`, so a fresh data volume was never seeded from the image and stayed root-owned. Non-root images such as Redpanda cannot write to it and crash on startup, so Managed Kafka clusters never reached `ACTIVE`.

Apply `nocopy` only to **read-only** volumes, which are pre-populated and must not be overlaid by the image (e.g. Cloud Run GCS snapshots). **Read-write** data volumes (Kafka, Cloud SQL) are now seeded from the image, preserving its initialized directory and ownership.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

No wire-protocol change. Fixed `mkdir /var/lib/redpanda/data/crash_reports: Permission denied` → Redpanda container exit → cluster stuck `CREATING` (the emulator's 90s readiness wait then timing out into "No route to host" against the dead container). Verified: clusters reach `ACTIVE` in ~5s, the Java/Node/Python/Go Managed Kafka compat suites pass, and the Cloud Run read-only GCS volume mount (and its unit test) are unchanged. Also benefits any other non-root read-write sidecar (e.g. Cloud SQL Postgres).

## Checklist

- [x] `./mvnw test` passes locally (incl. `CloudRunRuntimeServiceTest`)
- [x] New or updated integration test added — N/A (shared container infra; exercised by `CloudRunRuntimeServiceTest` + the compatibility suites)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
