### PR TITLE
chore: run local compat-docker against real sidecars like CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,12 @@ test: build
 	$(MAKE) stop
 
 # ── Docker-based compat tests (requires: docker compose up -d) ────────────────
-# Mirrors .github/workflows/compatibility.yml: each suite runs as its own
-# container on the emulator's compose network. Per-service *_EMULATOR_HOST values
-# are baked into each suite Dockerfile, so only the shared endpoint vars are
-# passed here — new services stay in sync automatically via their Dockerfile.
+# Runs every suite against the single shared compose emulator with ALL mocks off
+# (real Redpanda / Postgres / Cloud Run). The emulator's
+# FLOCI_GCP_SERVICES_DOCKER_NETWORK (set in docker-compose.yml) attaches spawned
+# sidecars to the compose network so they are reachable. Per-service
+# *_EMULATOR_HOST values are baked into each suite Dockerfile, so only the shared
+# endpoint vars + the Cloud Run execution gate are passed here.
 
 COMPAT_NET     = floci_gcp_default
 COMPAT_RESULTS = /tmp/floci-gcp-compat-results
@@ -92,6 +94,7 @@ compat-docker:
 			-e FLOCI_ENDPOINT=http://floci-gcp:4588 \
 			-e FLOCI_HOST=floci-gcp:4588 \
 			-e FLOCI_PROJECT=test-project \
+			-e FLOCI_GCP_CLOUDRUN_EXECUTION_ENABLED=true \
 			-v $(COMPAT_RESULTS)/$$suite:/results \
 			compat-$$suite || fail=1; \
 	done; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       FLOCI_GCP_HOSTNAME: floci-gcp
       FLOCI_GCP_BASE_URL: http://floci-gcp:4588
+      FLOCI_GCP_SERVICES_DOCKER_NETWORK: floci_gcp_default
     networks:
       floci_gcp_default:
         aliases:


### PR DESCRIPTION
## Summary

`docker-compose.yml` did not set `FLOCI_GCP_SERVICES_DOCKER_NETWORK`, so containers the emulator spawns (Redpanda, Postgres, Cloud Run) were not attached to the compose network. Set it to `floci_gcp_default`. Also pass `FLOCI_GCP_CLOUDRUN_EXECUTION_ENABLED=true` to the suite containers in the `compat-docker` target so Cloud Run tests assert execution behaviour, matching `.github/workflows/compatibility.yml`.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

N/A — local build tooling only; does not touch the emulator or the wire protocols.

## Checklist

- [x] `./mvnw test` passes locally — N/A (local tooling only)
- [x] New or updated integration test added — N/A
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
