### PR TITLE
fix(gcs): resolve 405 Method Not Allowed during resumable upload with…

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadRawTest.java
@@ -156,4 +156,46 @@ class GcsResumableUploadRawTest {
         assertThat(download.statusCode()).isEqualTo(200);
         assertThat(download.body()).containsExactly(data);
     }
+
+    @Test
+    void resumableUploadWithCustomEndpointUrlPath() throws Exception {
+        String objectName = "custom-endpoint-path.bin";
+        byte[] data = "custom-endpoint-path-data".getBytes(StandardCharsets.UTF_8);
+        HttpResponse<String> init = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=resumable&name=" + objectName))
+                        .header("X-Upload-Content-Type", "application/octet-stream")
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(init.statusCode()).isEqualTo(200);
+        URI uploadUri = URI.create(init.headers().firstValue("Location").orElseThrow());
+
+        // Rewrite uploadUri's path to /storage/v1/b/... to test the PUT path rewrite too
+        URI customUploadUri = URI.create(uploadUri.toString().replace("/upload/storage/v1/b/", "/storage/v1/b/"));
+
+        HttpResponse<String> upload = CLIENT.send(
+                HttpRequest.newBuilder(customUploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes 0-*/*")
+                        .PUT(HttpRequest.BodyPublishers.ofByteArray(data))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(upload.statusCode()).isEqualTo(200);
+        assertThat(upload.body()).contains("\"size\":\"" + data.length + "\"");
+
+        HttpResponse<byte[]> download = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/storage/v1/b/" + BUCKET + "/o/" + objectName + "?alt=media"))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(download.statusCode()).isEqualTo(200);
+        assertThat(download.body()).containsExactly(data);
+    }
 }

--- a/compatibility-tests/sdk-test-node/tests/gcs.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/gcs.test.ts
@@ -41,6 +41,17 @@ describe('Cloud Storage (GCS)', () => {
     });
   });
 
+  it('should upload a large object (>8MB) using resumable upload', async () => {
+    const largeContent = Buffer.alloc(9 * 1024 * 1024, 'x');
+    const largeObjectName = 'large-test-object.bin';
+    await storage.bucket(bucketName).file(largeObjectName).save(largeContent, {
+      contentType: 'application/octet-stream',
+    });
+    const [downloaded] = await storage.bucket(bucketName).file(largeObjectName).download();
+    expect(downloaded.length).toBe(largeContent.length);
+    await storage.bucket(bucketName).file(largeObjectName).delete();
+  });
+
   it('should download and verify object content', async () => {
     const [content] = await storage.bucket(bucketName).file(objectName).download();
     expect(content.toString()).toBe(objectContent);

--- a/src/main/java/io/floci/gcp/lifecycle/GrpcServerManager.java
+++ b/src/main/java/io/floci/gcp/lifecycle/GrpcServerManager.java
@@ -35,6 +35,10 @@ public class GrpcServerManager {
         grpcServer = GrpcIoServer.server(vertx);
         services.stream().forEach(svc -> GrpcIoServiceBridge.bridge(svc).bind(grpcServer));
         router.route().order(Integer.MIN_VALUE).handler(ctx -> {
+            String method = ctx.request().method().name();
+            String uri = ctx.request().uri();
+            String contentType = ctx.request().getHeader("Content-Type");
+            LOG.infof("Incoming request: %s %s, content-type=%s", method, uri, contentType);
             String ct = ctx.request().getHeader("Content-Type");
             if (ct != null && ct.startsWith("application/grpc")) {
                 long start = System.currentTimeMillis();

--- a/src/main/java/io/floci/gcp/services/gcs/GcsPathRewriteFilter.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsPathRewriteFilter.java
@@ -29,7 +29,16 @@ public class GcsPathRewriteFilter implements ContainerRequestFilter {
             newPath = "/storage/v1" + path;
         }
 
-        if (newPath != null) {
+        if (newPath == null) {
+            newPath = path;
+        }
+
+        if (("POST".equalsIgnoreCase(ctx.getMethod()) || "PUT".equalsIgnoreCase(ctx.getMethod()))
+                && (newPath.startsWith("/storage/v1/b/") && (newPath.endsWith("/o") || newPath.endsWith("/o/")))) {
+            newPath = "/upload" + newPath;
+        }
+
+        if (!newPath.equals(path)) {
             URI original = ctx.getUriInfo().getRequestUri();
             URI rewritten = URI.create(
                     original.getScheme() + "://" + original.getAuthority()


### PR DESCRIPTION
… custom endpoints

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Closes #71 

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

<!-- For new features: which GCP SDK version and gcloud CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior and how was it verified against real GCP behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
