### PR TITLE
feat(gke): add GKE control plane with real k3s backend and native kubectl auth

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -93,6 +93,7 @@ jobs:
             sdk-test-*) KAFKA_MOCK=true ;;
           esac
           docker run -d --name floci-gcp --network compat-net \
+            --network-alias container.localhost.floci.io \
             -p 4588:4588 \
             -v /var/run/docker.sock:/var/run/docker.sock \
             --group-add "$DOCKER_GID" \

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Cloud KMS | ✅ | ❌ |
 | IAM | ✅ | ❌ |
 | Managed Kafka | ✅ | ❌ |
+| GKE (Kubernetes Engine) | ✅ | ❌ |
 | Cloud Run | ✅ | ❌ |
 | Cloud Functions | ✅ | ❌ |
 | Cloud SQL for PostgreSQL | ✅ | ❌ |
@@ -158,7 +159,7 @@ flowchart LR
         end
 
         subgraph REST ["REST services"]
-            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions\nCloud SQL"]
+            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions\nCloud SQL\nGKE"]
         end
 
         subgraph Docker ["Docker-backed"]
@@ -185,6 +186,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Object and document storage | Cloud Storage (GCS), Firestore, Datastore |
 | Messaging | Pub/Sub, Managed Kafka |
 | Security and identity | Secret Manager, Cloud KMS, IAM |
+| Container orchestration | GKE (Kubernetes Engine) |
 | Serverless control planes | Cloud Run, Cloud Functions |
 | Task scheduling | Cloud Tasks, Cloud Scheduler |
 | Databases | Cloud SQL for PostgreSQL |
@@ -204,6 +206,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Cloud KMS** | gRPC + REST JSON | Key rings, crypto keys, key versions, symmetric encrypt/decrypt (AES-256-GCM), asymmetric sign (EC P-256, RSA PKCS1) and decrypt (RSA-OAEP), `GetPublicKey`, `GenerateRandomBytes`, CRC32C integrity fields |
 | **IAM** | REST JSON | Service accounts, RSA-2048 key pairs (JSON key file format), policy bindings, `SignBlob` (V4 signed URLs) |
 | **Managed Kafka** | REST JSON | Clusters, topics, consumer groups; Redpanda-backed or mock mode |
+| **GKE (Kubernetes Engine)** | REST JSON | Clusters and operations (`container.googleapis.com` v1); real k3s clusters via Docker (`rancher/k3s`) or mock mode. Reached by SDKs/gcloud through host-based routing (`container.*`) or the `/container/v1` path prefix |
 | **Cloud Run** | REST JSON | Services, IAM policies, revisions, long-running operations; control plane by default, experimental Docker-backed invocation when enabled |
 | **Cloud Functions** | REST JSON | Functions, source upload URL generation, long-running operations; control plane only, no runtime invocation |
 | **Cloud SQL for PostgreSQL** | REST JSON | Instances (Postgres), control-plane lifecycle, long-running operations |

--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -49,7 +49,7 @@ just test-all-iac
 
 ## Test Coverage
 
-### SDK tests — 233 tests total
+### SDK tests — 237 tests total
 
 | Test class | GCP service | Java | Python | Node | Go |
 |---|---|:---:|:---:|:---:|:---:|
@@ -62,9 +62,16 @@ just test-all-iac
 | `DatastoreTest` | Datastore | 5 | 5 | 5 | 5 |
 | `IamTest` | IAM | 7 | 5 | 7 | 7 |
 | `KafkaTest` | Managed Kafka | 11 | 9 | 11 | 11 |
+| `GkeTest` | GKE (Kubernetes Engine) | 4 | 0 | 0 | 0 |
 | `CloudSqlAdminTest` | Cloud SQL for PostgreSQL | 4 | 0 | 0 | 0 |
 | `SchedulerTest` | Cloud Scheduler | 7 | 0 | 0 | 0 |
-| **Total** | | **68** | **48** | **59** | **58** |
+| **Total** | | **72** | **48** | **59** | **58** |
+
+GKE uses the HttpJson transport (the Cloud SDK defaults to gRPC, which the REST-only
+emulator does not serve for GKE) and reaches the service via host-based routing
+(`container.*`). The gcloud suite also covers GKE (`container.bats`). The
+Terraform/OpenTofu `google_container_cluster` resource is not covered — the google provider
+expects a richer cluster surface than the emulator implements.
 
 ### IaC tests
 

--- a/compatibility-tests/sdk-test-gcloud/test/container.bats
+++ b/compatibility-tests/sdk-test-gcloud/test/container.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# GKE (gcloud container) integration tests.
+# Regional clusters use the projects/*/locations/* path the emulator implements.
+
+setup_file() {
+    load 'test_helper/common-setup'
+    export CLUSTER="$(unique_name gcloud-gke)"
+    gcloud container clusters create "$CLUSTER" \
+        --region="${FLOCI_GCP_LOCATION}" --async >/dev/null 2>&1
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+    gcloud container clusters delete "$CLUSTER" \
+        --region="${FLOCI_GCP_LOCATION}" --async --quiet >/dev/null 2>&1 || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+}
+
+@test "container: cluster appears in list" {
+    run gcloud_cmd container clusters list --region="${FLOCI_GCP_LOCATION}" \
+        --format="value(name)"
+    assert_success
+    assert_output --partial "$CLUSTER"
+}
+
+@test "container: describe reports a status" {
+    run gcloud_cmd container clusters describe "$CLUSTER" \
+        --region="${FLOCI_GCP_LOCATION}" --format="value(status)"
+    assert_success
+    assert_output --regexp "PROVISIONING|RUNNING"
+}
+
+@test "container: describe returns the cluster name" {
+    run gcloud_cmd container clusters describe "$CLUSTER" \
+        --region="${FLOCI_GCP_LOCATION}" --format="value(name)"
+    assert_success
+    assert_output --partial "$CLUSTER"
+}

--- a/compatibility-tests/sdk-test-gcloud/test/test_helper/common-setup.bash
+++ b/compatibility-tests/sdk-test-gcloud/test/test_helper/common-setup.bash
@@ -34,6 +34,14 @@ export CLOUDSDK_API_ENDPOINT_OVERRIDES_SECRETMANAGER="${FLOCI_GCP_ENDPOINT}/"
 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CLOUDKMS="${FLOCI_GCP_ENDPOINT}/"
 export CLOUDSDK_API_ENDPOINT_OVERRIDES_IAM="${FLOCI_GCP_ENDPOINT}/"
 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CLOUDSCHEDULER="${FLOCI_GCP_ENDPOINT}/"
+# GKE lives under the /container prefix (it shares the canonical /v1/.../clusters path with
+# Managed Kafka). gcloud appends "v1/...", so the override base must end in /container/.
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="${FLOCI_GCP_ENDPOINT}/container/"
+# `gcloud container` preflights an API-enablement check against serviceusage.googleapis.com,
+# which the fake token can't satisfy. Point serviceusage at the emulator (it 404s the check)
+# and disable the enable-API prompt so the command proceeds. floci-gcp ignores auth anyway.
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_SERVICEUSAGE="${FLOCI_GCP_ENDPOINT}/"
+export CLOUDSDK_CORE_SHOULD_PROMPT_TO_ENABLE_API=false
 
 # Run a gcloud command (stderr folded into stdout so asserts can match either).
 gcloud_cmd() {

--- a/compatibility-tests/sdk-test-java/Dockerfile
+++ b/compatibility-tests/sdk-test-java/Dockerfile
@@ -17,5 +17,8 @@ ENV PUBSUB_EMULATOR_HOST=floci-gcp:4588
 ENV FIRESTORE_EMULATOR_HOST=floci-gcp:4588
 ENV DATASTORE_EMULATOR_HOST=floci-gcp:4588
 ENV STORAGE_EMULATOR_HOST=http://floci-gcp:4588
+# GKE uses host-mode routing: the "container." first label triggers the emulator's
+# ServiceRoutingFilter. container.localhost.floci.io is a docker-compose network alias.
+ENV GKE_EMULATOR_ENDPOINT=http://container.localhost.floci.io:4588
 
 ENTRYPOINT ["/bin/bash", "-c", "mvn test; status=$?; mkdir -p /results && cp -r target/surefire-reports/*.xml /results/ 2>/dev/null || true; exit $status"]

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -90,6 +90,10 @@
             <artifactId>google-cloud-kms</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-container</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.7</version>

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -151,6 +151,27 @@ public final class TestFixtures {
         return ServicesClient.create(settings);
     }
 
+    /**
+     * GKE (container.googleapis.com) endpoint. The Cloud Client SDK defaults to gRPC, which the
+     * REST-only emulator cannot serve, so GKE tests use the HttpJson transport. The host's first
+     * DNS label must be {@code container} so the emulator's ServiceRoutingFilter rewrites the
+     * canonical {@code /v1/...} path onto the {@code /container} prefix (host-mode routing).
+     * Defaults to {@code container.localhost} (resolves to 127.0.0.1 on the host); the Docker
+     * compat run sets {@code GKE_EMULATOR_ENDPOINT=http://container.localhost.floci.io:4588}.
+     */
+    public static String gkeEndpoint() {
+        return System.getenv().getOrDefault("GKE_EMULATOR_ENDPOINT", "http://container.localhost:4588");
+    }
+
+    public static com.google.cloud.container.v1.ClusterManagerClient gkeClient() throws IOException {
+        com.google.cloud.container.v1.ClusterManagerSettings settings =
+                com.google.cloud.container.v1.ClusterManagerSettings.newHttpJsonBuilder()
+                        .setEndpoint(gkeEndpoint())
+                        .setCredentialsProvider(NoCredentialsProvider.create())
+                        .build();
+        return com.google.cloud.container.v1.ClusterManagerClient.create(settings);
+    }
+
     public static RevisionsClient cloudRunRevisionsClient() throws IOException {
         RevisionsSettings settings = RevisionsSettings.newHttpJsonBuilder()
                 .setEndpoint(endpoint())

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GkeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GkeTest.java
@@ -1,0 +1,95 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.container.v1.ClusterManagerClient;
+import com.google.container.v1.Cluster;
+import com.google.container.v1.CreateClusterRequest;
+import com.google.container.v1.DeleteClusterRequest;
+import com.google.container.v1.GetClusterRequest;
+import com.google.container.v1.ListClustersRequest;
+import com.google.container.v1.Operation;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * GKE (container.googleapis.com) compatibility via the official google-cloud-container SDK,
+ * using the HttpJson transport against the emulator. Assertions are mode-agnostic so the suite
+ * passes whether the cluster is mock (instant RUNNING) or real k3s (PROVISIONING then RUNNING).
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GkeTest {
+
+    private static ClusterManagerClient client;
+    private static final String CLUSTER = TestFixtures.uniqueName("gke");
+    private static final String PARENT =
+            "projects/" + TestFixtures.projectId() + "/locations/us-central1";
+    private static final String CLUSTER_NAME = PARENT + "/clusters/" + CLUSTER;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        client = TestFixtures.gkeClient();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createCluster() {
+        Cluster cluster = Cluster.newBuilder()
+                .setName(CLUSTER)
+                .setInitialNodeCount(1)
+                .build();
+        Operation op = client.createCluster(CreateClusterRequest.newBuilder()
+                .setParent(PARENT)
+                .setCluster(cluster)
+                .build());
+
+        assertThat(op.getName()).startsWith("operation-");
+        assertThat(op.getOperationType()).isEqualTo(Operation.Type.CREATE_CLUSTER);
+        assertThat(op.getStatus()).isEqualTo(Operation.Status.DONE);
+    }
+
+    @Test
+    @Order(2)
+    void getCluster() {
+        Cluster cluster = client.getCluster(GetClusterRequest.newBuilder()
+                .setName(CLUSTER_NAME)
+                .build());
+
+        assertThat(cluster.getName()).isEqualTo(CLUSTER);
+        assertThat(cluster.getStatus())
+                .isIn(Cluster.Status.PROVISIONING, Cluster.Status.RUNNING);
+        assertThat(cluster.getCurrentMasterVersion()).isNotBlank();
+    }
+
+    @Test
+    @Order(3)
+    void listClustersContainsCreated() {
+        var response = client.listClusters(ListClustersRequest.newBuilder()
+                .setParent(PARENT)
+                .build());
+        assertThat(response.getClustersList())
+                .anyMatch(c -> c.getName().equals(CLUSTER));
+    }
+
+    @Test
+    @Order(4)
+    void deleteCluster() {
+        Operation op = client.deleteCluster(DeleteClusterRequest.newBuilder()
+                .setName(CLUSTER_NAME)
+                .build());
+
+        assertThat(op.getOperationType()).isEqualTo(Operation.Type.DELETE_CLUSTER);
+        assertThat(op.getStatus()).isEqualTo(Operation.Status.DONE);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       floci_gcp_default:
         aliases:
           - localhost.floci.io
+          - container.localhost.floci.io
 
 networks:
   floci_gcp_default:

--- a/docs/services/gke.md
+++ b/docs/services/gke.md
@@ -1,0 +1,90 @@
+# GKE (Kubernetes Engine)
+
+floci-gcp emulates the Google Kubernetes Engine control plane (`container.googleapis.com`,
+ClusterManager v1) over REST JSON. Cluster lifecycle is backed by real
+[k3s](https://k3s.io/) containers (`rancher/k3s`) started through the host Docker daemon,
+or a lightweight mock mode.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_GKE_ENABLED` | `true` | Enable/disable GKE |
+| `FLOCI_GCP_SERVICES_GKE_MOCK` | `false` | Mock mode: clusters return `RUNNING` immediately without starting a k3s container |
+| `FLOCI_GCP_SERVICES_GKE_DEFAULT_IMAGE` | `rancher/k3s:latest` | Image used for real clusters |
+| `FLOCI_GCP_SERVICES_GKE_API_SERVER_BASE_PORT` | `6550` | Start of the host port range for k3s API servers |
+| `FLOCI_GCP_SERVICES_GKE_API_SERVER_MAX_PORT` | `6599` | End of the host port range |
+
+## Routing: how clients reach GKE
+
+On real GCP, `container.googleapis.com` and other APIs share the canonical
+`/v1/projects/.../clusters` path and are told apart only by hostname. floci-gcp serves
+everything on one port, where that path also belongs to Managed Kafka, so GKE mounts under a
+`/container` prefix and a routing filter maps clients onto it two ways:
+
+- **Host mode (SDKs):** point the client endpoint host at `container.*` (e.g.
+  `http://container.localhost:4588`). The first DNS label `container` triggers a rewrite of
+  `/v1/...` to `/container/v1/...`.
+- **Path mode (gcloud / direct):** call the `/container/v1/...` prefix directly, or set a
+  custom endpoint base of `<endpoint>/container/v1/`.
+
+!!! note "SDK transport"
+    The Cloud Client libraries default to gRPC, which the REST-only emulator does not serve
+    for GKE. Build the client with the HttpJson transport
+    (`ClusterManagerSettings.newHttpJsonBuilder()`) and a `container.*` endpoint host.
+
+## Quick Start
+
+=== "REST API"
+
+    ```bash
+    # Create a cluster (path mode)
+    curl -X POST \
+      "http://localhost:4588/container/v1/projects/floci-local/locations/us-central1/clusters" \
+      -H "Content-Type: application/json" \
+      -d '{"cluster":{"name":"my-cluster"}}'
+
+    # Get / list clusters
+    curl "http://localhost:4588/container/v1/projects/floci-local/locations/us-central1/clusters/my-cluster"
+    curl "http://localhost:4588/container/v1/projects/floci-local/locations/us-central1/clusters"
+
+    # Delete a cluster
+    curl -X DELETE \
+      "http://localhost:4588/container/v1/projects/floci-local/locations/us-central1/clusters/my-cluster"
+    ```
+
+=== "gcloud"
+
+    ```bash
+    export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="http://localhost:4588/container/"
+    # gcloud preflights an API-enablement check; point serviceusage at the emulator and
+    # disable the enable-API prompt (floci-gcp ignores auth).
+    export CLOUDSDK_API_ENDPOINT_OVERRIDES_SERVICEUSAGE="http://localhost:4588/"
+    export CLOUDSDK_CORE_SHOULD_PROMPT_TO_ENABLE_API=false
+
+    gcloud container clusters create my-cluster --region=us-central1 --async
+    gcloud container clusters list --region=us-central1
+    ```
+
+## Mock Mode
+
+Set `FLOCI_GCP_SERVICES_GKE_MOCK=true` to create clusters in memory that report `RUNNING`
+immediately without starting a k3s container. Useful for CI and for tools that provision a
+cluster but never connect to its API server.
+
+## Supported Operations
+
+- `CreateCluster` (returns a synchronous, `DONE` Operation)
+- `GetCluster`
+- `ListClusters`
+- `DeleteCluster` (returns a `DONE` Operation)
+- `GetOperation` / `ListOperations`
+
+## Limitations
+
+- Node pools, autoscaling, upgrades, and cluster IAM are not modeled.
+- Operations resolve synchronously (no real long-running operation lifecycle).
+- The Terraform/OpenTofu `google_container_cluster` resource is **not** supported: the
+  google provider expects a far richer cluster surface (node-pool reconciliation,
+  default-pool deletion, many computed fields) than the emulator implements. Use the Java
+  SDK (HttpJson) or gcloud instead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Cloud KMS: services/kms.md
     - IAM: services/iam.md
     - Managed Kafka: services/managed-kafka.md
+    - GKE (Kubernetes Engine): services/gke.md
     - Cloud SQL for PostgreSQL: services/cloud-sql-postgres.md
     - Cloud Run: services/cloud-run.md
     - Cloud Functions: services/cloud-functions.md

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -102,6 +102,33 @@ public interface EmulatorConfig {
         MonitoringServiceConfig monitoring();
 
         SchedulerServiceConfig scheduler();
+
+        GkeServiceConfig gke();
+    }
+
+    interface GkeServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        @WithDefault("false")
+        boolean mock();
+
+        @WithDefault("rancher/k3s:latest")
+        String defaultImage();
+
+        @WithDefault("6550")
+        int apiServerBasePort();
+
+        @WithDefault("6599")
+        int apiServerMaxPort();
+
+        @WithDefault("false")
+        boolean keepRunningOnShutdown();
+
+        @WithDefault("host")
+        String endpointMode();
+
+        Optional<String> dockerNetwork();
     }
 
     interface GcsServiceConfig {

--- a/src/main/java/io/floci/gcp/core/common/ServiceDescriptor.java
+++ b/src/main/java/io/floci/gcp/core/common/ServiceDescriptor.java
@@ -9,7 +9,9 @@ public record ServiceDescriptor(
         String storageMode,
         long storageFlushIntervalMs,
         ServiceProtocol protocol,
-        Set<Class<?>> resourceClasses
+        Set<Class<?>> resourceClasses,
+        String hostToken,
+        String pathPrefix
 ) {
 
     public static Builder builder(String name) {
@@ -24,6 +26,8 @@ public record ServiceDescriptor(
         private long storageFlushIntervalMs = 5000;
         private ServiceProtocol protocol = ServiceProtocol.REST;
         private Set<Class<?>> resourceClasses = Set.of();
+        private String hostToken;
+        private String pathPrefix;
 
         private Builder(String name) {
             this.name = name;
@@ -35,10 +39,12 @@ public record ServiceDescriptor(
         public Builder flushInterval(long ms) { this.storageFlushIntervalMs = ms; return this; }
         public Builder protocol(ServiceProtocol protocol) { this.protocol = protocol; return this; }
         public Builder resourceClasses(Class<?>... classes) { this.resourceClasses = Set.of(classes); return this; }
+        public Builder hostToken(String hostToken) { this.hostToken = hostToken; return this; }
+        public Builder pathPrefix(String pathPrefix) { this.pathPrefix = pathPrefix; return this; }
 
         public ServiceDescriptor build() {
             return new ServiceDescriptor(name, enabled, storageKey, storageMode,
-                    storageFlushIntervalMs, protocol, resourceClasses);
+                    storageFlushIntervalMs, protocol, resourceClasses, hostToken, pathPrefix);
         }
     }
 }

--- a/src/main/java/io/floci/gcp/core/common/ServiceRegistry.java
+++ b/src/main/java/io/floci/gcp/core/common/ServiceRegistry.java
@@ -28,6 +28,18 @@ public class ServiceRegistry {
         return Optional.ofNullable(byResourceClass.get(clazz));
     }
 
+    /**
+     * Returns enabled services that declare a routing {@code pathPrefix} (and usually a
+     * {@code hostToken}). Used by the single-port {@code ServiceRoutingFilter} to map
+     * canonical/host-based REST requests onto a prefixed controller.
+     */
+    public List<ServiceDescriptor> getRoutableServices() {
+        return descriptors.stream()
+                .filter(ServiceDescriptor::enabled)
+                .filter(d -> d.pathPrefix() != null && !d.pathPrefix().isBlank())
+                .toList();
+    }
+
     public boolean isEnabled(String name) {
         return descriptors.stream()
                 .filter(d -> d.name().equals(name))

--- a/src/main/java/io/floci/gcp/core/common/routing/ServiceRoutingFilter.java
+++ b/src/main/java/io/floci/gcp/core/common/routing/ServiceRoutingFilter.java
@@ -1,0 +1,96 @@
+package io.floci.gcp.core.common.routing;
+
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceRegistry;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
+
+import java.net.URI;
+
+/**
+ * Single-port REST routing for services that share the canonical {@code /v1/projects/...}
+ * path shape on real GCP but are disambiguated only by hostname (e.g.
+ * {@code container.googleapis.com} vs {@code pubsub.googleapis.com}). On one origin those
+ * paths collide, so colliding services mount under a unique prefix (GKE → {@code /container}).
+ *
+ * <p>Before JAX-RS matching, for each routable service in the {@link ServiceRegistry}:
+ * <ul>
+ *   <li><b>Path mode</b> (Terraform/gcloud): if the path already starts with the service's
+ *       prefix ({@code /container/}) it is left as-is.</li>
+ *   <li><b>Host mode</b> (SDKs): if the path is canonical ({@code /v1/...}) and the first DNS
+ *       label of the {@code Host}/{@code :authority} header equals the service's
+ *       {@code hostToken} ({@code container}), the path is rewritten to prepend the prefix
+ *       ({@code /v1/projects/...} → {@code /container/v1/projects/...}).</li>
+ * </ul>
+ * Requests that match neither are untouched, so IAM/Datastore/SecretManager/GCS keep working.
+ * Only {@code /v1/} paths are ever rewritten, so GCS XML/object, {@code /storage}, {@code /v2}
+ * and health endpoints are never affected.
+ */
+@Provider
+@PreMatching
+@Priority(Priorities.AUTHENTICATION - 100)
+@ApplicationScoped
+public class ServiceRoutingFilter implements ContainerRequestFilter {
+
+    private final ServiceRegistry serviceRegistry;
+
+    @Inject
+    public ServiceRoutingFilter(ServiceRegistry serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext ctx) {
+        URI original = ctx.getUriInfo().getRequestUri();
+        String path = original.getRawPath();
+        if (path == null || !path.startsWith("/v1/")) {
+            return;
+        }
+
+        for (ServiceDescriptor route : serviceRegistry.getRoutableServices()) {
+            String prefix = route.pathPrefix();
+            // Already in path mode for this (or another) prefixed service → nothing to do.
+            if (path.startsWith(prefix + "/")) {
+                return;
+            }
+            if (route.hostToken() == null || route.hostToken().isBlank()) {
+                continue;
+            }
+            if (route.hostToken().equals(firstHostLabel(ctx, original))) {
+                String newPath = prefix + path;
+                URI rewritten = URI.create(original.getScheme() + "://" + original.getRawAuthority()
+                        + newPath + query(original));
+                ctx.setRequestUri(rewritten);
+                return;
+            }
+        }
+    }
+
+    private static String firstHostLabel(ContainerRequestContext ctx, URI original) {
+        String host = ctx.getHeaders().getFirst(HttpHeaders.HOST);
+        if (host == null || host.isBlank()) {
+            host = original.getRawAuthority();
+        }
+        if (host == null || host.isBlank()) {
+            return null;
+        }
+        int colon = host.indexOf(':');
+        if (colon >= 0) {
+            host = host.substring(0, colon);
+        }
+        int dot = host.indexOf('.');
+        return dot >= 0 ? host.substring(0, dot) : host;
+    }
+
+    private static String query(URI uri) {
+        String q = uri.getRawQuery();
+        return q == null || q.isBlank() ? "" : "?" + q;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/GkeClusterManager.java
+++ b/src/main/java/io/floci/gcp/services/gke/GkeClusterManager.java
@@ -1,0 +1,342 @@
+package io.floci.gcp.services.gke;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.model.Frame;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.docker.ContainerBuilder;
+import io.floci.gcp.core.common.docker.ContainerDetector;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.floci.gcp.core.common.docker.ContainerSpec;
+import io.floci.gcp.core.common.docker.DockerHostResolver;
+import io.floci.gcp.core.common.docker.PortAllocator;
+import io.floci.gcp.services.gke.model.StoredCluster;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the Docker lifecycle of {@code rancher/k3s} containers for real-mode GKE clusters.
+ * Mirrors the sibling AWS emulator's EKS cluster manager: it talks to the Docker daemon via
+ * the docker-java API (no {@code k3d}/{@code docker} CLI in the image) and spawns k3s as a
+ * sibling container. Not used when {@code floci-gcp.services.gke.mock=true}.
+ */
+@ApplicationScoped
+public class GkeClusterManager {
+
+    private static final Logger LOG = Logger.getLogger(GkeClusterManager.class);
+    private static final int K3S_API_SERVER_PORT = 6443;
+    private static final String ENDPOINT_MODE_NETWORK = "network";
+
+    private static final String WEBHOOK_CONFIG_DIR = "/etc";
+    private static final String WEBHOOK_CONFIG_FILE = "gke-token-webhook.yaml";
+    private static final String WEBHOOK_CONFIG_PATH = WEBHOOK_CONFIG_DIR + "/" + WEBHOOK_CONFIG_FILE;
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final ContainerDetector containerDetector;
+    private final PortAllocator portAllocator;
+    private final DockerHostResolver dockerHostResolver;
+    private final EmulatorConfig config;
+
+    @Inject
+    public GkeClusterManager(ContainerBuilder containerBuilder,
+                             ContainerLifecycleManager lifecycleManager,
+                             ContainerDetector containerDetector,
+                             PortAllocator portAllocator,
+                             DockerHostResolver dockerHostResolver,
+                             EmulatorConfig config) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.containerDetector = containerDetector;
+        this.portAllocator = portAllocator;
+        this.dockerHostResolver = dockerHostResolver;
+        this.config = config;
+    }
+
+    /**
+     * Starts a k3s container for the given cluster, setting its container id, host port and
+     * endpoints. The cluster status stays {@code PROVISIONING} until {@link #isReady} returns
+     * true and {@link #finalizeCluster} extracts the CA.
+     */
+    public void startCluster(StoredCluster cluster) {
+        String image = config.services().gke().defaultImage();
+        String containerName = "floci-gke-" + cluster.getName();
+
+        LOG.infov("Starting k3s container for GKE cluster {0} using image {1}",
+                cluster.getName(), image);
+
+        int hostPort = portAllocator.allocate(
+                config.services().gke().apiServerBasePort(),
+                config.services().gke().apiServerMaxPort());
+        cluster.setHostPort(hostPort);
+
+        lifecycleManager.removeIfExists(containerName);
+
+        // A named Docker volume (not a host bind mount) for the k3s data dir: bind mounts to a
+        // macOS host path make kine's unix socket chmod fail (EINVAL); named volumes live in the
+        // Docker VM's Linux filesystem. k3s v1.34+ manages embedded SQLite (kine) internally.
+        String volumeName = "floci-gke-" + cluster.getName();
+
+        List<String> serverArgs = new ArrayList<>(List.of(
+                "server", "--disable=traefik", "--tls-san=localhost"));
+
+        // Wire a token-authentication webhook so the bearer token from gke-gcloud-auth-plugin
+        // (i.e. `gcloud container clusters get-credentials` + kubectl) is validated by floci-gcp
+        // and mapped to cluster-admin — the native GKE auth flow. The kubeconfig is streamed into
+        // the container via the Docker API (not bind-mounted) so it works in Docker-in-Docker.
+        String webhookLocalFile = writeWebhookKubeconfig(cluster.getName());
+        ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
+                .withName(containerName)
+                .withEnv("K3S_KUBECONFIG_MODE", "644")
+                .withPortBinding(K3S_API_SERVER_PORT, hostPort)
+                .withNamedVolume(volumeName, "/var/lib/rancher/k3s")
+                .withDockerNetwork(config.services().gke().dockerNetwork())
+                .withPrivileged(true)
+                .withLogRotation();
+        if (webhookLocalFile != null) {
+            specBuilder.withHostDockerInternalOnLinux();
+            serverArgs.add("--kube-apiserver-arg=authentication-token-webhook-config-file=" + WEBHOOK_CONFIG_PATH);
+            serverArgs.add("--kube-apiserver-arg=authentication-token-webhook-version=v1");
+            serverArgs.add("--kube-apiserver-arg=authentication-token-webhook-cache-ttl=30s");
+        }
+        ContainerSpec spec = specBuilder.withCmd(serverArgs).build();
+
+        // create -> inject webhook kubeconfig -> start, so the file exists before the API server boots.
+        String containerId = lifecycleManager.create(spec);
+        cluster.setContainerId(containerId);
+        if (webhookLocalFile != null) {
+            copyWebhookIntoContainer(containerId, webhookLocalFile, cluster.getName());
+        }
+        ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+
+        cluster.setEndpoint(resolvePublicEndpoint(
+                containerDetector.isRunningInContainer(),
+                config.services().gke().endpointMode(),
+                containerName, hostPort));
+
+        if (containerDetector.isRunningInContainer()) {
+            ContainerLifecycleManager.EndpointInfo ep = info.getEndpoint(K3S_API_SERVER_PORT);
+            cluster.setInternalEndpoint(ep != null
+                    ? "https://" + ep.host() + ":" + ep.port()
+                    : "https://localhost:" + hostPort);
+        } else {
+            cluster.setInternalEndpoint("https://localhost:" + hostPort);
+        }
+
+        LOG.infov("k3s container {0} started for cluster {1} on port {2}",
+                containerId, cluster.getName(), String.valueOf(hostPort));
+    }
+
+    /** Polls the k3s API server's /livez endpoint to check readiness. */
+    public boolean isReady(StoredCluster cluster) {
+        String endpoint = cluster.getInternalEndpoint() != null
+                ? cluster.getInternalEndpoint()
+                : cluster.getEndpoint();
+        if (endpoint == null || cluster.getContainerId() == null) {
+            return false;
+        }
+        try {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(endpoint + "/livez").toURL().openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(2000);
+            conn.setReadTimeout(2000);
+            if (conn instanceof javax.net.ssl.HttpsURLConnection https) {
+                disableSslVerification(https);
+            }
+            int code = conn.getResponseCode();
+            return code == 200 || code == 401 || code == 403;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** Extracts the kubeconfig CA from the running k3s container and sets it on the cluster. */
+    public void finalizeCluster(StoredCluster cluster) {
+        String containerId = cluster.getContainerId();
+        if (containerId == null) {
+            return;
+        }
+        try {
+            String kubeconfigYaml = execInContainer(containerId,
+                    new String[]{"cat", "/etc/rancher/k3s/k3s.yaml"});
+            String caData = extractYamlField(kubeconfigYaml, "certificate-authority-data");
+            if (caData != null) {
+                cluster.setCaCertificate(caData.trim());
+            }
+            LOG.infov("Finalized GKE cluster {0} with CA data extracted", cluster.getName());
+        } catch (Exception e) {
+            LOG.warnv("Could not extract kubeconfig for cluster {0}: {1}",
+                    cluster.getName(), e.getMessage());
+        }
+    }
+
+    /** Stops and removes the k3s container and its data volume. */
+    public void stopCluster(StoredCluster cluster) {
+        if (cluster.getContainerId() == null) {
+            return;
+        }
+        if (config.services().gke().keepRunningOnShutdown()) {
+            LOG.infov("Leaving k3s container for cluster {0} running", cluster.getName());
+            return;
+        }
+        lifecycleManager.stopAndRemove(cluster.getContainerId(), null);
+        lifecycleManager.removeVolume("floci-gke-" + cluster.getName());
+        LOG.infov("Stopped k3s container for cluster {0}", cluster.getName());
+    }
+
+    /** The raw k3s kubeconfig (server URL unmodified), for the internal kubeconfig endpoint. */
+    public String kubeConfig(StoredCluster cluster) {
+        if (cluster.getContainerId() == null) {
+            return "";
+        }
+        try {
+            return execInContainer(cluster.getContainerId(),
+                    new String[]{"cat", "/etc/rancher/k3s/k3s.yaml"});
+        } catch (Exception e) {
+            LOG.warnv("Could not read kubeconfig for cluster {0}: {1}",
+                    cluster.getName(), e.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * The cluster's public {@code endpoint} — a bare {@code host:port} with no scheme, matching real
+     * GKE (whose endpoint is a bare host). {@code gcloud container clusters get-credentials} prepends
+     * {@code https://}, so a scheme here would produce a malformed {@code https://https://...} server.
+     */
+    static String resolvePublicEndpoint(boolean inContainer, String endpointMode,
+                                        String containerName, int hostPort) {
+        if (inContainer && ENDPOINT_MODE_NETWORK.equalsIgnoreCase(endpointMode)) {
+            return containerName + ":" + K3S_API_SERVER_PORT;
+        }
+        return "localhost:" + hostPort;
+    }
+
+    /** floci-gcp's GKE token-webhook URL, reachable from inside the k3s container. */
+    String webhookUrl() {
+        return "http://" + dockerHostResolver.resolve() + ":" + config.port() + "/_floci-gcp/gke/token-webhook";
+    }
+
+    /**
+     * Writes the token-webhook kubeconfig (pointing the k3s API server's webhook at floci-gcp) to a
+     * temp file and returns its path, or {@code null} if it could not be written (the caller then
+     * skips the webhook so cluster creation still succeeds).
+     */
+    private String writeWebhookKubeconfig(String clusterName) {
+        try {
+            Path dir = Files.createTempDirectory("floci-gke-webhook-");
+            Path file = dir.resolve(WEBHOOK_CONFIG_FILE);
+            Files.writeString(file, buildWebhookKubeconfig(webhookUrl()));
+            return file.toString();
+        } catch (IOException e) {
+            LOG.warnv("GKE token-webhook disabled for cluster {0}: could not write kubeconfig: {1}",
+                    clusterName, e.getMessage());
+            return null;
+        }
+    }
+
+    /** Streams the webhook kubeconfig into the (created, not-yet-started) k3s container at /etc. */
+    private void copyWebhookIntoContainer(String containerId, String localFile, String clusterName) {
+        try {
+            lifecycleManager.getDockerClient()
+                    .copyArchiveToContainerCmd(containerId)
+                    .withHostResource(localFile)
+                    .withRemotePath(WEBHOOK_CONFIG_DIR)
+                    .exec();
+        } catch (Exception e) {
+            LOG.warnv("GKE token-webhook may not authenticate for cluster {0}: could not copy kubeconfig "
+                    + "into the k3s container: {1}", clusterName, e.getMessage());
+        }
+    }
+
+    static String buildWebhookKubeconfig(String serverUrl) {
+        return """
+                apiVersion: v1
+                kind: Config
+                clusters:
+                - name: floci-token-webhook
+                  cluster:
+                    server: %s
+                users:
+                - name: floci-token-webhook
+                contexts:
+                - name: floci-token-webhook
+                  context:
+                    cluster: floci-token-webhook
+                    user: floci-token-webhook
+                current-context: floci-token-webhook
+                """.formatted(serverUrl);
+    }
+
+    private String execInContainer(String containerId, String[] cmd) throws Exception {
+        var dockerClient = lifecycleManager.getDockerClient();
+        ExecCreateCmdResponse exec = dockerClient
+                .execCreateCmd(containerId)
+                .withCmd(cmd)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec();
+
+        StringBuilder output = new StringBuilder();
+        boolean completed = dockerClient.execStartCmd(exec.getId())
+                .exec(new ResultCallback.Adapter<Frame>() {
+                    @Override
+                    public void onNext(Frame frame) {
+                        output.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
+                    }
+                })
+                .awaitCompletion(10, TimeUnit.SECONDS);
+
+        if (!completed) {
+            throw new RuntimeException("exec timed out in container " + containerId);
+        }
+        return output.toString();
+    }
+
+    private String extractYamlField(String yaml, String fieldName) {
+        for (String line : yaml.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith(fieldName + ":")) {
+                return trimmed.substring(fieldName.length() + 1).trim();
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("java:S4830")
+    private void disableSslVerification(javax.net.ssl.HttpsURLConnection conn) {
+        try {
+            javax.net.ssl.TrustManager[] trustAll = new javax.net.ssl.TrustManager[]{
+                new javax.net.ssl.X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+
+                    public void checkClientTrusted(java.security.cert.X509Certificate[] c, String a) {
+                    }
+
+                    public void checkServerTrusted(java.security.cert.X509Certificate[] c, String a) {
+                    }
+                }
+            };
+            javax.net.ssl.SSLContext sc = javax.net.ssl.SSLContext.getInstance("TLS");
+            sc.init(null, trustAll, new java.security.SecureRandom());
+            conn.setSSLSocketFactory(sc.getSocketFactory());
+            conn.setHostnameVerifier((h, s) -> true);
+        } catch (Exception e) {
+            LOG.debugv("Could not disable SSL verification: {0}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/GkeService.java
+++ b/src/main/java/io/floci/gcp/services/gke/GkeService.java
@@ -1,0 +1,227 @@
+package io.floci.gcp.services.gke;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.gke.model.StoredCluster;
+import io.floci.gcp.services.gke.operations.GkeOperationService;
+import io.floci.gcp.services.gke.operations.OperationType;
+import io.floci.gcp.services.gke.operations.StoredOperation;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class GkeService {
+
+    private static final Logger LOG = Logger.getLogger(GkeService.class);
+
+    private static final String DEFAULT_MASTER_VERSION = "1.30.5-gke.1014001";
+    private static final Pattern VALID_CLUSTER_NAME =
+            Pattern.compile("^[a-z](?:[a-z0-9-]{0,38}[a-z0-9])?$");
+
+    private final StorageBackend<String, StoredCluster> storage;
+    private final EmulatorConfig config;
+    private final GkeClusterManager clusterManager;
+    private final GkeOperationService operationService;
+    private final ServiceRegistry serviceRegistry;
+    private final ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "gke-readiness-poller");
+        t.setDaemon(true);
+        return t;
+    });
+
+    @Inject
+    public GkeService(StorageFactory storageFactory,
+                      EmulatorConfig config,
+                      GkeClusterManager clusterManager,
+                      GkeOperationService operationService,
+                      ServiceRegistry serviceRegistry) {
+        this(storageFactory.createGlobal("gke", "gke-clusters.json",
+                new TypeReference<Map<String, StoredCluster>>() {
+                }), config, clusterManager, operationService, serviceRegistry);
+    }
+
+    GkeService(StorageBackend<String, StoredCluster> storage,
+               EmulatorConfig config,
+               GkeClusterManager clusterManager,
+               GkeOperationService operationService,
+               ServiceRegistry serviceRegistry) {
+        this.storage = storage;
+        this.config = config;
+        this.clusterManager = clusterManager;
+        this.operationService = operationService;
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("gke")
+                .enabled(config.services().gke().enabled())
+                .storageKey("gke")
+                .protocol(ServiceProtocol.REST)
+                .hostToken("container")
+                .pathPrefix("/container")
+                .resourceClasses(KubernetesController.class)
+                .build());
+    }
+
+    @PostConstruct
+    public void init() {
+        if (!mock()) {
+            poller.scheduleAtFixedRate(this::pollReadiness, 2, 3, TimeUnit.SECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        poller.shutdownNow();
+        if (!mock()) {
+            for (StoredCluster cluster : storage.scan(k -> true)) {
+                clusterManager.stopCluster(cluster);
+            }
+        }
+    }
+
+    public StoredOperation createCluster(String project, String location, Map<String, Object> clusterMap) {
+        if (clusterMap == null) {
+            throw GcpException.invalidArgument("Missing root 'cluster' object");
+        }
+        String name = (String) clusterMap.get("name");
+        if (name == null || name.isBlank()) {
+            throw GcpException.invalidArgument("Cluster name is required");
+        }
+        if (!VALID_CLUSTER_NAME.matcher(name).matches()) {
+            throw GcpException.invalidArgument(
+                    "Invalid cluster name: '" + name + "'. Must match " + VALID_CLUSTER_NAME.pattern());
+        }
+        String key = clusterKey(project, location, name);
+        if (storage.get(key).isPresent()) {
+            throw GcpException.alreadyExists("Already exists: cluster " + name);
+        }
+
+        StoredCluster cluster = new StoredCluster();
+        cluster.setName(name);
+        cluster.setProject(project);
+        cluster.setLocation(location);
+        cluster.setCreateTime(Instant.now().toString());
+        cluster.setCurrentMasterVersion(stringField(clusterMap, "initialClusterVersion", DEFAULT_MASTER_VERSION));
+        cluster.setNetwork(stringField(clusterMap, "network", "default"));
+        cluster.setSubnetwork(stringField(clusterMap, "subnetwork", "default"));
+        cluster.setResourceLabels(labels(clusterMap));
+        cluster.setNodePools(List.of(Map.of("name", "default-pool", "status", "RUNNING")));
+        cluster.setCaCertificate("");
+        cluster.setSelfLink(selfLink(project, location, name));
+
+        if (mock()) {
+            cluster.setStatus("RUNNING");
+            cluster.setEndpoint("127.0.0.1");
+        } else {
+            cluster.setStatus("PROVISIONING");
+            try {
+                clusterManager.startCluster(cluster);
+            } catch (Exception e) {
+                LOG.errorv("Failed to start k3s container for cluster {0}: {1}", name, e.getMessage());
+                cluster.setStatus("ERROR");
+            }
+        }
+
+        storage.put(key, cluster);
+        return operationService.createOperation(project, location, name, OperationType.CREATE_CLUSTER);
+    }
+
+    public StoredCluster getCluster(String project, String location, String clusterId) {
+        return storage.get(clusterKey(project, location, clusterId))
+                .orElseThrow(() -> GcpException.notFound("Not found: cluster " + clusterId));
+    }
+
+    public List<StoredCluster> listClusters(String project, String location) {
+        return storage.scan(k -> true).stream()
+                .filter(c -> project.equals(c.getProject()) && location.equals(c.getLocation()))
+                .toList();
+    }
+
+    public StoredOperation deleteCluster(String project, String location, String clusterId) {
+        String key = clusterKey(project, location, clusterId);
+        StoredCluster cluster = storage.get(key)
+                .orElseThrow(() -> GcpException.notFound("Not found: cluster " + clusterId));
+        if (!mock()) {
+            clusterManager.stopCluster(cluster);
+        }
+        storage.delete(key);
+        return operationService.createOperation(project, location, clusterId, OperationType.DELETE_CLUSTER);
+    }
+
+    public List<StoredOperation> listOperations(String project, String location) {
+        return operationService.listOperations(project, location);
+    }
+
+    public StoredOperation getOperation(String operationId) {
+        return operationService.getOperation(operationId);
+    }
+
+    public String kubeConfig(String project, String location, String clusterId) {
+        StoredCluster cluster = getCluster(project, location, clusterId);
+        return mock() ? "" : clusterManager.kubeConfig(cluster);
+    }
+
+    private void pollReadiness() {
+        try {
+            for (StoredCluster cluster : storage.scan(k -> true)) {
+                if ("PROVISIONING".equals(cluster.getStatus()) && clusterManager.isReady(cluster)) {
+                    clusterManager.finalizeCluster(cluster);
+                    cluster.setStatus("RUNNING");
+                    storage.put(clusterKey(cluster.getProject(), cluster.getLocation(), cluster.getName()), cluster);
+                    LOG.infov("GKE cluster {0} is now RUNNING", cluster.getName());
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error in GKE readiness poller", e);
+        }
+    }
+
+    private boolean mock() {
+        return config.services().gke().mock();
+    }
+
+    private static String clusterKey(String project, String location, String name) {
+        return "projects/" + project + "/locations/" + location + "/clusters/" + name;
+    }
+
+    private String selfLink(String project, String location, String name) {
+        return config.baseUrl() + "/container/v1/" + clusterKey(project, location, name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> labels(Map<String, Object> clusterMap) {
+        Object labels = clusterMap.get("resourceLabels");
+        if (labels instanceof Map<?, ?> m) {
+            Map<String, String> result = new HashMap<>();
+            m.forEach((k, v) -> result.put(String.valueOf(k), String.valueOf(v)));
+            return result;
+        }
+        return Map.of();
+    }
+
+    private static String stringField(Map<String, Object> map, String field, String fallback) {
+        Object v = map.get(field);
+        return v instanceof String s && !s.isBlank() ? s : fallback;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/GkeTokenWebhookController.java
+++ b/src/main/java/io/floci/gcp/services/gke/GkeTokenWebhookController.java
@@ -1,0 +1,80 @@
+package io.floci.gcp.services.gke;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Kubernetes token-authentication webhook for k3s-backed GKE clusters.
+ *
+ * <p>The k3s API server is configured (see {@code GkeClusterManager}) to POST a {@code TokenReview}
+ * here for any bearer token it does not recognise — notably the GCP access token produced by
+ * {@code gke-gcloud-auth-plugin}, i.e. the credential that {@code gcloud container clusters
+ * get-credentials} wires into the kubeconfig. floci-gcp does not validate credentials, so it accepts
+ * any non-empty token and maps it to the {@code system:masters} group (bound to {@code cluster-admin}
+ * by default). This is what makes the native {@code gcloud get-credentials} + {@code kubectl} flow
+ * authenticate against a floci-gcp GKE cluster, mirroring the EKS token-webhook in the AWS emulator.
+ *
+ * <p>This is floci-gcp plumbing under the {@code _floci-gcp/...} namespace, not a GCP API.
+ */
+@ApplicationScoped
+@Path("_floci-gcp/gke/token-webhook")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GkeTokenWebhookController {
+
+    private static final Logger LOG = Logger.getLogger(GkeTokenWebhookController.class);
+
+    @POST
+    public Response review(Map<String, Object> tokenReview) {
+        // The response apiVersion MUST match the request's (the kube-apiserver sends v1beta1 by
+        // default and cannot convert a v1 response back). Echo whatever the apiserver sent.
+        String apiVersion = tokenReview != null && tokenReview.get("apiVersion") instanceof String v
+                ? v : "authentication.k8s.io/v1";
+
+        String token = extractToken(tokenReview);
+        boolean authenticated = token != null && !token.isBlank();
+
+        if (authenticated) {
+            LOG.debug("GKE token-webhook: authenticated token as cluster-admin");
+            return Response.ok(Map.of(
+                    "apiVersion", apiVersion,
+                    "kind", "TokenReview",
+                    "status", Map.of(
+                            "authenticated", true,
+                            "user", Map.of(
+                                    "username", "floci:gcp-iam",
+                                    "uid", "floci-gcp-iam",
+                                    "groups", List.of("system:masters"))))).build();
+        }
+
+        LOG.debug("GKE token-webhook: rejecting empty token");
+        return Response.ok(Map.of(
+                "apiVersion", apiVersion,
+                "kind", "TokenReview",
+                "status", Map.of("authenticated", false))).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractToken(Map<String, Object> tokenReview) {
+        if (tokenReview == null) {
+            return null;
+        }
+        Object spec = tokenReview.get("spec");
+        if (spec instanceof Map<?, ?> specMap) {
+            Object token = ((Map<String, Object>) specMap).get("token");
+            if (token instanceof String s) {
+                return s;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/KubernetesController.java
+++ b/src/main/java/io/floci/gcp/services/gke/KubernetesController.java
@@ -1,0 +1,134 @@
+package io.floci.gcp.services.gke;
+
+import io.floci.gcp.services.gke.model.StoredCluster;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GKE (container.googleapis.com) REST controller, mounted under the {@code /container}
+ * prefix to avoid colliding with the canonical {@code /v1/projects} path owned by other
+ * services. The {@code ServiceRoutingFilter} rewrites canonical SDK/CLI requests
+ * (Host {@code container.*}) to this prefix; Terraform/gcloud reach it directly via a
+ * {@code /container/v1/} custom endpoint.
+ *
+ * <p>Shapes mirror {@code google.container.v1.Cluster} / {@code Operation}.
+ */
+@Path("/container/v1/projects/{project}/locations/{location}")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class KubernetesController {
+
+    private final GkeService gkeService;
+
+    @Inject
+    public KubernetesController(GkeService gkeService) {
+        this.gkeService = gkeService;
+    }
+
+    @POST
+    @Path("/clusters")
+    public Response createCluster(
+            @PathParam("project") String project,
+            @PathParam("location") String location,
+            Map<String, Object> body) {
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> clusterMap = body == null ? null : (Map<String, Object>) body.get("cluster");
+        return Response.ok(gkeService.createCluster(project, location, clusterMap)).build();
+    }
+
+    @GET
+    @Path("/clusters")
+    public Response listClusters(
+            @PathParam("project") String project,
+            @PathParam("location") String location) {
+
+        List<Map<String, Object>> clusters = gkeService.listClusters(project, location).stream()
+                .map(KubernetesController::clusterToJson)
+                .toList();
+        return Response.ok(Map.of("clusters", clusters)).build();
+    }
+
+    @GET
+    @Path("/clusters/{clusterId}")
+    public Response getCluster(
+            @PathParam("project") String project,
+            @PathParam("location") String location,
+            @PathParam("clusterId") String clusterId) {
+
+        return Response.ok(clusterToJson(gkeService.getCluster(project, location, clusterId))).build();
+    }
+
+    @DELETE
+    @Path("/clusters/{clusterId}")
+    public Response deleteCluster(
+            @PathParam("project") String project,
+            @PathParam("location") String location,
+            @PathParam("clusterId") String clusterId) {
+
+        return Response.ok(gkeService.deleteCluster(project, location, clusterId)).build();
+    }
+
+    @GET
+    @Path("/operations")
+    public Response listOperations(
+            @PathParam("project") String project,
+            @PathParam("location") String location) {
+
+        return Response.ok(Map.of("operations", gkeService.listOperations(project, location))).build();
+    }
+
+    @GET
+    @Path("/operations/{operationId}")
+    public Response getOperation(
+            @PathParam("operationId") String operationId) {
+
+        return Response.ok(gkeService.getOperation(operationId)).build();
+    }
+
+    /** Non-standard convenience endpoint (no GKE API equivalent): raw k3s kubeconfig. */
+    @GET
+    @Path("/clusters/{clusterId}/kubeconfig")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response kubeConfig(
+            @PathParam("project") String project,
+            @PathParam("location") String location,
+            @PathParam("clusterId") String clusterId) {
+
+        return Response.ok(gkeService.kubeConfig(project, location, clusterId)).build();
+    }
+
+    private static Map<String, Object> clusterToJson(StoredCluster cluster) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("name", cluster.getName());
+        result.put("location", cluster.getLocation());
+        result.put("status", cluster.getStatus());
+        result.put("endpoint", cluster.getEndpoint());
+        result.put("selfLink", cluster.getSelfLink());
+        result.put("masterAuth", Map.of(
+                "clusterCaCertificate", cluster.getCaCertificate() == null ? "" : cluster.getCaCertificate()));
+        result.put("currentMasterVersion", cluster.getCurrentMasterVersion());
+        result.put("currentNodeVersion", cluster.getCurrentMasterVersion());
+        result.put("initialClusterVersion", cluster.getCurrentMasterVersion());
+        result.put("network", cluster.getNetwork());
+        result.put("subnetwork", cluster.getSubnetwork());
+        result.put("nodePools", cluster.getNodePools());
+        result.put("resourceLabels", cluster.getResourceLabels());
+        result.put("createTime", cluster.getCreateTime());
+        return result;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/model/StoredCluster.java
+++ b/src/main/java/io/floci/gcp/services/gke/model/StoredCluster.java
@@ -1,0 +1,168 @@
+package io.floci.gcp.services.gke.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Internal persistence model for a GKE cluster. The REST response shape
+ * ({@code google.container.v1.Cluster}) is built from this by the controller;
+ * fields here include emulator-internal state (container id, host port) that is
+ * never returned to clients.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StoredCluster {
+
+    private String name;
+    private String project;
+    private String location;
+    private String status;
+    private String endpoint;
+    private String caCertificate;
+    private String currentMasterVersion;
+    private String network;
+    private String subnetwork;
+    private List<Map<String, Object>> nodePools;
+    private Map<String, String> resourceLabels;
+    private String createTime;
+    private String selfLink;
+
+    // Emulator-internal (real mode only)
+    private String containerId;
+    private int hostPort;
+    private String internalEndpoint;
+
+    public StoredCluster() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getCaCertificate() {
+        return caCertificate;
+    }
+
+    public void setCaCertificate(String caCertificate) {
+        this.caCertificate = caCertificate;
+    }
+
+    public String getCurrentMasterVersion() {
+        return currentMasterVersion;
+    }
+
+    public void setCurrentMasterVersion(String currentMasterVersion) {
+        this.currentMasterVersion = currentMasterVersion;
+    }
+
+    public String getNetwork() {
+        return network;
+    }
+
+    public void setNetwork(String network) {
+        this.network = network;
+    }
+
+    public String getSubnetwork() {
+        return subnetwork;
+    }
+
+    public void setSubnetwork(String subnetwork) {
+        this.subnetwork = subnetwork;
+    }
+
+    public List<Map<String, Object>> getNodePools() {
+        return nodePools;
+    }
+
+    public void setNodePools(List<Map<String, Object>> nodePools) {
+        this.nodePools = nodePools;
+    }
+
+    public Map<String, String> getResourceLabels() {
+        return resourceLabels;
+    }
+
+    public void setResourceLabels(Map<String, String> resourceLabels) {
+        this.resourceLabels = resourceLabels;
+    }
+
+    public String getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(String createTime) {
+        this.createTime = createTime;
+    }
+
+    public String getSelfLink() {
+        return selfLink;
+    }
+
+    public void setSelfLink(String selfLink) {
+        this.selfLink = selfLink;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    public int getHostPort() {
+        return hostPort;
+    }
+
+    public void setHostPort(int hostPort) {
+        this.hostPort = hostPort;
+    }
+
+    public String getInternalEndpoint() {
+        return internalEndpoint;
+    }
+
+    public void setInternalEndpoint(String internalEndpoint) {
+        this.internalEndpoint = internalEndpoint;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/operations/GkeOperationService.java
+++ b/src/main/java/io/floci/gcp/services/gke/operations/GkeOperationService.java
@@ -1,0 +1,89 @@
+package io.floci.gcp.services.gke.operations;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class GkeOperationService {
+
+    private final StorageBackend<String, StoredOperation> operationStore;
+
+    @Inject
+    public GkeOperationService(StorageFactory storageFactory) {
+        this(storageFactory.createGlobal(
+                "gke",
+                "gke-operations.json",
+                new TypeReference<Map<String, StoredOperation>>() {
+                }));
+    }
+
+    public GkeOperationService(StorageBackend<String, StoredOperation> operationStore) {
+        this.operationStore = operationStore;
+    }
+
+    /**
+     * Creates a synchronous (already {@code DONE}) operation, mirroring the
+     * emulator's instant cluster lifecycle. The operation {@code name} follows
+     * GKE's {@code operation-<id>} convention so gcloud/Terraform can poll it via
+     * {@code GetOperation}.
+     */
+    public StoredOperation createOperation(
+            String project,
+            String location,
+            String clusterId,
+            OperationType type) {
+
+        String operationId = "operation-" + UUID.randomUUID();
+        String now = Instant.now().toString();
+
+        String selfLink = "projects/" + project
+                + "/locations/" + location
+                + "/operations/" + operationId;
+
+        String targetLink = "projects/" + project
+                + "/locations/" + location
+                + "/clusters/" + clusterId;
+
+        StoredOperation op = new StoredOperation(
+                operationId,
+                type,
+                "DONE",
+                location,
+                targetLink,
+                selfLink,
+                now,
+                now);
+
+        operationStore.put(operationId, op);
+
+        return op;
+    }
+
+    public List<StoredOperation> listOperations(
+            String project,
+            String location) {
+
+        return operationStore.scan(k -> true)
+                .stream()
+                .filter(op -> location.equals(op.getLocation()))
+                .toList();
+    }
+
+    public StoredOperation getOperation(
+            String operationId) {
+
+        return operationStore
+                .get(operationId)
+                .orElseThrow(() -> GcpException.notFound(
+                        "Operation not found: " + operationId));
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gke/operations/OperationType.java
+++ b/src/main/java/io/floci/gcp/services/gke/operations/OperationType.java
@@ -1,0 +1,6 @@
+package io.floci.gcp.services.gke.operations;
+
+public enum OperationType {
+    CREATE_CLUSTER,
+    DELETE_CLUSTER
+}

--- a/src/main/java/io/floci/gcp/services/gke/operations/StoredOperation.java
+++ b/src/main/java/io/floci/gcp/services/gke/operations/StoredOperation.java
@@ -1,0 +1,84 @@
+package io.floci.gcp.services.gke.operations;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Models {@code google.container.v1.Operation}. Timestamps are RFC3339 strings
+ * (proto field type {@code string}), not epoch numbers, so the HttpJson SDK /
+ * gcloud / Terraform parse them correctly.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StoredOperation {
+
+    private String name;
+    private OperationType operationType;
+    private String status;
+    private String zone;
+    private String location;
+    private String targetLink;
+    private String selfLink;
+    private String startTime;
+    private String endTime;
+
+    public StoredOperation() {
+    }
+
+    public StoredOperation(
+            String name,
+            OperationType operationType,
+            String status,
+            String location,
+            String targetLink,
+            String selfLink,
+            String startTime,
+            String endTime) {
+
+        this.name = name;
+        this.operationType = operationType;
+        this.status = status;
+        this.zone = location;
+        this.location = location;
+        this.targetLink = targetLink;
+        this.selfLink = selfLink;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getZone() {
+        return zone;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getTargetLink() {
+        return targetLink;
+    }
+
+    public String getSelfLink() {
+        return selfLink;
+    }
+
+    public String getStartTime() {
+        return startTime;
+    }
+
+    public String getEndTime() {
+        return endTime;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,15 @@ floci-gcp:
       enabled: true
       invocation-enabled: true
       tick-interval-seconds: 10
+    gke:
+      enabled: true
+      mock: false
+      default-image: "rancher/k3s:latest"
+      api-server-base-port: 6550
+      api-server-max-port: 6599
+      keep-running-on-shutdown: false
+      endpoint-mode: host
+      docker-network:
   dns:
     extra-suffixes:
   docker:

--- a/src/test/java/io/floci/gcp/core/common/routing/ServiceRoutingFilterTest.java
+++ b/src/test/java/io/floci/gcp/core/common/routing/ServiceRoutingFilterTest.java
@@ -1,0 +1,88 @@
+package io.floci.gcp.core.common.routing;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Verifies the single-port routing of GKE ({@code container} hostToken, {@code /container} prefix):
+ * host mode routes canonical {@code /v1/...} requests, path mode routes prefixed requests, and
+ * neither hijacks IAM's canonical {@code /v1/projects} surface.
+ */
+@QuarkusTest
+class ServiceRoutingFilterTest {
+
+    private static final String CANONICAL_CLUSTERS =
+            "/v1/projects/test-project/locations/us-central1/clusters";
+    private static final String PREFIXED_CLUSTERS =
+            "/container/v1/projects/test-project/locations/us-central1/clusters";
+
+    @Test
+    void hostModeRoutesCanonicalPathToGke() {
+        given()
+            .header("Host", "container.localhost")
+        .when()
+            .get(CANONICAL_CLUSTERS)
+        .then()
+            .statusCode(200)
+            .body("clusters", notNullValue());
+    }
+
+    @Test
+    void pathModeRoutesPrefixedPathToGke() {
+        given()
+        .when()
+            .get(PREFIXED_CLUSTERS)
+        .then()
+            .statusCode(200)
+            .body("clusters", notNullValue());
+    }
+
+    @Test
+    void hostDisambiguatesGkeFromTheDefaultClustersHandler() {
+        // The canonical /clusters path is shared with Managed Kafka and disambiguated only
+        // by Host. A cluster created via the container host is visible to GKE but NOT to the
+        // default (Kafka) handler, proving host-based routing rather than path hijacking.
+        String name = "route-test-cluster";
+        given()
+            .header("Host", "container.localhost")
+            .contentType("application/json")
+            .body(Map.of("cluster", Map.of("name", name)))
+        .when()
+            .post(CANONICAL_CLUSTERS)
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Host", "container.localhost")
+        .when()
+            .get(CANONICAL_CLUSTERS + "/" + name)
+        .then()
+            .statusCode(200)
+            .body("name", equalTo(name));
+
+        // Without the container host the same GET falls to the Kafka handler, which has no
+        // such cluster → 404.
+        given()
+        .when()
+            .get(CANONICAL_CLUSTERS + "/" + name)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void iamCanonicalPathStillWorks() {
+        // A genuine IAM canonical /v1 request is unaffected by the routing filter.
+        given()
+        .when()
+            .get("/v1/projects/test-project/serviceAccounts")
+        .then()
+            .statusCode(200)
+            .body("accounts", notNullValue());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gke/GkeServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gke/GkeServiceTest.java
@@ -1,0 +1,111 @@
+package io.floci.gcp.services.gke;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.gke.model.StoredCluster;
+import io.floci.gcp.services.gke.operations.GkeOperationService;
+import io.floci.gcp.services.gke.operations.OperationType;
+import io.floci.gcp.services.gke.operations.StoredOperation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GkeServiceTest {
+
+    private static final String PROJECT = "test-project";
+    private static final String LOCATION = "us-central1";
+
+    @Mock
+    EmulatorConfig config;
+    @Mock
+    EmulatorConfig.ServicesConfig services;
+    @Mock
+    EmulatorConfig.GkeServiceConfig gkeConfig;
+    @Mock
+    GkeClusterManager clusterManager;
+
+    private GkeService service;
+
+    @BeforeEach
+    void setUp() {
+        when(config.services()).thenReturn(services);
+        when(services.gke()).thenReturn(gkeConfig);
+        when(gkeConfig.mock()).thenReturn(true);
+        when(config.baseUrl()).thenReturn("http://localhost:4588");
+
+        GkeOperationService operationService =
+                new GkeOperationService(new InMemoryStorage<String, StoredOperation>());
+        service = new GkeService(new InMemoryStorage<String, StoredCluster>(), config,
+                clusterManager, operationService, null);
+    }
+
+    @Test
+    void createClusterReturnsDoneOperationAndClusterIsRunning() {
+        StoredOperation op = service.createCluster(PROJECT, LOCATION, Map.of("name", "my-cluster"));
+
+        assertNotNull(op);
+        assertEquals(OperationType.CREATE_CLUSTER, op.getOperationType());
+        assertEquals("DONE", op.getStatus());
+        assertTrue(op.getName().startsWith("operation-"));
+
+        StoredCluster cluster = service.getCluster(PROJECT, LOCATION, "my-cluster");
+        assertEquals("RUNNING", cluster.getStatus());
+        assertEquals(LOCATION, cluster.getLocation());
+        assertNotNull(cluster.getCurrentMasterVersion());
+    }
+
+    @Test
+    void createClusterRejectsMissingName() {
+        assertThrows(GcpException.class,
+                () -> service.createCluster(PROJECT, LOCATION, Map.of()));
+    }
+
+    @Test
+    void createClusterRejectsDuplicate() {
+        service.createCluster(PROJECT, LOCATION, Map.of("name", "dup"));
+        assertThrows(GcpException.class,
+                () -> service.createCluster(PROJECT, LOCATION, Map.of("name", "dup")));
+    }
+
+    @Test
+    void listClustersIsScopedToProjectAndLocation() {
+        service.createCluster(PROJECT, LOCATION, Map.of("name", "a"));
+        service.createCluster(PROJECT, LOCATION, Map.of("name", "b"));
+        service.createCluster(PROJECT, "europe-west1", Map.of("name", "c"));
+
+        List<StoredCluster> central = service.listClusters(PROJECT, LOCATION);
+        assertEquals(2, central.size());
+        assertTrue(service.listClusters("other-project", LOCATION).isEmpty());
+    }
+
+    @Test
+    void getOperationResolvesByName() {
+        StoredOperation op = service.createCluster(PROJECT, LOCATION, Map.of("name", "with-op"));
+        assertEquals(op.getName(), service.getOperation(op.getName()).getName());
+    }
+
+    @Test
+    void deleteClusterRemovesItAndReturnsOperation() {
+        service.createCluster(PROJECT, LOCATION, Map.of("name", "to-delete"));
+        StoredOperation op = service.deleteCluster(PROJECT, LOCATION, "to-delete");
+
+        assertEquals(OperationType.DELETE_CLUSTER, op.getOperationType());
+        assertThrows(GcpException.class, () -> service.getCluster(PROJECT, LOCATION, "to-delete"));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -40,5 +40,8 @@ floci-gcp:
       enabled: true
       invocation-enabled: true
       tick-interval-seconds: 1
+    gke:
+      enabled: true
+      mock: true
   docker:
     api-timeout: 30s


### PR DESCRIPTION
## Summary

Adds the GKE control plane (`container.googleapis.com`, ClusterManager v1) to floci-gcp.
Cluster lifecycle is backed by real `rancher/k3s` containers via the docker-java API (with a
`gke.mock` fast path). A new single-port `ServiceRoutingFilter` mounts GKE under `/container/v1`
and routes canonical `/v1` requests by host (`container.*`, for SDKs) or path prefix (gcloud/
Terraform) so it doesn't collide with Managed Kafka. A k8s TokenReview webhook makes the native
`gcloud container clusters get-credentials` + `kubectl` flow authenticate, exactly like real GKE.

Builds on the original GKE work in #36 (k3d driver), reworked onto the docker-java k3s backend.

Closes #3

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Verified with the GKE Java SDK `google-cloud-container` (HttpJson transport) and `gcloud`
(Cloud SDK 573.0.0) `container clusters create/describe/list` + `get-credentials` →
`kubectl get nodes` against a real k3s node. Wire shapes grounded in
`google/container/v1/cluster_service.proto`. Note: the Terraform/OpenTofu
`google_container_cluster` resource is out of scope — the google provider expects a far
richer cluster surface than the emulator implements.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (Java `GkeTest`, `ServiceRoutingFilterTest`, `GkeServiceTest`, gcloud `container.bats`)
- [x] Commit messages follow Conventional Commits