### PR TITLE
docs: document GKE config and record unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **gke:** GKE control plane (`container.googleapis.com`, ClusterManager v1) — cluster and operation lifecycle backed by real `rancher/k3s` clusters via the docker-java API (with a `gke.mock` synthetic fast path), responses following the `google.container.v1` `Cluster`/`Operation` shapes. Reached through a single-port host+path routing filter (`container.*` host for SDKs, `/container/v1` prefix for gcloud/Terraform). Native `kubectl` auth via a token webhook so `gcloud container clusters get-credentials` plus the `gke-gcloud-auth-plugin` work end to end
+
+### Fixed
+
+- **gcs:** resolved `405 Method Not Allowed` during resumable uploads when using a custom endpoint
+
 ## [0.3.0] - 2026-06-19
 
 ### Added

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -78,6 +78,12 @@ floci-gcp:
     iam:
       enabled: true
 
+    logging:
+      enabled: true
+
+    kms:
+      enabled: true
+
     kafka:
       enabled: true
       mock: false
@@ -97,9 +103,8 @@ floci-gcp:
 
     cloudrun:
       enabled: true
+      mock: false                     # false runs Docker-backed service execution
       execution:
-        enabled: false
-        mock: false
         default-port: 8080
         startup-timeout: 240s
         request-timeout: 300s
@@ -110,6 +115,24 @@ floci-gcp:
 
     cloudfunctions:
       enabled: true
+
+    monitoring:
+      enabled: true
+
+    scheduler:
+      enabled: true
+      invocation-enabled: true        # background dispatcher fires due jobs
+      tick-interval-seconds: 10
+
+    gke:
+      enabled: true
+      mock: false                     # false starts real rancher/k3s clusters
+      default-image: "rancher/k3s:latest"
+      api-server-base-port: 6550
+      api-server-max-port: 6599
+      keep-running-on-shutdown: false
+      endpoint-mode: host
+      docker-network:                 # overrides services.docker-network for k3s sidecars
 ```
 
 ## Disabling Services

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -104,6 +104,18 @@ Some services (e.g. Managed Kafka) start real sidecar containers via the host Do
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES18_IMAGE` | `postgres:18.4-alpine` | Docker image used for `POSTGRES_18` instances |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_STARTUP_TIMEOUT_SECONDS` | `90` | Max time to wait for PostgreSQL readiness after container start |
 
+### GKE (Kubernetes Engine)
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_GKE_MOCK` | `false` | When `true`, emulate the GKE control plane only — no real `k3s` clusters are started |
+| `FLOCI_GCP_SERVICES_GKE_DEFAULT_IMAGE` | `rancher/k3s:latest` | Image used for spawned k3s control-plane containers |
+| `FLOCI_GCP_SERVICES_GKE_API_SERVER_BASE_PORT` | `6550` | Lowest host port assigned to a cluster's Kubernetes API server |
+| `FLOCI_GCP_SERVICES_GKE_API_SERVER_MAX_PORT` | `6599` | Highest host port assigned to a cluster's Kubernetes API server |
+| `FLOCI_GCP_SERVICES_GKE_KEEP_RUNNING_ON_SHUTDOWN` | `false` | When `true`, leave spawned k3s containers running after floci-gcp shuts down |
+| `FLOCI_GCP_SERVICES_GKE_ENDPOINT_MODE` | `host` | How the cluster endpoint is advertised to `kubectl` (`host` for a reachable `host:port`) |
+| `FLOCI_GCP_SERVICES_GKE_DOCKER_NETWORK` | _(none)_ | Overrides `FLOCI_GCP_SERVICES_DOCKER_NETWORK` for GKE/k3s sidecars only |
+
 ---
 
 ## Initialization Hooks

--- a/docs/services/gke.md
+++ b/docs/services/gke.md
@@ -14,6 +14,9 @@ or a lightweight mock mode.
 | `FLOCI_GCP_SERVICES_GKE_DEFAULT_IMAGE` | `rancher/k3s:latest` | Image used for real clusters |
 | `FLOCI_GCP_SERVICES_GKE_API_SERVER_BASE_PORT` | `6550` | Start of the host port range for k3s API servers |
 | `FLOCI_GCP_SERVICES_GKE_API_SERVER_MAX_PORT` | `6599` | End of the host port range |
+| `FLOCI_GCP_SERVICES_GKE_ENDPOINT_MODE` | `host` | How the cluster endpoint is advertised to `kubectl` (`host` for a reachable `host:port`) |
+| `FLOCI_GCP_SERVICES_GKE_KEEP_RUNNING_ON_SHUTDOWN` | `false` | Leave spawned k3s containers running after floci-gcp shuts down |
+| `FLOCI_GCP_SERVICES_GKE_DOCKER_NETWORK` | _(none)_ | Overrides `FLOCI_GCP_SERVICES_DOCKER_NETWORK` for GKE/k3s sidecars only |
 
 ## Routing: how clients reach GKE
 
@@ -65,6 +68,25 @@ everything on one port, where that path also belongs to Managed Kafka, so GKE mo
     gcloud container clusters create my-cluster --region=us-central1 --async
     gcloud container clusters list --region=us-central1
     ```
+
+## kubectl Access
+
+Real (non-mock) clusters run an actual k3s API server, so the native
+`gcloud container clusters get-credentials` + `kubectl` flow works end to end:
+
+```bash
+gcloud container clusters get-credentials my-cluster --region=us-central1
+kubectl get nodes
+```
+
+`get-credentials` writes a kubeconfig that authenticates with the GCP access token produced by
+the `gke-gcloud-auth-plugin`. k3s forwards any bearer token it does not recognise to floci-gcp's
+token-authentication webhook, which — since floci-gcp does not validate credentials — accepts any
+non-empty token and maps it to `cluster-admin`. The cluster endpoint is advertised as a reachable
+`host:port` (`FLOCI_GCP_SERVICES_GKE_ENDPOINT_MODE=host`, the default) so the kubeconfig server URL
+resolves correctly.
+
+This flow requires a real cluster — it does not apply in mock mode, where no API server is started.
 
 ## Mock Mode
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -15,6 +15,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud KMS](kms.md) | gRPC + REST JSON | `google.cloud.kms.v1.KeyManagementService`, `/v1/projects/{project}/locations/{location}/keyRings` |
 | [IAM](iam.md) | REST JSON | `/v1/projects/{project}/serviceAccounts` |
 | [Managed Kafka](managed-kafka.md) | REST JSON | `/v1/projects/{project}/locations/{location}/clusters` |
+| [GKE (Kubernetes Engine)](gke.md) | REST JSON | `container.*` host or `/container/v1/projects/{project}/locations/{location}/clusters` |
 | [Cloud SQL for PostgreSQL](cloud-sql-postgres.md) | REST JSON | `/v1/projects/{project}/instances` |
 | [Cloud Run](cloud-run.md) | REST JSON | `/v2/projects/{project}/locations/{location}/services` |
 | [Cloud Functions](cloud-functions.md) | REST JSON | `/v2/projects/{project}/locations/{location}/functions` |


### PR DESCRIPTION
## Summary

Documentation catch-up after the GKE (#73) and GCS resumable-upload fix (#72) merges, plus a refresh of the stale `application.yml` reference.

## Changes

- **CHANGELOG:** record both unreleased entries (GKE control plane; GCS `405` resumable-upload fix with custom endpoints) under `[Unreleased]`.
- **Services overview:** add GKE to the service matrix.
- **Environment variables:** add the `FLOCI_GCP_SERVICES_GKE_*` section (mock, image, API-server port range, endpoint mode, keep-running, docker network).
- **GKE service page:** document the native `gcloud container clusters get-credentials` + `kubectl` flow (k3s token webhook → `cluster-admin`) and complete the config table.
- **application.yml reference:** fix the `cloudrun` block for the 0.3.0 root-level `mock` flag (it still showed the removed `execution.enabled`), and add the previously missing `logging`, `kms`, `monitoring`, `scheduler`, and `gke` services.

## Notes

- Docs-only change; no behavior changes.
- The `kubectl`/`get-credentials` flow is documented from the implementation (`GkeTokenWebhookController` + the k3s authentication-token-webhook); the gcloud `container.bats` compat suite currently exercises cluster CRUD but not that path.