### PR TITLE
fix(gcs): use snake_case field names in notification request and response

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsNotificationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsNotificationTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,7 +58,7 @@ class GcsNotificationTest {
     private static TopicAdminClient topicAdminClient;
     private static SubscriptionAdminClient subscriptionAdminClient;
 
-    private static String notificationId;
+    private static Notification createdNotification;
 
     @BeforeAll
     static void setUp() throws IOException {
@@ -121,13 +122,21 @@ class GcsNotificationTest {
                 .setEventTypes(NotificationInfo.EventType.OBJECT_FINALIZE,
                         NotificationInfo.EventType.OBJECT_DELETE)
                 .setPayloadFormat(NotificationInfo.PayloadFormat.JSON_API_V1)
+                .setCustomAttributes(Map.of("env", "test"))
+                .setObjectNamePrefix("notification/")
                 .build();
 
-        Notification notification = storage.createNotification(BUCKET_NAME, notifInfo);
-        assertThat(notification).isNotNull();
-        assertThat(notification.getTopic()).isEqualTo(topicName);
-        notificationId = notification.getNotificationId();
-        assertThat(notificationId).isNotBlank();
+        createdNotification = storage.createNotification(BUCKET_NAME, notifInfo);
+        assertThat(createdNotification).isNotNull();
+        assertThat(createdNotification.getTopic()).isEqualTo(topicName);
+        assertThat(createdNotification.getNotificationId()).isNotBlank();
+        assertThat(createdNotification.getPayloadFormat()).isEqualTo(NotificationInfo.PayloadFormat.JSON_API_V1);
+        assertThat(createdNotification.getEventTypes())
+                .containsExactlyInAnyOrder(NotificationInfo.EventType.OBJECT_FINALIZE,
+                        NotificationInfo.EventType.OBJECT_DELETE);
+        assertThat(createdNotification.getCustomAttributes())
+                .containsEntry("env", "test");
+        assertThat(createdNotification.getObjectNamePrefix()).isEqualTo("notification/");
     }
 
     @Test
@@ -135,15 +144,23 @@ class GcsNotificationTest {
     void listNotificationsReturnCreated() {
         List<Notification> notifications = storage.listNotifications(BUCKET_NAME);
         assertThat(notifications).isNotEmpty();
-        assertThat(notifications.stream().anyMatch(n -> notificationId.equals(n.getNotificationId()))).isTrue();
+        assertThat(notifications.stream()
+                .anyMatch(n -> createdNotification.getNotificationId().equals(n.getNotificationId())))
+                .isTrue();
     }
 
     @Test
     @Order(4)
     void getNotificationById() {
-        Notification notification = storage.getNotification(BUCKET_NAME, notificationId);
+        Notification notification = storage.getNotification(BUCKET_NAME, createdNotification.getNotificationId());
         assertThat(notification).isNotNull();
-        assertThat(notification.getNotificationId()).isEqualTo(notificationId);
+        assertThat(notification.getNotificationId()).isEqualTo(createdNotification.getNotificationId());
+        assertThat(notification.getTopic()).isEqualTo(createdNotification.getTopic());
+        assertThat(notification.getPayloadFormat()).isEqualTo(createdNotification.getPayloadFormat());
+        assertThat(notification.getEventTypes())
+                .containsExactlyInAnyOrderElementsOf(createdNotification.getEventTypes());
+        assertThat(notification.getCustomAttributes()).isEqualTo(createdNotification.getCustomAttributes());
+        assertThat(notification.getObjectNamePrefix()).isEqualTo(createdNotification.getObjectNamePrefix());
     }
 
     @Test
@@ -222,11 +239,11 @@ class GcsNotificationTest {
     @Test
     @Order(7)
     void deleteNotificationConfig() {
-        storage.deleteNotification(BUCKET_NAME, notificationId);
+        storage.deleteNotification(BUCKET_NAME, createdNotification.getNotificationId());
 
         List<Notification> remaining = storage.listNotifications(BUCKET_NAME);
         boolean stillPresent = remaining.stream()
-                .anyMatch(n -> notificationId.equals(n.getNotificationId()));
+                .anyMatch(n -> createdNotification.getNotificationId().equals(n.getNotificationId()));
         assertThat(stillPresent).isFalse();
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -758,16 +758,16 @@ public class GcsService {
         StoredNotification notif = new StoredNotification();
         notif.setId(id);
         notif.setTopic((String) body.get("topic"));
-        String fmt = (String) body.get("payloadFormat");
+        String fmt = (String) body.get("payload_format");
         if (fmt != null) notif.setPayloadFormat(fmt);
-        if (body.containsKey("eventTypes")) {
-            notif.setEventTypes((List<String>) body.get("eventTypes"));
+        if (body.containsKey("event_types")) {
+            notif.setEventTypes((List<String>) body.get("event_types"));
         }
-        if (body.containsKey("customAttributes")) {
-            notif.setCustomAttributes((Map<String, String>) body.get("customAttributes"));
+        if (body.containsKey("custom_attributes")) {
+            notif.setCustomAttributes((Map<String, String>) body.get("custom_attributes"));
         }
-        if (body.containsKey("objectNamePrefix")) {
-            notif.setObjectNamePrefix((String) body.get("objectNamePrefix"));
+        if (body.containsKey("object_name_prefix")) {
+            notif.setObjectNamePrefix((String) body.get("object_name_prefix"));
         }
         notif.setSelfLink(config != null
                 ? config.baseUrl() + "/storage/v1/b/" + bucket + "/notificationConfigs/" + id

--- a/src/main/java/io/floci/gcp/services/gcs/model/StoredNotification.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/StoredNotification.java
@@ -1,5 +1,6 @@
 package io.floci.gcp.services.gcs.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -16,12 +17,16 @@ public class StoredNotification {
     private String selfLink;
     private String topic;
     @JsonProperty("payload_format")
+    @JsonAlias("payloadFormat")
     private String payloadFormat = "JSON_API_V1";
     @JsonProperty("event_types")
+    @JsonAlias("eventTypes")
     private List<String> eventTypes;
     @JsonProperty("custom_attributes")
+    @JsonAlias("customAttributes")
     private Map<String, String> customAttributes;
     @JsonProperty("object_name_prefix")
+    @JsonAlias("objectNamePrefix")
     private String objectNamePrefix;
 
     public String getKind() { return kind; }

--- a/src/main/java/io/floci/gcp/services/gcs/model/StoredNotification.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/StoredNotification.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.gcs.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.List;
@@ -14,9 +15,13 @@ public class StoredNotification {
     private String id;
     private String selfLink;
     private String topic;
+    @JsonProperty("payload_format")
     private String payloadFormat = "JSON_API_V1";
+    @JsonProperty("event_types")
     private List<String> eventTypes;
+    @JsonProperty("custom_attributes")
     private Map<String, String> customAttributes;
+    @JsonProperty("object_name_prefix")
     private String objectNamePrefix;
 
     public String getKind() { return kind; }


### PR DESCRIPTION
## Summary

The Google Storage REST API uses snake_case for notification fields (`payload_format`, `event_types`, `object_name_prefix`, `custom_attributes`), but `createNotification` was reading camelCase keys from the request body, silently dropping those values. The GET response also serialized as camelCase, so clients reading back a notification would receive empty values for those fields.

Fix `GcsService` to accept snake_case keys and add `@JsonProperty` annotations to `StoredNotification` so the response matches the API spec: https://docs.cloud.google.com/storage/docs/json_api/v1/notifications

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Verified by creating a GCS Notification via a Terraform test and the `hashicorp/google` Terraform provider.
Before the fix, Terraform fails to apply with error, indicating the API returns empty fields:

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to
│ module.gcs_bucket.google_storage_notification.this[0], provider
│ "provider[\"registry.terraform.io/hashicorp/google\"]" produced an
│ unexpected new value: .payload_format: was cty.StringVal("JSON_API_V1"),
│ but now cty.StringVal("").
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```

Ran the sdk-test-java compatibility tests which include `GcsNotificationTest`.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
