### PR TITLE
fix(pubsub): deliver messages to active StreamingPull streams

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/pubsub.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/pubsub.test.ts
@@ -76,6 +76,40 @@ describe('Pub/Sub', () => {
     });
   });
 
+  it('should stream messages published after the listener starts', async () => {
+    const streamingTopicName = uniqueName('test-stream-topic');
+    const streamingSubscriptionName = uniqueName('test-stream-sub');
+    const [topic] = await pubsub.createTopic(streamingTopicName);
+    const [subscription] = await topic.createSubscription(streamingSubscriptionName);
+
+    try {
+      const received = new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('No streaming message received')), 10000);
+        subscription.on('message', (message) => {
+          clearTimeout(timer);
+          message.ack();
+          resolve(message.data.toString());
+        });
+        subscription.on('error', (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+      });
+
+      await sleep(200);
+      await topic.publishMessage({
+        data: Buffer.from('StreamingPull message'),
+        attributes: { source: 'node-streaming-test' },
+      });
+
+      await expect(received).resolves.toBe('StreamingPull message');
+    } finally {
+      await subscription.close().catch(() => {});
+      await subscription.delete().catch(() => {});
+      await topic.delete().catch(() => {});
+    }
+  });
+
   it('should delete subscription', async () => {
     await pubsub.subscription(subscriptionName).delete();
     const [subscriptions] = await pubsub.getSubscriptions();

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
@@ -44,6 +45,7 @@ public class PubSubService {
 
     private final ConcurrentHashMap<String, ConcurrentLinkedDeque<StoredMessage>> queues = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, StoredMessage>> delivered = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CopyOnWriteArrayList<MessageListener>> listeners = new ConcurrentHashMap<>();
     private final AtomicLong messageIdCounter = new AtomicLong(0);
 
     private final ServiceRegistry serviceRegistry;
@@ -215,6 +217,7 @@ public class PubSubService {
         subStore.put(name, sub);
         queues.put(name, new ConcurrentLinkedDeque<>());
         delivered.put(name, new ConcurrentHashMap<>());
+        listeners.put(name, new CopyOnWriteArrayList<>());
         return sub;
     }
 
@@ -353,6 +356,7 @@ public class PubSubService {
         subStore.delete(name);
         queues.remove(name);
         delivered.remove(name);
+        listeners.remove(name);
     }
 
     public void detachSubscription(String name) {
@@ -363,6 +367,7 @@ public class PubSubService {
         subStore.put(name, sub);
         queues.remove(name);
         delivered.remove(name);
+        listeners.remove(name);
     }
 
     public List<String> listTopicSubscriptions(String topicName) {
@@ -403,6 +408,7 @@ public class PubSubService {
                 StoredSubscription sub = subStore.get(entry).orElse(null);
                 if (sub != null && !sub.isDetached() && topicName.equals(sub.getTopic())) {
                     queues.computeIfAbsent(entry, k -> new ConcurrentLinkedDeque<>()).add(stored);
+                    notifyListeners(entry);
                     fanOut++;
                 }
             }
@@ -473,6 +479,33 @@ public class PubSubService {
         for (String ackId : ackIds) {
             deliveredMap.remove(ackId);
         }
+    }
+
+    Runnable registerMessageListener(String subName, MessageListener listener) {
+        getSubscription(subName);
+        CopyOnWriteArrayList<MessageListener> subscriptionListeners =
+                listeners.computeIfAbsent(subName, k -> new CopyOnWriteArrayList<>());
+        subscriptionListeners.add(listener);
+        return () -> subscriptionListeners.remove(listener);
+    }
+
+    private void notifyListeners(String subName) {
+        CopyOnWriteArrayList<MessageListener> subscriptionListeners = listeners.get(subName);
+        if (subscriptionListeners == null) {
+            return;
+        }
+        for (MessageListener listener : subscriptionListeners) {
+            try {
+                listener.onMessagesAvailable();
+            } catch (Exception e) {
+                LOG.warnf("message listener failed for subscription=%s: %s", subName, e.getMessage());
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface MessageListener {
+        void onMessagesAvailable();
     }
 
     // ── Snapshots ──────────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
@@ -190,25 +190,20 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
                     deliverStreamingMessages(sub, responseObserver, closed, deliveryLock);
                 } catch (Exception e) {
                     LOG.warnf("streamingPull error: %s", e.getMessage());
-                    closeStreamingPull(unregisterRef, closed);
-                    responseObserver.onError(GcpGrpcController.grpcException(e));
+                    failStreamingPull(responseObserver, unregisterRef, closed, deliveryLock, e);
                 }
             }
 
             @Override
             public void onError(Throwable t) {
                 LOG.debugf("streamingPull stream closed by client: %s", t.getMessage());
-                closeStreamingPull(unregisterRef, closed);
-                try {
-                    responseObserver.onCompleted();
-                } catch (Exception ignored) {}
+                completeStreamingPull(responseObserver, unregisterRef, closed, deliveryLock);
             }
 
             @Override
             public void onCompleted() {
                 LOG.debugf("streamingPull stream completed subscription=%s", subscriptionRef.get());
-                closeStreamingPull(unregisterRef, closed);
-                responseObserver.onCompleted();
+                completeStreamingPull(responseObserver, unregisterRef, closed, deliveryLock);
             }
         };
     }
@@ -232,13 +227,38 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
         }
     }
 
-    private void closeStreamingPull(AtomicReference<Runnable> unregisterRef, AtomicBoolean closed) {
-        if (closed.compareAndSet(false, true)) {
-            Runnable unregister = unregisterRef.getAndSet(null);
-            if (unregister != null) {
-                unregister.run();
+    private void completeStreamingPull(StreamObserver<StreamingPullResponse> responseObserver,
+            AtomicReference<Runnable> unregisterRef,
+            AtomicBoolean closed,
+            Object deliveryLock) {
+        synchronized (deliveryLock) {
+            if (closeStreamingPull(unregisterRef, closed)) {
+                responseObserver.onCompleted();
             }
         }
+    }
+
+    private void failStreamingPull(StreamObserver<StreamingPullResponse> responseObserver,
+            AtomicReference<Runnable> unregisterRef,
+            AtomicBoolean closed,
+            Object deliveryLock,
+            Exception e) {
+        synchronized (deliveryLock) {
+            if (closeStreamingPull(unregisterRef, closed)) {
+                responseObserver.onError(GcpGrpcController.grpcException(e));
+            }
+        }
+    }
+
+    private boolean closeStreamingPull(AtomicReference<Runnable> unregisterRef, AtomicBoolean closed) {
+        if (!closed.compareAndSet(false, true)) {
+            return false;
+        }
+        Runnable unregister = unregisterRef.getAndSet(null);
+        if (unregister != null) {
+            unregister.run();
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
@@ -14,6 +14,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBase {
@@ -157,6 +158,9 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
     public StreamObserver<StreamingPullRequest> streamingPull(
             StreamObserver<StreamingPullResponse> responseObserver) {
         AtomicReference<String> subscriptionRef = new AtomicReference<>();
+        AtomicReference<Runnable> unregisterRef = new AtomicReference<>();
+        AtomicBoolean closed = new AtomicBoolean(false);
+        Object deliveryLock = new Object();
 
         return new StreamObserver<>() {
             @Override
@@ -165,6 +169,14 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
                     if (!request.getSubscription().isEmpty()) {
                         String sub = request.getSubscription();
                         subscriptionRef.set(sub);
+                        Runnable previous = unregisterRef.getAndSet(
+                                service.registerMessageListener(
+                                        sub,
+                                        () -> deliverStreamingMessages(
+                                                sub, responseObserver, closed, deliveryLock)));
+                        if (previous != null) {
+                            previous.run();
+                        }
                         LOG.infof("streamingPull opened subscription=%s", sub);
                     }
                     String sub = subscriptionRef.get();
@@ -175,16 +187,10 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
                         LOG.debugf("streamingPull ack subscription=%s ackIds=%d", sub, request.getAckIdsCount());
                         service.acknowledge(sub, request.getAckIdsList());
                     }
-                    List<ReceivedMessage> messages = service.pull(sub, 1000);
-                    if (!messages.isEmpty()) {
-                        LOG.debugf("streamingPull deliver subscription=%s messages=%d", sub, messages.size());
-                        responseObserver.onNext(
-                                StreamingPullResponse.newBuilder()
-                                        .addAllReceivedMessages(messages)
-                                        .build());
-                    }
+                    deliverStreamingMessages(sub, responseObserver, closed, deliveryLock);
                 } catch (Exception e) {
                     LOG.warnf("streamingPull error: %s", e.getMessage());
+                    closeStreamingPull(unregisterRef, closed);
                     responseObserver.onError(GcpGrpcController.grpcException(e));
                 }
             }
@@ -192,6 +198,7 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
             @Override
             public void onError(Throwable t) {
                 LOG.debugf("streamingPull stream closed by client: %s", t.getMessage());
+                closeStreamingPull(unregisterRef, closed);
                 try {
                     responseObserver.onCompleted();
                 } catch (Exception ignored) {}
@@ -200,9 +207,38 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
             @Override
             public void onCompleted() {
                 LOG.debugf("streamingPull stream completed subscription=%s", subscriptionRef.get());
+                closeStreamingPull(unregisterRef, closed);
                 responseObserver.onCompleted();
             }
         };
+    }
+
+    private void deliverStreamingMessages(String sub,
+            StreamObserver<StreamingPullResponse> responseObserver,
+            AtomicBoolean closed,
+            Object deliveryLock) {
+        synchronized (deliveryLock) {
+            if (closed.get()) {
+                return;
+            }
+            List<ReceivedMessage> messages = service.pull(sub, 1000);
+            if (!messages.isEmpty()) {
+                LOG.debugf("streamingPull deliver subscription=%s messages=%d", sub, messages.size());
+                responseObserver.onNext(
+                        StreamingPullResponse.newBuilder()
+                                .addAllReceivedMessages(messages)
+                                .build());
+            }
+        }
+    }
+
+    private void closeStreamingPull(AtomicReference<Runnable> unregisterRef, AtomicBoolean closed) {
+        if (closed.compareAndSet(false, true)) {
+            Runnable unregister = unregisterRef.getAndSet(null);
+            if (unregister != null) {
+                unregister.run();
+            }
+        }
     }
 
     @Override

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubSubscriberControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubSubscriberControllerTest.java
@@ -1,0 +1,89 @@
+package io.floci.gcp.services.pubsub;
+
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.StreamingPullRequest;
+import com.google.pubsub.v1.StreamingPullResponse;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PubSubSubscriberControllerTest {
+
+    private PubSubService service;
+    private PubSubSubscriberController controller;
+
+    @BeforeEach
+    void setUp() {
+        service = new PubSubService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>());
+        controller = new PubSubSubscriberController(service);
+    }
+
+    @Test
+    void streamingPullReceivesMessagePublishedAfterStreamOpens() throws Exception {
+        String topic = "projects/p1/topics/t1";
+        String subscription = "projects/p1/subscriptions/s1";
+        service.createTopic(topic);
+        service.createSubscription(subscription, topic, 10);
+
+        RecordingObserver<StreamingPullResponse> responseObserver = new RecordingObserver<>();
+        StreamObserver<StreamingPullRequest> requestObserver = controller.streamingPull(responseObserver);
+
+        requestObserver.onNext(StreamingPullRequest.newBuilder()
+                .setSubscription(subscription)
+                .build());
+
+        service.publish(topic, List.of(PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8("hello"))
+                .putAttributes("source", "streaming-pull-test")
+                .build()));
+
+        assertTrue(responseObserver.awaitValue(), "streaming pull should deliver published message");
+        assertNull(responseObserver.error.get());
+        StreamingPullResponse response = responseObserver.values.get(0);
+        assertEquals(1, response.getReceivedMessagesCount());
+        assertEquals("hello", response.getReceivedMessages(0).getMessage().getData().toStringUtf8());
+        assertEquals("streaming-pull-test",
+                response.getReceivedMessages(0).getMessage().getAttributesOrThrow("source"));
+
+        requestObserver.onCompleted();
+    }
+
+    private static final class RecordingObserver<T> implements StreamObserver<T> {
+        private final CountDownLatch valueLatch = new CountDownLatch(1);
+        private final List<T> values = new CopyOnWriteArrayList<>();
+        private final AtomicReference<Throwable> error = new AtomicReference<>();
+
+        @Override
+        public void onNext(T value) {
+            values.add(value);
+            valueLatch.countDown();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error.set(t);
+        }
+
+        @Override
+        public void onCompleted() {}
+
+        private boolean awaitValue() throws InterruptedException {
+            return valueLatch.await(1, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #83.

This fixes Pub/Sub `StreamingPull` so messages published after a streaming subscriber has opened are delivered to that active stream. Previously `StreamingPull` only drained queued messages when the client sent a `StreamingPullRequest`; if the queue was empty when the stream opened, later publishes only enqueued messages and never woke the stream.

Changes:

- Add per-subscription message listeners in `PubSubService`.
- Register active `StreamingPull` streams and wake them when `publish()` enqueues messages.
- Keep unary `Pull` behavior unchanged.
- Add a Java regression test for stream-open-before-publish delivery.
- Add a Node compatibility test for `@google-cloud/pubsub` `subscription.on('message')`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

The incorrect behavior was that the Node high-level Pub/Sub subscriber API (`subscription.on('message')`) opened `Subscriber/StreamingPull`, but messages published after the stream opened were not delivered. Unary `Subscriber/Pull` could receive the same message, so publish/fanout worked but active stream delivery was missing.

This PR verifies the expected client behavior with a Node compatibility test that starts the listener before publishing, then asserts the listener receives the published message.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Local validation

- `./mvnw test -Dtest=PubSubServiceTest,PubSubSubscriberControllerTest`
- `./mvnw test`
- `PUBSUB_EMULATOR_HOST=localhost:4588 FLOCI_GCP_ENDPOINT=http://localhost:4588 npm test -- tests/pubsub.test.ts` from `compatibility-tests/sdk-test-node`, against `./mvnw quarkus:dev`
