### PR TITLE
feat(firebaseauth): implement Identity Platform / Firebase Auth v1 REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Cloud Scheduler | ✅ | ❌ |
 | Cloud Monitoring | ✅ | ❌ |
 | Service Usage | ✅ | ❌ |
+| Identity Platform / Firebase Auth | ✅ | ❌ |
 | Native binary | ✅ | ❌ |
 
 ## Architecture Overview
@@ -215,6 +216,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Cloud Scheduler** | gRPC + REST JSON | Cron jobs with Pub/Sub, HTTP, and App Engine targets; `Pause`/`Resume`/`RunJob`; unix-cron + time zones; background tick fires due jobs (Pub/Sub publishes into the local backend) |
 | **Cloud Monitoring** | gRPC + REST JSON | Metric descriptors (create/get/list/delete), monitored resource descriptors, time series write (`CreateTimeSeries`) and read (`ListTimeSeries`) |
 | **Service Usage** | REST JSON | Enable/disable/list a project's services (`serviceusage.googleapis.com` v1) with done LROs; accept-and-succeed state store for Terraform `google_project_service`, Pulumi, and `gcloud services`; includes a minimal Cloud Resource Manager v1 `projects.get` for provider project lookups |
+| **Firebase Auth (Identity Platform)** | REST JSON | Identity Toolkit v1 wire-compatible with the official Auth emulator: email/password, anonymous and custom-token sign-in, unsigned emulator JWTs `firebase-admin` verifies, token refresh + revocation, admin user CRUD/list via `FIREBASE_AUTH_EMULATOR_HOST` |
 
 </details>
 

--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -49,7 +49,7 @@ just test-all-iac
 
 ## Test Coverage
 
-### SDK tests — 250 tests total
+### SDK tests — 256 tests total
 
 | Test class | GCP service | Java | Python | Node | Go |
 |---|---|:---:|:---:|:---:|:---:|
@@ -67,7 +67,8 @@ just test-all-iac
 | `SchedulerTest` | Cloud Scheduler | 7 | 0 | 0 | 0 |
 | `EventarcTest` | Eventarc | 7 | 0 | 0 | 0 |
 | `ServiceUsageTest` | Service Usage | 6 | 0 | 0 | 0 |
-| **Total** | | **85** | **48** | **59** | **58** |
+| `FirebaseAuthTest` | Firebase Auth | 6 | 0 | 0 | 0 |
+| **Total** | | **91** | **48** | **59** | **58** |
 
 GKE uses the HttpJson transport (the Cloud SDK defaults to gRPC, which the REST-only
 emulator does not serve for GKE) and reaches the service via host-based routing

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -102,6 +102,11 @@
             <artifactId>google-cloud-service-usage</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>9.9.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.7</version>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirebaseAuthTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirebaseAuthTest.java
@@ -1,0 +1,155 @@
+package io.floci.gcp.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.google.firebase.auth.UserRecord;
+import com.google.firebase.internal.EmulatorCredentials;
+import com.google.firebase.internal.FirebaseProcessEnvironment;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * firebase-admin SDK against floci-gcp via FIREBASE_AUTH_EMULATOR_HOST. Client-mode
+ * calls (API-key sign-in) resolve to the emulator's default project, mirroring the
+ * official Auth emulator's single-project behavior — so the Firebase app is
+ * initialized with that project ID.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FirebaseAuthTest {
+
+    private static final String PROJECT_ID =
+            System.getenv().getOrDefault("FLOCI_GCP_DEFAULT_PROJECT", "floci-local");
+    private static final String UID = "fb-compat-" + TestFixtures.uniqueName("u").replace("-", "");
+    private static final String EMAIL = UID.toLowerCase() + "@example.com";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static FirebaseApp app;
+    private static FirebaseAuth auth;
+    private static String signedInIdToken;
+
+    @BeforeAll
+    static void setUp() {
+        String host = TestFixtures.endpoint().replaceFirst("^https?://", "");
+        FirebaseProcessEnvironment.setenv("FIREBASE_AUTH_EMULATOR_HOST", host);
+        app = FirebaseApp.initializeApp(FirebaseOptions.builder()
+                .setProjectId(PROJECT_ID)
+                .setCredentials(new EmulatorCredentials())
+                .build(), "floci-firebase-auth-test");
+        auth = FirebaseAuth.getInstance(app);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (auth != null) {
+            try {
+                auth.deleteUser(UID);
+            } catch (FirebaseAuthException ignored) {
+                // already deleted by the test
+            }
+        }
+        if (app != null) {
+            app.delete();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createUserAndGetByEmail() throws Exception {
+        UserRecord created = auth.createUser(new UserRecord.CreateRequest()
+                .setUid(UID)
+                .setEmail(EMAIL)
+                .setPassword("secret123")
+                .setDisplayName("Compat User")
+                .setEmailVerified(true));
+
+        assertThat(created.getUid()).isEqualTo(UID);
+        assertThat(created.getEmail()).isEqualTo(EMAIL);
+
+        UserRecord fetched = auth.getUserByEmail(EMAIL);
+        assertThat(fetched.getUid()).isEqualTo(UID);
+        assertThat(fetched.getDisplayName()).isEqualTo("Compat User");
+        assertThat(fetched.isEmailVerified()).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void setCustomClaimsRoundtrip() throws Exception {
+        auth.setCustomUserClaims(UID, Map.of("role", "tester"));
+
+        UserRecord fetched = auth.getUser(UID);
+        assertThat(fetched.getCustomClaims()).containsEntry("role", "tester");
+    }
+
+    @Test
+    @Order(3)
+    void customTokenSignInAndVerifyIdToken() throws Exception {
+        String customToken = auth.createCustomToken(UID, Map.of("premium", true));
+
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create(TestFixtures.endpoint()
+                                + "/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake-api-key"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(
+                                MAPPER.writeValueAsString(Map.of("token", customToken, "returnSecureToken", true))))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode body = MAPPER.readTree(response.body());
+        assertThat(body.get("isNewUser").asBoolean()).isFalse();
+        signedInIdToken = body.get("idToken").asText();
+
+        FirebaseToken decoded = auth.verifyIdToken(signedInIdToken);
+        assertThat(decoded.getUid()).isEqualTo(UID);
+        assertThat(decoded.getClaims().get("premium")).isEqualTo(true);
+        assertThat(decoded.getClaims().get("role")).isEqualTo("tester");
+    }
+
+    @Test
+    @Order(4)
+    void listUsersContainsCreatedUser() throws Exception {
+        List<String> uids = new ArrayList<>();
+        auth.listUsers(null).iterateAll().forEach(user -> uids.add(user.getUid()));
+
+        assertThat(uids).contains(UID);
+    }
+
+    @Test
+    @Order(5)
+    void revokeRefreshTokensInvalidatesIdToken() throws Exception {
+        Thread.sleep(1100);
+        auth.revokeRefreshTokens(UID);
+
+        assertThatThrownBy(() -> auth.verifyIdToken(signedInIdToken, true))
+                .isInstanceOf(FirebaseAuthException.class);
+    }
+
+    @Test
+    @Order(6)
+    void deleteUserRemovesAccount() throws Exception {
+        auth.deleteUser(UID);
+
+        assertThatThrownBy(() -> auth.getUser(UID))
+                .isInstanceOf(FirebaseAuthException.class);
+    }
+}

--- a/docs/services/firebase-auth.md
+++ b/docs/services/firebase-auth.md
@@ -1,0 +1,84 @@
+# Identity Platform / Firebase Auth
+
+floci-gcp emulates the Google Identity Toolkit API (`identitytoolkit.googleapis.com` v1)
+wire-compatibly with the **official Firebase Auth emulator**: same paths, same unsigned
+JWTs, same error strings. Anything that works against `firebase emulators:start --only auth`
+is the compatibility target.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_FIREBASEAUTH_ENABLED` | `true` | Enable/disable Firebase Auth |
+
+## Endpoint
+
+Set `FIREBASE_AUTH_EMULATOR_HOST=localhost:4588`. Firebase SDKs then prefix requests with
+the API hostname as a **path**, which floci-gcp serves directly on its single port:
+
+| Method | Path |
+|---|---|
+| `POST` | `/identitytoolkit.googleapis.com/v1/accounts:signUp` \| `:signInWithPassword` \| `:signInWithCustomToken` \| `:lookup` \| `:update` \| `:delete` (client, `?key=` any non-empty API key) |
+| `POST` | `/identitytoolkit.googleapis.com/v1/projects/{project}/accounts[:lookup\|:update\|:delete\|:batchDelete]` (admin, `Authorization: Bearer owner`) |
+| `GET` | `/identitytoolkit.googleapis.com/v1/projects/{project}/accounts:batchGet` (admin listUsers) |
+| `POST` | `/securetoken.googleapis.com/v1/token` (refresh; JSON or form-urlencoded) |
+| `DELETE` | `/emulator/v1/projects/{project}/accounts` (test helper: delete all users) |
+
+## Tokens
+
+- ID tokens are **unsigned JWTs** (`alg: none`, empty signature) with the claims the
+  Admin SDK's emulator-mode verifier checks: `iss=https://securetoken.google.com/{project}`,
+  `aud={project}`, `sub`/`user_id`, `auth_time`, `firebase.{identities, sign_in_provider}`.
+  Custom claims (from `setCustomUserClaims` or custom-token `claims`) are merged into the payload.
+- Refresh tokens follow the emulator's base64-JSON record format; `POST /securetoken.../token`
+  with `grant_type=refresh_token` re-issues tokens.
+- Token revocation: `revokeRefreshTokens` sets `validSince`; tokens with `iat < validSince`
+  fail with `TOKEN_EXPIRED` (wall-clock `exp` is intentionally not enforced, like the emulator).
+- Custom tokens: Admin SDK JWTs (signed or unsigned) and the emulator's strict-JSON form
+  (`{"uid": "...", "claims": {...}}`) are both accepted.
+
+## Quick Start
+
+=== "Java (firebase-admin)"
+
+    ```java
+    // export FIREBASE_AUTH_EMULATOR_HOST=localhost:4588
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
+            .setProjectId("floci-local")   // the emulator's default project
+            .setCredentials(new EmulatorCredentials())
+            .build());
+    FirebaseAuth auth = FirebaseAuth.getInstance(app);
+
+    auth.createUser(new UserRecord.CreateRequest()
+            .setUid("alice").setEmail("alice@example.com").setPassword("secret123"));
+    auth.setCustomUserClaims("alice", Map.of("role", "admin"));
+    String customToken = auth.createCustomToken("alice");
+    // client exchanges it at accounts:signInWithCustomToken, then:
+    FirebaseToken decoded = auth.verifyIdToken(idToken);
+    ```
+
+=== "REST"
+
+    ```bash
+    # client sign-up (any non-empty API key)
+    curl -X POST 'http://localhost:4588/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-api-key' \
+      -H 'Content-Type: application/json' \
+      -d '{"email":"alice@example.com","password":"secret123"}'
+
+    # refresh
+    curl -X POST 'http://localhost:4588/securetoken.googleapis.com/v1/token?key=fake-api-key' \
+      -d 'grant_type=refresh_token&refresh_token=<refreshToken>'
+    ```
+
+## Scope and deviations
+
+- Client API-key calls resolve to the emulator's **default project**
+  (`floci-gcp.default-project-id`), mirroring the official emulator's single-project model.
+- Phase 1 covers email/password, anonymous, and custom-token flows plus the admin user CRUD
+  surface (create/lookup/update/delete/batchGet/batchDelete). Not yet implemented: OOB codes
+  (email verification / password reset), email-link, IdP, phone, MFA, passkeys, tenants,
+  session cookies, and the legacy v3 `relyingparty` paths — these return 404 (the official
+  emulator returns 501 for unimplemented operations).
+- Passwords are stored in the emulator's literal `fakeHash:salt=...:password=...` format —
+  a dev fixture, not a security boundary, identical to the official emulator.
+- `securetoken` responses report `project_id: "12345"`, the emulator's hardcoded project number.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -23,6 +23,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud Scheduler](scheduler.md) | gRPC + REST JSON | `google.cloud.scheduler.v1.CloudScheduler`, `/v1/projects/{project}/locations/{location}/jobs` |
 | [Cloud Monitoring](cloud-monitoring.md) | gRPC + REST JSON | `google.monitoring.v3.MetricService`, `/v3/projects/{project}` |
 | [Service Usage](service-usage.md) | REST JSON | `/v1/projects/{project}/services` (+ minimal Resource Manager `/v1/projects/{projectId}`) |
+| [Firebase Auth](firebase-auth.md) | REST JSON | `/identitytoolkit.googleapis.com/v1/accounts:*`, `/securetoken.googleapis.com/v1/token` |
 
 ## Single-Port Design
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,4 +86,5 @@ nav:
     - Cloud Scheduler: services/scheduler.md
     - Cloud Monitoring: services/cloud-monitoring.md
     - Service Usage: services/service-usage.md
+    - Firebase Auth: services/firebase-auth.md
   - Contributing: contributing.md

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -110,9 +110,16 @@ public interface EmulatorConfig {
         ServiceUsageServiceConfig serviceusage();
 
         ResourceManagerServiceConfig resourcemanager();
+
+        FirebaseAuthServiceConfig firebaseauth();
     }
 
     interface ServiceUsageServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface FirebaseAuthServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthController.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthController.java
@@ -1,0 +1,206 @@
+package io.floci.gcp.services.firebaseauth;
+
+import io.floci.gcp.config.EmulatorConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+
+/**
+ * Identity Toolkit v1 REST surface, mounted at the same paths the Firebase Auth
+ * emulator serves: the API hostname is a path prefix (SDKs with
+ * FIREBASE_AUTH_EMULATOR_HOST prepend it), bare /v1 is intentionally not served.
+ */
+@Path("/identitytoolkit.googleapis.com/v1")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class FirebaseAuthController {
+
+    private final FirebaseAuthService service;
+    private final EmulatorConfig config;
+
+    @Inject
+    public FirebaseAuthController(FirebaseAuthService service, EmulatorConfig config) {
+        this.service = service;
+        this.config = config;
+    }
+
+    // ── client endpoints (project inferred from API key → default project) ────
+
+    @POST
+    @Path("/accounts:signUp")
+    public Response signUp(@HeaderParam("Authorization") String authorization,
+                           @QueryParam("key") String apiKey,
+                           @HeaderParam("x-goog-api-key") String apiKeyHeader,
+                           Map<String, Object> body) {
+        boolean privileged = requireClientOrPrivileged(authorization, apiKey, apiKeyHeader);
+        return json(service.signUp(defaultProject(), safe(body), privileged));
+    }
+
+    @POST
+    @Path("/accounts:signInWithPassword")
+    public Response signInWithPassword(@HeaderParam("Authorization") String authorization,
+                                       @QueryParam("key") String apiKey,
+                                       @HeaderParam("x-goog-api-key") String apiKeyHeader,
+                                       Map<String, Object> body) {
+        requireClientOrPrivileged(authorization, apiKey, apiKeyHeader);
+        return json(service.signInWithPassword(defaultProject(), safe(body)));
+    }
+
+    @POST
+    @Path("/accounts:signInWithCustomToken")
+    public Response signInWithCustomToken(@HeaderParam("Authorization") String authorization,
+                                          @QueryParam("key") String apiKey,
+                                          @HeaderParam("x-goog-api-key") String apiKeyHeader,
+                                          Map<String, Object> body) {
+        requireClientOrPrivileged(authorization, apiKey, apiKeyHeader);
+        return json(service.signInWithCustomToken(defaultProject(), safe(body)));
+    }
+
+    @POST
+    @Path("/accounts:lookup")
+    public Response lookup(@HeaderParam("Authorization") String authorization,
+                           @QueryParam("key") String apiKey,
+                           @HeaderParam("x-goog-api-key") String apiKeyHeader,
+                           Map<String, Object> body) {
+        boolean privileged = requireClientOrPrivileged(authorization, apiKey, apiKeyHeader);
+        return json(service.lookup(defaultProject(), safe(body), privileged));
+    }
+
+    @POST
+    @Path("/accounts:update")
+    public Response update(@HeaderParam("Authorization") String authorization,
+                           @QueryParam("key") String apiKey,
+                           @HeaderParam("x-goog-api-key") String apiKeyHeader,
+                           Map<String, Object> body) {
+        boolean privileged = requireClientOrPrivileged(authorization, apiKey, apiKeyHeader);
+        return json(service.update(defaultProject(), safe(body), privileged));
+    }
+
+    @POST
+    @Path("/accounts:delete")
+    public Response delete(@HeaderParam("Authorization") String authorization,
+                           @QueryParam("key") String apiKey,
+                           @HeaderParam("x-goog-api-key") String apiKeyHeader,
+                           Map<String, Object> body) {
+        boolean privileged = requireClientOrPrivileged(authorization, apiKey, apiKeyHeader);
+        return json(service.delete(defaultProject(), safe(body), privileged));
+    }
+
+    // ── admin endpoints (firebase-admin SDK, project in path) ─────────────────
+
+    @POST
+    @Path("/projects/{project}/accounts")
+    public Response adminSignUp(@HeaderParam("Authorization") String authorization,
+                                @PathParam("project") String project,
+                                Map<String, Object> body) {
+        requirePrivileged(authorization);
+        return json(service.signUp(project, safe(body), true));
+    }
+
+    @POST
+    @Path("/projects/{project}/accounts:lookup")
+    public Response adminLookup(@HeaderParam("Authorization") String authorization,
+                                @PathParam("project") String project,
+                                Map<String, Object> body) {
+        requirePrivileged(authorization);
+        return json(service.lookup(project, safe(body), true));
+    }
+
+    @POST
+    @Path("/projects/{project}/accounts:update")
+    public Response adminUpdate(@HeaderParam("Authorization") String authorization,
+                                @PathParam("project") String project,
+                                Map<String, Object> body) {
+        requirePrivileged(authorization);
+        return json(service.update(project, safe(body), true));
+    }
+
+    @POST
+    @Path("/projects/{project}/accounts:delete")
+    public Response adminDelete(@HeaderParam("Authorization") String authorization,
+                                @PathParam("project") String project,
+                                Map<String, Object> body) {
+        requirePrivileged(authorization);
+        return json(service.delete(project, safe(body), true));
+    }
+
+    @GET
+    @Path("/projects/{project}/accounts:batchGet")
+    public Response batchGet(@HeaderParam("Authorization") String authorization,
+                             @PathParam("project") String project,
+                             @QueryParam("maxResults") @DefaultValue("0") int maxResults,
+                             @QueryParam("nextPageToken") String nextPageToken) {
+        requirePrivileged(authorization);
+        return json(service.batchGet(project, maxResults, nextPageToken));
+    }
+
+    @POST
+    @Path("/projects/{project}/accounts:batchDelete")
+    public Response batchDelete(@HeaderParam("Authorization") String authorization,
+                                @PathParam("project") String project,
+                                Map<String, Object> body) {
+        requirePrivileged(authorization);
+        return json(service.batchDelete(project, safe(body)));
+    }
+
+    // ── auth model (matches the Auth emulator) ────────────────────────────────
+
+    static boolean isPrivileged(String authorization) {
+        if (authorization == null || !authorization.regionMatches(true, 0, "bearer ", 0, 7)) {
+            return false;
+        }
+        String token = authorization.substring(7).trim();
+        if ("owner".equalsIgnoreCase(token) || token.startsWith("ya29.")) {
+            return true;
+        }
+        throw FirebaseAuthException.unauthenticated(
+                "Request had invalid authentication credentials. Expected OAuth 2 access token, "
+                        + "login cookie or other valid authentication credential.");
+    }
+
+    static void requirePrivileged(String authorization) {
+        if (authorization == null) {
+            throw FirebaseAuthException.unauthenticated(
+                    "Request is missing required authentication credential. Expected OAuth 2 "
+                            + "access token, login cookie or other valid authentication credential.");
+        }
+        isPrivileged(authorization);
+    }
+
+    private static boolean requireClientOrPrivileged(String authorization, String apiKey, String apiKeyHeader) {
+        if (authorization != null) {
+            return isPrivileged(authorization);
+        }
+        boolean hasKey = (apiKey != null && !apiKey.isEmpty())
+                || (apiKeyHeader != null && !apiKeyHeader.isEmpty());
+        if (!hasKey) {
+            throw FirebaseAuthException.permissionDenied("The request is missing a valid API key.");
+        }
+        return false;
+    }
+
+    private String defaultProject() {
+        return config.defaultProjectId();
+    }
+
+    private static Map<String, Object> safe(Map<String, Object> body) {
+        return body == null ? Map.of() : body;
+    }
+
+    private static Response json(Object entity) {
+        return Response.ok(entity, MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthController.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthController.java
@@ -172,17 +172,16 @@ public class FirebaseAuthController {
     }
 
     static void requirePrivileged(String authorization) {
-        if (authorization == null) {
+        if (authorization == null || !isPrivileged(authorization)) {
             throw FirebaseAuthException.unauthenticated(
                     "Request is missing required authentication credential. Expected OAuth 2 "
                             + "access token, login cookie or other valid authentication credential.");
         }
-        isPrivileged(authorization);
     }
 
     private static boolean requireClientOrPrivileged(String authorization, String apiKey, String apiKeyHeader) {
-        if (authorization != null) {
-            return isPrivileged(authorization);
+        if (authorization != null && isPrivileged(authorization)) {
+            return true;
         }
         boolean hasKey = (apiKey != null && !apiKey.isEmpty())
                 || (apiKeyHeader != null && !apiKeyHeader.isEmpty());

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthEmulatorController.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthEmulatorController.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.firebaseauth;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+
+/** Emulator-only management surface (unauthenticated, like the official Auth emulator). */
+@Path("/emulator/v1")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class FirebaseAuthEmulatorController {
+
+    private final FirebaseAuthService service;
+
+    @Inject
+    public FirebaseAuthEmulatorController(FirebaseAuthService service) {
+        this.service = service;
+    }
+
+    @DELETE
+    @Path("/projects/{project}/accounts")
+    public Response deleteAllAccounts(@PathParam("project") String project) {
+        service.deleteAllAccounts(project);
+        return Response.ok(Map.of(), MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthException.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthException.java
@@ -1,0 +1,46 @@
+package io.floci.gcp.services.firebaseauth;
+
+/**
+ * Firebase Auth wire errors. The Identity Toolkit error body differs from the generic
+ * GCP JSON error ({@code GcpExceptionMapper}): the machine-readable code IS the message
+ * (optionally with a "CODE : detail" suffix), the errors[] reason is always "invalid",
+ * and plain 400 asserts carry no status field — matching the official Auth emulator.
+ */
+public class FirebaseAuthException extends RuntimeException {
+
+    private final int httpCode;
+    private final String status;
+
+    private FirebaseAuthException(int httpCode, String status, String message) {
+        super(message);
+        this.httpCode = httpCode;
+        this.status = status;
+    }
+
+    public int getHttpCode() {
+        return httpCode;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    /** Mirrors the emulator's assert() → BadRequestError: HTTP 400, no status field. */
+    public static FirebaseAuthException badRequest(String message) {
+        return new FirebaseAuthException(400, null, message);
+    }
+
+    public static FirebaseAuthException permissionDenied(String message) {
+        return new FirebaseAuthException(403, "PERMISSION_DENIED", message);
+    }
+
+    public static FirebaseAuthException unauthenticated(String message) {
+        return new FirebaseAuthException(401, "UNAUTHENTICATED", message);
+    }
+
+    public static void check(boolean condition, String message) {
+        if (!condition) {
+            throw badRequest(message);
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthExceptionMapper.java
@@ -1,0 +1,32 @@
+package io.floci.gcp.services.firebaseauth;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Provider
+public class FirebaseAuthExceptionMapper implements ExceptionMapper<FirebaseAuthException> {
+
+    @Override
+    public Response toResponse(FirebaseAuthException e) {
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("code", e.getHttpCode());
+        error.put("message", e.getMessage());
+        error.put("errors", List.of(Map.of(
+                "message", e.getMessage(),
+                "domain", "global",
+                "reason", "invalid")));
+        if (e.getStatus() != null) {
+            error.put("status", e.getStatus());
+        }
+        return Response.status(e.getHttpCode())
+                .type(MediaType.APPLICATION_JSON)
+                .entity(Map.of("error", error))
+                .build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
@@ -1,0 +1,783 @@
+package io.floci.gcp.services.firebaseauth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.firebaseauth.model.ProviderUserInfo;
+import io.floci.gcp.services.firebaseauth.model.StoredUser;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.floci.gcp.services.firebaseauth.FirebaseAuthException.badRequest;
+import static io.floci.gcp.services.firebaseauth.FirebaseAuthException.check;
+
+/**
+ * Identity Toolkit v1 emulation, wire-compatible with the official Firebase Auth emulator
+ * (local/google/firebase-tools/src/emulator/auth). Tokens are unsigned JWTs; passwords are
+ * stored as the emulator's literal fakeHash strings — this service is a dev fixture, not
+ * a security boundary.
+ */
+@ApplicationScoped
+public class FirebaseAuthService {
+
+    private static final Logger LOG = Logger.getLogger(FirebaseAuthService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static final String ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final int PASSWORD_MIN_LENGTH = 6;
+    private static final long TOKEN_EXPIRES_IN_SECONDS = 3600;
+    private static final String PROJECT_NUMBER = "12345";
+    static final String CUSTOM_TOKEN_AUDIENCE =
+            "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit";
+    private static final Set<String> RESERVED_CLAIMS = Set.of(
+            "iss", "aud", "sub", "iat", "exp", "nbf", "jti", "nonce", "azp", "acr", "amr",
+            "cnf", "auth_time", "firebase", "at_hash", "c_hash");
+
+    private final StorageBackend<String, String> userStore;
+    private final ServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+
+    @Inject
+    public FirebaseAuthService(StorageFactory storageFactory,
+                               ServiceRegistry serviceRegistry,
+                               EmulatorConfig config) {
+        this.userStore = storageFactory.createGlobal("firebaseauth", "firebaseauth-users.json",
+                new TypeReference<Map<String, String>>() {});
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+    }
+
+    FirebaseAuthService(StorageBackend<String, String> userStore, EmulatorConfig config) {
+        this.userStore = userStore;
+        this.serviceRegistry = null;
+        this.config = config;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("firebaseauth")
+                .enabled(config.services().firebaseauth().enabled())
+                .storageKey("firebaseauth")
+                .protocol(ServiceProtocol.REST)
+                .resourceClasses(FirebaseAuthController.class, SecureTokenController.class,
+                        FirebaseAuthEmulatorController.class)
+                .build());
+    }
+
+    // ── signUp ────────────────────────────────────────────────────────────────
+
+    public Map<String, Object> signUp(String project, Map<String, Object> body, boolean privileged) {
+        String email = str(body.get("email"));
+        String password = str(body.get("password"));
+        String idToken = str(body.get("idToken"));
+        String requestedLocalId = str(body.get("localId"));
+
+        String provider = null;
+        StoredUser existing = null;
+        if (privileged) {
+            if (idToken != null) {
+                check(requestedLocalId == null, "UNEXPECTED_PARAMETER : User ID");
+                existing = parseIdToken(project, idToken);
+            } else if (requestedLocalId != null) {
+                check(getUser(project, requestedLocalId) == null, "DUPLICATE_LOCAL_ID");
+            }
+        } else {
+            check(requestedLocalId == null, "UNEXPECTED_PARAMETER : User ID");
+            if (idToken != null || password != null || email != null) {
+                check(email != null, "MISSING_EMAIL");
+                check(password != null, "MISSING_PASSWORD");
+                provider = "password";
+            } else {
+                provider = "anonymous";
+            }
+            if (idToken != null) {
+                existing = parseIdToken(project, idToken);
+            }
+        }
+
+        if (email != null) {
+            check(isValidEmail(email), "INVALID_EMAIL");
+            email = canonicalizeEmail(email);
+            StoredUser byEmail = findByEmail(project, email);
+            check(byEmail == null || (existing != null && byEmail.getLocalId().equals(existing.getLocalId())),
+                    "EMAIL_EXISTS");
+        }
+        if (password != null) {
+            check(password.length() >= PASSWORD_MIN_LENGTH,
+                    "WEAK_PASSWORD : Password should be at least 6 characters");
+        }
+
+        String nowMs = String.valueOf(Instant.now().toEpochMilli());
+        StoredUser user = existing != null ? existing : new StoredUser();
+        if (existing == null) {
+            user.setLocalId(requestedLocalId != null ? requestedLocalId : randomId(28));
+            user.setCreatedAt(nowMs);
+            user.setLastLoginAt(nowMs);
+        }
+        boolean anonymous = "anonymous".equals(provider);
+        if (!anonymous) {
+            if (email != null) {
+                user.setEmail(email);
+            }
+            if (body.get("displayName") != null) {
+                user.setDisplayName(str(body.get("displayName")));
+            }
+            if (body.get("photoUrl") != null) {
+                user.setPhotoUrl(str(body.get("photoUrl")));
+            }
+        }
+        if (privileged) {
+            user.setEmailVerified(bool(body.get("emailVerified")));
+            if (body.get("disabled") != null) {
+                user.setDisabled(bool(body.get("disabled")));
+            }
+            String phoneNumber = str(body.get("phoneNumber"));
+            if (phoneNumber != null) {
+                check(phoneNumber.startsWith("+"), "INVALID_PHONE_NUMBER : Invalid format.");
+                check(findByPhoneNumber(project, phoneNumber) == null, "PHONE_NUMBER_EXISTS");
+                user.setPhoneNumber(phoneNumber);
+            }
+        } else if (existing == null) {
+            user.setEmailVerified(false);
+        }
+        if (password != null) {
+            setPassword(user, password);
+            upsertPasswordProvider(user);
+        }
+        putUser(project, user);
+        LOG.debugf("firebaseauth signUp project=%s localId=%s provider=%s", project, user.getLocalId(), provider);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "identitytoolkit#SignupNewUserResponse");
+        response.put("localId", user.getLocalId());
+        if (user.getDisplayName() != null) {
+            response.put("displayName", user.getDisplayName());
+        }
+        if (user.getEmail() != null) {
+            response.put("email", user.getEmail());
+        }
+        if (provider != null) {
+            response.putAll(issueTokens(project, user, provider, Map.of()));
+        }
+        return response;
+    }
+
+    // ── signInWithPassword ────────────────────────────────────────────────────
+
+    public Map<String, Object> signInWithPassword(String project, Map<String, Object> body) {
+        String email = str(body.get("email"));
+        String password = str(body.get("password"));
+        check(email != null, "MISSING_EMAIL");
+        check(isValidEmail(email), "INVALID_EMAIL");
+        check(password != null && !password.isEmpty(), "MISSING_PASSWORD");
+
+        StoredUser user = findByEmail(project, canonicalizeEmail(email));
+        check(user != null, "EMAIL_NOT_FOUND");
+        check(!user.isDisabled(), "USER_DISABLED");
+        check(user.getPasswordHash() != null && user.getSalt() != null, "INVALID_PASSWORD");
+        check(user.getPasswordHash().equals(hashPassword(password, user.getSalt())), "INVALID_PASSWORD");
+
+        user.setLastLoginAt(String.valueOf(Instant.now().toEpochMilli()));
+        putUser(project, user);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "identitytoolkit#VerifyPasswordResponse");
+        response.put("registered", true);
+        response.put("localId", user.getLocalId());
+        response.put("email", user.getEmail());
+        response.putAll(issueTokens(project, user, "password", Map.of()));
+        return response;
+    }
+
+    // ── signInWithCustomToken ─────────────────────────────────────────────────
+
+    public Map<String, Object> signInWithCustomToken(String project, Map<String, Object> body) {
+        String token = str(body.get("token"));
+        check(token != null && !token.isEmpty(), "MISSING_CUSTOM_TOKEN");
+
+        Map<String, Object> payload;
+        if (token.trim().startsWith("{")) {
+            try {
+                payload = MAPPER.readValue(token, new TypeReference<Map<String, Object>>() {});
+            } catch (Exception e) {
+                throw badRequest("INVALID_CUSTOM_TOKEN : "
+                        + "((Auth Emulator only accepts strict JSON or JWTs as fake custom tokens.))");
+            }
+        } else {
+            payload = FirebaseJwt.decodePayload(token);
+            check(payload != null, "INVALID_CUSTOM_TOKEN : Invalid assertion format");
+            check(CUSTOM_TOKEN_AUDIENCE.equals(payload.get("aud")),
+                    "INVALID_CUSTOM_TOKEN : ((Invalid aud (audience) in custom token.))");
+        }
+
+        String localId = str(payload.get("uid") != null ? payload.get("uid") : payload.get("user_id"));
+        check(localId != null && !localId.isEmpty(), "MISSING_IDENTIFIER");
+
+        Map<String, Object> extraClaims = Map.of();
+        if (payload.containsKey("claims")) {
+            extraClaims = validateCustomClaims(payload.get("claims"));
+        }
+
+        StoredUser user = getUser(project, localId);
+        boolean isNewUser = user == null;
+        if (user == null) {
+            user = new StoredUser();
+            user.setLocalId(localId);
+            user.setCreatedAt(String.valueOf(Instant.now().toEpochMilli()));
+        } else {
+            check(!user.isDisabled(), "USER_DISABLED");
+        }
+        user.setCustomAuth(true);
+        user.setLastLoginAt(String.valueOf(Instant.now().toEpochMilli()));
+        putUser(project, user);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "identitytoolkit#VerifyCustomTokenResponse");
+        response.put("isNewUser", isNewUser);
+        response.putAll(issueTokens(project, user, "custom", extraClaims));
+        return response;
+    }
+
+    // ── lookup ────────────────────────────────────────────────────────────────
+
+    public Map<String, Object> lookup(String project, Map<String, Object> body, boolean privileged) {
+        List<StoredUser> users = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        if (privileged) {
+            for (String localId : strList(body.get("localId"))) {
+                addUser(users, seen, getUser(project, localId));
+            }
+            for (String email : strList(body.get("email"))) {
+                addUser(users, seen, findByEmail(project, canonicalizeEmail(email)));
+            }
+            for (String phone : strList(body.get("phoneNumber"))) {
+                addUser(users, seen, findByPhoneNumber(project, phone));
+            }
+        } else {
+            String idToken = str(body.get("idToken"));
+            check(idToken != null, "MISSING_ID_TOKEN");
+            addUser(users, seen, parseIdToken(project, idToken));
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "identitytoolkit#GetAccountInfoResponse");
+        if (!users.isEmpty()) {
+            response.put("users", users);
+        }
+        return response;
+    }
+
+    // ── update (setAccountInfo) ───────────────────────────────────────────────
+
+    public Map<String, Object> update(String project, Map<String, Object> body, boolean privileged) {
+        String idToken = str(body.get("idToken"));
+        StoredUser user;
+        String signInProvider = null;
+        if (privileged) {
+            String localId = str(body.get("localId"));
+            check(localId != null, "MISSING_LOCAL_ID");
+            user = getUser(project, localId);
+            check(user != null, "USER_NOT_FOUND");
+        } else {
+            check(idToken != null, "INVALID_REQ_TYPE : Unsupported request parameters.");
+            check(body.get("customAttributes") == null, "INSUFFICIENT_PERMISSION");
+            check(body.get("disableUser") == null, "OPERATION_NOT_ALLOWED");
+            user = parseIdToken(project, idToken);
+            signInProvider = user.getPasswordHash() != null ? "password"
+                    : Boolean.TRUE.equals(user.getCustomAuth()) ? "custom" : "anonymous";
+        }
+
+        boolean revokesTokens = false;
+
+        String email = str(body.get("email"));
+        if (email != null) {
+            check(isValidEmail(email), "INVALID_EMAIL");
+            email = canonicalizeEmail(email);
+            if (!email.equals(user.getEmail())) {
+                StoredUser byEmail = findByEmail(project, email);
+                check(byEmail == null, "EMAIL_EXISTS");
+                user.setEmail(email);
+                user.setEmailVerified(false);
+                revokesTokens = true;
+            }
+        }
+        String password = str(body.get("password"));
+        if (password != null) {
+            check(password.length() >= PASSWORD_MIN_LENGTH,
+                    "WEAK_PASSWORD : Password should be at least 6 characters");
+            setPassword(user, password);
+            upsertPasswordProvider(user);
+            signInProvider = "password";
+            revokesTokens = true;
+        }
+        if (body.get("validSince") != null) {
+            user.setValidSince(str(body.get("validSince")));
+            revokesTokens = true;
+        } else if (revokesTokens) {
+            user.setValidSince(String.valueOf(Instant.now().getEpochSecond()));
+        }
+        if (body.get("displayName") != null) {
+            user.setDisplayName(str(body.get("displayName")));
+        }
+        if (body.get("photoUrl") != null) {
+            user.setPhotoUrl(str(body.get("photoUrl")));
+        }
+        if (privileged) {
+            if (body.get("disableUser") != null) {
+                user.setDisabled(bool(body.get("disableUser")));
+            }
+            if (body.get("emailVerified") != null) {
+                user.setEmailVerified(bool(body.get("emailVerified")));
+            }
+            if (body.get("customAttributes") != null) {
+                String serialized = str(body.get("customAttributes"));
+                validateSerializedCustomClaims(serialized);
+                user.setCustomAttributes(serialized);
+            }
+            String phoneNumber = str(body.get("phoneNumber"));
+            if (phoneNumber != null) {
+                check(phoneNumber.startsWith("+"), "INVALID_PHONE_NUMBER : Invalid format.");
+                StoredUser byPhone = findByPhoneNumber(project, phoneNumber);
+                check(byPhone == null || byPhone.getLocalId().equals(user.getLocalId()), "PHONE_NUMBER_EXISTS");
+                user.setPhoneNumber(phoneNumber);
+            }
+        }
+        for (String attribute : strList(body.get("deleteAttribute"))) {
+            switch (attribute) {
+                case "DISPLAY_NAME" -> user.setDisplayName(null);
+                case "PHOTO_URL" -> user.setPhotoUrl(null);
+                case "EMAIL" -> user.setEmail(null);
+                case "PASSWORD" -> {
+                    user.setPasswordHash(null);
+                    user.setSalt(null);
+                }
+                default -> { }
+            }
+        }
+        for (String providerId : strList(body.get("deleteProvider"))) {
+            if ("password".equals(providerId)) {
+                user.setEmail(null);
+                user.setPasswordHash(null);
+                user.setSalt(null);
+            } else if ("phone".equals(providerId)) {
+                user.setPhoneNumber(null);
+            }
+            if (user.getProviderUserInfo() != null) {
+                user.setProviderUserInfo(user.getProviderUserInfo().stream()
+                        .filter(p -> !providerId.equals(p.getProviderId()))
+                        .toList());
+            }
+        }
+        putUser(project, user);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "identitytoolkit#SetAccountInfoResponse");
+        response.put("localId", user.getLocalId());
+        if (user.getEmail() != null) {
+            response.put("email", user.getEmail());
+        }
+        if (user.getDisplayName() != null) {
+            response.put("displayName", user.getDisplayName());
+        }
+        if (user.getPhotoUrl() != null) {
+            response.put("photoUrl", user.getPhotoUrl());
+        }
+        if (user.getEmailVerified() != null) {
+            response.put("emailVerified", user.getEmailVerified());
+        }
+        if (user.getProviderUserInfo() != null && !user.getProviderUserInfo().isEmpty()) {
+            response.put("providerUserInfo", user.getProviderUserInfo());
+        }
+        if (user.getPasswordHash() != null) {
+            response.put("passwordHash", user.getPasswordHash());
+        }
+        if (revokesTokens && signInProvider != null) {
+            response.putAll(issueTokens(project, user, signInProvider, Map.of()));
+        }
+        return response;
+    }
+
+    // ── delete ────────────────────────────────────────────────────────────────
+
+    public Map<String, Object> delete(String project, Map<String, Object> body, boolean privileged) {
+        StoredUser user;
+        if (privileged && body.get("localId") != null) {
+            user = getUser(project, str(body.get("localId")));
+            check(user != null, "USER_NOT_FOUND");
+        } else {
+            String idToken = str(body.get("idToken"));
+            check(idToken != null, "MISSING_ID_TOKEN");
+            user = parseIdToken(project, idToken);
+        }
+        userStore.delete(userKey(project, user.getLocalId()));
+        LOG.debugf("firebaseauth delete project=%s localId=%s", project, user.getLocalId());
+        return Map.of("kind", "identitytoolkit#DeleteAccountResponse");
+    }
+
+    // ── batchGet / batchDelete ────────────────────────────────────────────────
+
+    public Map<String, Object> batchGet(String project, int maxResults, String nextPageToken) {
+        int effectiveMax = maxResults <= 0 ? 20 : Math.min(maxResults, 1000);
+        List<StoredUser> all = listUsers(project).stream()
+                .filter(u -> nextPageToken == null || nextPageToken.isEmpty()
+                        || u.getLocalId().compareTo(nextPageToken) > 0)
+                .toList();
+        List<StoredUser> page = all.stream().limit(effectiveMax).toList();
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "identitytoolkit#DownloadAccountResponse");
+        if (!page.isEmpty()) {
+            response.put("users", page);
+        }
+        if (page.size() >= effectiveMax) {
+            response.put("nextPageToken", page.get(page.size() - 1).getLocalId());
+        }
+        return response;
+    }
+
+    public Map<String, Object> batchDelete(String project, Map<String, Object> body) {
+        List<String> localIds = strList(body.get("localIds"));
+        check(!localIds.isEmpty() && localIds.size() <= 1000, "LOCAL_ID_LIST_EXCEEDS_LIMIT");
+        boolean force = Boolean.TRUE.equals(bool(body.get("force")));
+
+        List<Map<String, Object>> errors = new ArrayList<>();
+        for (int i = 0; i < localIds.size(); i++) {
+            StoredUser user = getUser(project, localIds.get(i));
+            if (user == null) {
+                continue;
+            }
+            if (!force && !user.isDisabled()) {
+                errors.add(Map.of(
+                        "index", i,
+                        "localId", user.getLocalId(),
+                        "message", "NOT_DISABLED : Disable the account before batch deletion."));
+                continue;
+            }
+            userStore.delete(userKey(project, user.getLocalId()));
+        }
+        Map<String, Object> response = new LinkedHashMap<>();
+        if (!errors.isEmpty()) {
+            response.put("errors", errors);
+        }
+        return response;
+    }
+
+    // ── securetoken grantToken ────────────────────────────────────────────────
+
+    public Map<String, Object> grantToken(String project, String grantType, String refreshToken) {
+        check(grantType != null && !grantType.isEmpty(), "MISSING_GRANT_TYPE");
+        check("refresh_token".equals(grantType), "INVALID_GRANT_TYPE");
+        check(refreshToken != null && !refreshToken.isEmpty(), "MISSING_REFRESH_TOKEN");
+
+        Map<String, Object> record;
+        try {
+            record = MAPPER.readValue(Base64.getDecoder().decode(refreshToken),
+                    new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            throw badRequest("INVALID_REFRESH_TOKEN");
+        }
+        check(record.containsKey("_AuthEmulatorRefreshToken"), "INVALID_REFRESH_TOKEN");
+        check(project.equals(record.get("projectId")), "INVALID_REFRESH_TOKEN");
+
+        StoredUser user = getUser(project, str(record.get("localId")));
+        check(user != null, "INVALID_REFRESH_TOKEN");
+        check(!user.isDisabled(), "USER_DISABLED");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> extraClaims = record.get("extraClaims") instanceof Map<?, ?> m
+                ? (Map<String, Object>) m : Map.of();
+        Map<String, Object> tokens = issueTokens(project, user, str(record.get("provider")), extraClaims);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id_token", tokens.get("idToken"));
+        response.put("access_token", tokens.get("idToken"));
+        response.put("expires_in", tokens.get("expiresIn"));
+        response.put("refresh_token", tokens.get("refreshToken"));
+        response.put("token_type", "Bearer");
+        response.put("user_id", user.getLocalId());
+        response.put("project_id", PROJECT_NUMBER);
+        return response;
+    }
+
+    // ── emulator management ───────────────────────────────────────────────────
+
+    public void deleteAllAccounts(String project) {
+        String prefix = "projects/" + project + "/users/";
+        for (String key : List.copyOf(userStore.keys())) {
+            if (key.startsWith(prefix)) {
+                userStore.delete(key);
+            }
+        }
+    }
+
+    // ── tokens ────────────────────────────────────────────────────────────────
+
+    Map<String, Object> issueTokens(String project, StoredUser user, String provider,
+                                    Map<String, Object> extraClaims) {
+        user.setLastRefreshAt(Instant.now().toString());
+        putUser(project, user);
+
+        Map<String, Object> refreshRecord = new LinkedHashMap<>();
+        refreshRecord.put("_AuthEmulatorRefreshToken", "DO NOT MODIFY");
+        refreshRecord.put("localId", user.getLocalId());
+        refreshRecord.put("provider", provider);
+        refreshRecord.put("extraClaims", extraClaims);
+        refreshRecord.put("projectId", project);
+        String refreshToken;
+        try {
+            refreshToken = Base64.getEncoder().encodeToString(
+                    MAPPER.writeValueAsBytes(refreshRecord));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encode refresh token", e);
+        }
+
+        Map<String, Object> tokens = new LinkedHashMap<>();
+        tokens.put("idToken", generateIdToken(project, user, provider, extraClaims));
+        tokens.put("refreshToken", refreshToken);
+        tokens.put("expiresIn", String.valueOf(TOKEN_EXPIRES_IN_SECONDS));
+        return tokens;
+    }
+
+    private String generateIdToken(String project, StoredUser user, String provider,
+                                   Map<String, Object> extraClaims) {
+        long iat = Instant.now().getEpochSecond();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (user.getDisplayName() != null) {
+            payload.put("name", user.getDisplayName());
+        }
+        if (user.getPhotoUrl() != null) {
+            payload.put("picture", user.getPhotoUrl());
+        }
+        if (user.getCustomAttributes() != null) {
+            try {
+                payload.putAll(MAPPER.readValue(user.getCustomAttributes(),
+                        new TypeReference<Map<String, Object>>() {}));
+            } catch (Exception ignored) {
+                // stored attributes were validated on write
+            }
+        }
+        payload.putAll(extraClaims);
+        if (user.getEmail() != null) {
+            payload.put("email", user.getEmail());
+            payload.put("email_verified", Boolean.TRUE.equals(user.getEmailVerified()));
+        }
+        if (user.getPhoneNumber() != null) {
+            payload.put("phone_number", user.getPhoneNumber());
+        }
+        if ("anonymous".equals(provider)) {
+            payload.put("provider_id", "anonymous");
+        }
+        payload.put("auth_time", authTimeSeconds(user));
+        payload.put("user_id", user.getLocalId());
+
+        Map<String, Object> identities = new LinkedHashMap<>();
+        if (user.getEmail() != null) {
+            identities.put("email", List.of(user.getEmail()));
+        }
+        if (user.getProviderUserInfo() != null) {
+            for (ProviderUserInfo info : user.getProviderUserInfo()) {
+                if (!"password".equals(info.getProviderId()) && info.getRawId() != null) {
+                    identities.put(info.getProviderId(), List.of(info.getRawId()));
+                }
+            }
+        }
+        Map<String, Object> firebase = new LinkedHashMap<>();
+        firebase.put("identities", identities);
+        firebase.put("sign_in_provider", provider);
+        payload.put("firebase", firebase);
+
+        payload.put("iat", iat);
+        payload.put("exp", iat + TOKEN_EXPIRES_IN_SECONDS);
+        payload.put("aud", project);
+        payload.put("iss", "https://securetoken.google.com/" + project);
+        payload.put("sub", user.getLocalId());
+        return FirebaseJwt.sign(payload);
+    }
+
+    StoredUser parseIdToken(String project, String idToken) {
+        Map<String, Object> payload = FirebaseJwt.decodePayload(idToken);
+        check(payload != null, "INVALID_ID_TOKEN");
+        StoredUser user = getUser(project, str(payload.get("user_id")));
+        check(user != null, "USER_NOT_FOUND");
+        if (user.getValidSince() != null && payload.get("iat") instanceof Number iat) {
+            check(iat.longValue() >= Long.parseLong(user.getValidSince()), "TOKEN_EXPIRED");
+        }
+        check(!user.isDisabled(), "USER_DISABLED");
+        return user;
+    }
+
+    // ── claims validation ─────────────────────────────────────────────────────
+
+    private void validateSerializedCustomClaims(String serialized) {
+        check(serialized.length() <= 1000, "CLAIMS_TOO_LARGE");
+        Object parsed;
+        try {
+            parsed = MAPPER.readValue(serialized, Object.class);
+        } catch (Exception e) {
+            throw badRequest("INVALID_CLAIMS");
+        }
+        validateCustomClaims(parsed);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> validateCustomClaims(Object claims) {
+        check(claims instanceof Map, "INVALID_CLAIMS");
+        Map<String, Object> map = (Map<String, Object>) claims;
+        for (String key : map.keySet()) {
+            check(!RESERVED_CLAIMS.contains(key), "FORBIDDEN_CLAIM : " + key);
+        }
+        return map;
+    }
+
+    // ── user store helpers ────────────────────────────────────────────────────
+
+    StoredUser getUser(String project, String localId) {
+        if (localId == null) {
+            return null;
+        }
+        return userStore.get(userKey(project, localId)).map(this::parseUser).orElse(null);
+    }
+
+    private void putUser(String project, StoredUser user) {
+        try {
+            userStore.put(userKey(project, user.getLocalId()), MAPPER.writeValueAsString(user));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize user", e);
+        }
+    }
+
+    StoredUser findByEmail(String project, String email) {
+        return listUsers(project).stream()
+                .filter(u -> email.equals(u.getEmail()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private StoredUser findByPhoneNumber(String project, String phoneNumber) {
+        return listUsers(project).stream()
+                .filter(u -> phoneNumber.equals(u.getPhoneNumber()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<StoredUser> listUsers(String project) {
+        String prefix = "projects/" + project + "/users/";
+        return userStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(this::parseUser)
+                .sorted(Comparator.comparing(StoredUser::getLocalId))
+                .toList();
+    }
+
+    private StoredUser parseUser(String json) {
+        try {
+            return MAPPER.readValue(json, StoredUser.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse stored user", e);
+        }
+    }
+
+    private static String userKey(String project, String localId) {
+        return "projects/" + project + "/users/" + localId;
+    }
+
+    // ── small helpers ─────────────────────────────────────────────────────────
+
+    private void setPassword(StoredUser user, String password) {
+        String salt = "fakeSalt" + randomId(20);
+        user.setSalt(salt);
+        user.setPasswordHash(hashPassword(password, salt));
+        user.setPasswordUpdatedAt(Instant.now().toEpochMilli());
+        user.setValidSince(String.valueOf(Instant.now().getEpochSecond()));
+    }
+
+    private void upsertPasswordProvider(StoredUser user) {
+        if (user.getEmail() == null) {
+            return;
+        }
+        List<ProviderUserInfo> providers = new ArrayList<>(
+                user.getProviderUserInfo() == null ? List.of() : user.getProviderUserInfo());
+        providers.removeIf(p -> "password".equals(p.getProviderId()));
+        providers.add(ProviderUserInfo.password(user.getEmail(), user.getDisplayName(), user.getPhotoUrl()));
+        user.setProviderUserInfo(providers);
+    }
+
+    private static String hashPassword(String password, String salt) {
+        return "fakeHash:salt=" + salt + ":password=" + password;
+    }
+
+    private static long authTimeSeconds(StoredUser user) {
+        if (user.getLastLoginAt() != null) {
+            return Long.parseLong(user.getLastLoginAt()) / 1000;
+        }
+        if (user.getLastRefreshAt() != null) {
+            return Instant.parse(user.getLastRefreshAt()).getEpochSecond();
+        }
+        return Instant.now().getEpochSecond();
+    }
+
+    private static boolean isValidEmail(String email) {
+        return email.matches("^[^@]+@[^@]+$");
+    }
+
+    private static String canonicalizeEmail(String email) {
+        return email.toLowerCase();
+    }
+
+    static String randomId(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(ALPHANUMERIC.charAt(RANDOM.nextInt(ALPHANUMERIC.length())));
+        }
+        return sb.toString();
+    }
+
+    private static void addUser(List<StoredUser> users, Set<String> seen, StoredUser user) {
+        if (user != null && seen.add(user.getLocalId())) {
+            users.add(user);
+        }
+    }
+
+    private static String str(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return value instanceof String s ? s : String.valueOf(value);
+    }
+
+    private static Boolean bool(Object value) {
+        if (value == null) {
+            return false;
+        }
+        return value instanceof Boolean b ? b : Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> strList(Object value) {
+        if (value == null) {
+            return List.of();
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(FirebaseAuthService::str).toList();
+        }
+        return List.of(str(value));
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
@@ -329,10 +329,12 @@ public class FirebaseAuthService {
             signInProvider = "password";
             revokesTokens = true;
         }
+        // Any caller may trigger revocation (validSince = now); only privileged callers
+        // may copy a literal validSince value — mirrors the emulator's fieldsToCopy split.
         if (body.get("validSince") != null) {
-            user.setValidSince(str(body.get("validSince")));
             revokesTokens = true;
-        } else if (revokesTokens) {
+        }
+        if (revokesTokens) {
             user.setValidSince(String.valueOf(Instant.now().getEpochSecond()));
         }
         if (body.get("displayName") != null) {
@@ -359,6 +361,9 @@ public class FirebaseAuthService {
                 StoredUser byPhone = findByPhoneNumber(project, phoneNumber);
                 check(byPhone == null || byPhone.getLocalId().equals(user.getLocalId()), "PHONE_NUMBER_EXISTS");
                 user.setPhoneNumber(phoneNumber);
+            }
+            if (body.get("validSince") != null) {
+                user.setValidSince(str(body.get("validSince")));
             }
         }
         for (String attribute : strList(body.get("deleteAttribute"))) {
@@ -490,7 +495,8 @@ public class FirebaseAuthService {
 
         Map<String, Object> record;
         try {
-            record = MAPPER.readValue(Base64.getDecoder().decode(refreshToken),
+            // Space is never valid Base64; restore '+' mangled by unescaped form transport.
+            record = MAPPER.readValue(Base64.getDecoder().decode(refreshToken.replace(' ', '+')),
                     new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {
             throw badRequest("INVALID_REFRESH_TOKEN");

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseJwt.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseJwt.java
@@ -1,0 +1,60 @@
+package io.floci.gcp.services.firebaseauth;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * Unsigned ("alg":"none") JWTs in the exact shape the Firebase Auth emulator mints:
+ * base64url(header) + "." + base64url(payload) + "." with an empty signature segment.
+ */
+final class FirebaseJwt {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP = new TypeReference<>() {};
+
+    private FirebaseJwt() {}
+
+    static String sign(Map<String, Object> payload) {
+        return encode(Map.of("alg", "none", "typ", "JWT")) + "." + encode(payload) + ".";
+    }
+
+    /** Decodes the payload of any JWT (signed or not) without verifying the signature. */
+    static Map<String, Object> decodePayload(String jwt) {
+        String[] parts = jwt.split("\\.", -1);
+        if (parts.length < 2) {
+            return null;
+        }
+        try {
+            byte[] json = Base64.getUrlDecoder().decode(parts[1]);
+            return MAPPER.readValue(json, MAP);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    static Map<String, Object> decodeHeader(String jwt) {
+        String[] parts = jwt.split("\\.", -1);
+        if (parts.length < 2) {
+            return null;
+        }
+        try {
+            byte[] json = Base64.getUrlDecoder().decode(parts[0]);
+            return MAPPER.readValue(json, MAP);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String encode(Map<String, Object> value) {
+        try {
+            return Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(MAPPER.writeValueAsBytes(value));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encode JWT segment", e);
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/SecureTokenController.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/SecureTokenController.java
@@ -1,0 +1,63 @@
+package io.floci.gcp.services.firebaseauth;
+
+import io.floci.gcp.config.EmulatorConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+
+/** Secure Token refresh endpoint; accepts both form-urlencoded (SDK default) and JSON. */
+@Path("/securetoken.googleapis.com/v1")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class SecureTokenController {
+
+    private final FirebaseAuthService service;
+    private final EmulatorConfig config;
+
+    @Inject
+    public SecureTokenController(FirebaseAuthService service, EmulatorConfig config) {
+        this.service = service;
+        this.config = config;
+    }
+
+    @POST
+    @Path("/token")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response tokenForm(@FormParam("grant_type") String grantType,
+                              @FormParam("grantType") String grantTypeCamel,
+                              @FormParam("refresh_token") String refreshToken,
+                              @FormParam("refreshToken") String refreshTokenCamel) {
+        return json(service.grantToken(config.defaultProjectId(),
+                first(grantType, grantTypeCamel), first(refreshToken, refreshTokenCamel)));
+    }
+
+    @POST
+    @Path("/token")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response tokenJson(Map<String, Object> body) {
+        Map<String, Object> safe = body == null ? Map.of() : body;
+        return json(service.grantToken(config.defaultProjectId(),
+                first(str(safe.get("grant_type")), str(safe.get("grantType"))),
+                first(str(safe.get("refresh_token")), str(safe.get("refreshToken")))));
+    }
+
+    private static String first(String a, String b) {
+        return a != null && !a.isEmpty() ? a : b;
+    }
+
+    private static String str(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static Response json(Object entity) {
+        return Response.ok(entity, MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/model/ProviderUserInfo.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/model/ProviderUserInfo.java
@@ -1,0 +1,48 @@
+package io.floci.gcp.services.firebaseauth.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ProviderUserInfo {
+
+    private String providerId;
+    private String rawId;
+    private String federatedId;
+    private String displayName;
+    private String photoUrl;
+    private String email;
+    private String phoneNumber;
+    private String screenName;
+
+    public String getProviderId() { return providerId; }
+    public void setProviderId(String providerId) { this.providerId = providerId; }
+    public String getRawId() { return rawId; }
+    public void setRawId(String rawId) { this.rawId = rawId; }
+    public String getFederatedId() { return federatedId; }
+    public void setFederatedId(String federatedId) { this.federatedId = federatedId; }
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public String getPhotoUrl() { return photoUrl; }
+    public void setPhotoUrl(String photoUrl) { this.photoUrl = photoUrl; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+    public String getScreenName() { return screenName; }
+    public void setScreenName(String screenName) { this.screenName = screenName; }
+
+    public static ProviderUserInfo password(String email, String displayName, String photoUrl) {
+        ProviderUserInfo info = new ProviderUserInfo();
+        info.setProviderId("password");
+        info.setRawId(email);
+        info.setFederatedId(email);
+        info.setEmail(email);
+        info.setDisplayName(displayName);
+        info.setPhotoUrl(photoUrl);
+        return info;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/model/StoredUser.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/model/StoredUser.java
@@ -1,0 +1,75 @@
+package io.floci.gcp.services.firebaseauth.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/**
+ * Identity Toolkit v1 UserInfo. Timestamp conventions follow the Firebase Auth emulator:
+ * createdAt/lastLoginAt are ms-epoch strings, validSince is a seconds-epoch string,
+ * passwordUpdatedAt is a numeric ms value, lastRefreshAt is ISO-8601.
+ */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StoredUser {
+
+    private String localId;
+    private String email;
+    private Boolean emailVerified;
+    private String displayName;
+    private String photoUrl;
+    private String phoneNumber;
+    private Boolean disabled;
+    private String passwordHash;
+    private String salt;
+    private Long passwordUpdatedAt;
+    private String validSince;
+    private String createdAt;
+    private String lastLoginAt;
+    private String lastRefreshAt;
+    private String customAttributes;
+    private Boolean customAuth;
+    private List<ProviderUserInfo> providerUserInfo;
+
+    public String getLocalId() { return localId; }
+    public void setLocalId(String localId) { this.localId = localId; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public Boolean getEmailVerified() { return emailVerified; }
+    public void setEmailVerified(Boolean emailVerified) { this.emailVerified = emailVerified; }
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+    public String getPhotoUrl() { return photoUrl; }
+    public void setPhotoUrl(String photoUrl) { this.photoUrl = photoUrl; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+    public Boolean getDisabled() { return disabled; }
+    public void setDisabled(Boolean disabled) { this.disabled = disabled; }
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+    public String getSalt() { return salt; }
+    public void setSalt(String salt) { this.salt = salt; }
+    public Long getPasswordUpdatedAt() { return passwordUpdatedAt; }
+    public void setPasswordUpdatedAt(Long passwordUpdatedAt) { this.passwordUpdatedAt = passwordUpdatedAt; }
+    public String getValidSince() { return validSince; }
+    public void setValidSince(String validSince) { this.validSince = validSince; }
+    public String getCreatedAt() { return createdAt; }
+    public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
+    public String getLastLoginAt() { return lastLoginAt; }
+    public void setLastLoginAt(String lastLoginAt) { this.lastLoginAt = lastLoginAt; }
+    public String getLastRefreshAt() { return lastRefreshAt; }
+    public void setLastRefreshAt(String lastRefreshAt) { this.lastRefreshAt = lastRefreshAt; }
+    public String getCustomAttributes() { return customAttributes; }
+    public void setCustomAttributes(String customAttributes) { this.customAttributes = customAttributes; }
+    public Boolean getCustomAuth() { return customAuth; }
+    public void setCustomAuth(Boolean customAuth) { this.customAuth = customAuth; }
+    public List<ProviderUserInfo> getProviderUserInfo() { return providerUserInfo; }
+    public void setProviderUserInfo(List<ProviderUserInfo> providerUserInfo) { this.providerUserInfo = providerUserInfo; }
+
+    public boolean isDisabled() {
+        return Boolean.TRUE.equals(disabled);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ quarkus:
       - --enable-url-protocols=http,https
       - --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32
       - --initialize-at-run-time=io.floci.gcp.services.cloudkms.KmsCrypto
+      - --initialize-at-run-time=io.floci.gcp.services.firebaseauth.FirebaseAuthService
       - --initialize-at-run-time=io.floci.gcp.services.cloudsql.CloudSqlPostgresDataPlane
       - --initialize-at-run-time=io.floci.gcp.services.scheduler.SchedulerExpressionParser
 
@@ -107,6 +108,8 @@ floci-gcp:
     serviceusage:
       enabled: true
     resourcemanager:
+      enabled: true
+    firebaseauth:
       enabled: true
   dns:
     extra-suffixes:

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthDisabledRestIntegrationTest.java
@@ -1,0 +1,37 @@
+package io.floci.gcp.services.firebaseauth;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(FirebaseAuthDisabledRestIntegrationTest.DisabledFirebaseAuthProfile.class)
+class FirebaseAuthDisabledRestIntegrationTest {
+
+    @Test
+    void disabledFirebaseAuthReturnsUnavailableWrapper() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of())
+                .when().post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service firebaseauth is not enabled."));
+    }
+
+    public static class DisabledFirebaseAuthProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.firebaseauth.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
@@ -284,6 +284,61 @@ class FirebaseAuthRestIntegrationTest {
     }
 
     @Test
+    void clientValidSinceTriggersRevocationButCannotSetLiteralValue() {
+        String idToken = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", "validsince@example.com", "password", "secret123"))
+                .when().post(CLIENT + ":signUp")
+                .then().statusCode(200)
+                .extract().path("idToken");
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("idToken", idToken, "validSince", "9999999999"))
+                .when().post(CLIENT + ":update")
+                .then().statusCode(200);
+
+        String storedValidSince = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("email", new String[]{"validsince@example.com"}))
+                .when().post(ADMIN + ":lookup")
+                .then().statusCode(200)
+                .extract().path("users[0].validSince");
+        org.junit.jupiter.api.Assertions.assertNotEquals("9999999999", storedValidSince);
+
+        // privileged callers may copy a literal validSince
+        String localId = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("email", new String[]{"validsince@example.com"}))
+                .when().post(ADMIN + ":lookup")
+                .then().statusCode(200)
+                .extract().path("users[0].localId");
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", localId, "validSince", "1234567890"))
+                .when().post(ADMIN + ":update")
+                .then().statusCode(200);
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", new String[]{localId}))
+                .when().post(ADMIN + ":lookup")
+                .then().statusCode(200)
+                .body("users[0].validSince", equalTo("1234567890"));
+    }
+
+    @Test
     void nonBearerAuthorizationIsRejectedOnAdminAndClientEndpoints() {
         given()
                 .urlEncodingEnabled(false)

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
@@ -1,0 +1,309 @@
+package io.floci.gcp.services.firebaseauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FirebaseAuthRestIntegrationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String CLIENT = "/identitytoolkit.googleapis.com/v1/accounts";
+    private static final String ADMIN = "/identitytoolkit.googleapis.com/v1/projects/test-project/accounts";
+
+    @Test
+    void signUpSignInAndRefreshRoundtrip() throws Exception {
+        String email = "roundtrip@example.com";
+
+        Map<String, Object> signUp = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", email, "password", "secret123"))
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#SignupNewUserResponse"))
+                .body("email", equalTo(email))
+                .body("expiresIn", equalTo("3600"))
+                .body("idToken", notNullValue())
+                .body("refreshToken", notNullValue())
+                .extract().as(Map.class);
+
+        String localId = (String) signUp.get("localId");
+        assertEquals(28, localId.length());
+
+        String idToken = (String) signUp.get("idToken");
+        Map<String, Object> header = decodeSegment(idToken, 0);
+        Map<String, Object> payload = decodeSegment(idToken, 1);
+        assertEquals("none", header.get("alg"));
+        assertTrue(idToken.endsWith("."));
+        assertEquals("https://securetoken.google.com/test-project", payload.get("iss"));
+        assertEquals("test-project", payload.get("aud"));
+        assertEquals(localId, payload.get("user_id"));
+        assertEquals(email, payload.get("email"));
+        assertEquals("password", ((Map<?, ?>) payload.get("firebase")).get("sign_in_provider"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", email, "password", "secret123"))
+                .when().post(CLIENT + ":signInWithPassword")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#VerifyPasswordResponse"))
+                .body("registered", equalTo(true))
+                .body("localId", equalTo(localId));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/x-www-form-urlencoded")
+                .queryParam("key", "fake-api-key")
+                .formParam("grant_type", "refresh_token")
+                .formParam("refresh_token", (String) signUp.get("refreshToken"))
+                .when().post("/securetoken.googleapis.com/v1/token")
+                .then()
+                .statusCode(200)
+                .body("token_type", equalTo("Bearer"))
+                .body("expires_in", equalTo("3600"))
+                .body("user_id", equalTo(localId))
+                .body("project_id", equalTo("12345"))
+                .body("id_token", notNullValue())
+                .body("refresh_token", notNullValue());
+    }
+
+    @Test
+    void signInErrorsMatchEmulatorStrings() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", "nobody@example.com", "password", "whatever"))
+                .when().post(CLIENT + ":signInWithPassword")
+                .then()
+                .statusCode(400)
+                .body("error.code", equalTo(400))
+                .body("error.message", equalTo("EMAIL_NOT_FOUND"))
+                .body("error.errors[0].reason", equalTo("invalid"))
+                .body("error.errors[0].domain", equalTo("global"))
+                .body("error.status", nullValue());
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", "weak@example.com", "password", "abc"))
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("WEAK_PASSWORD : Password should be at least 6 characters"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body(Map.of("email", "nokey@example.com", "password", "secret123"))
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(403)
+                .body("error.message", equalTo("The request is missing a valid API key."))
+                .body("error.status", equalTo("PERMISSION_DENIED"));
+    }
+
+    @Test
+    void adminCreateLookupUpdateDisableAndDelete() {
+        String email = "admin-user@example.com";
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", "admin-fixed-id", "email", email,
+                        "password", "secret123", "emailVerified", true))
+                .when().post(ADMIN)
+                .then()
+                .statusCode(200)
+                .body("localId", equalTo("admin-fixed-id"))
+                .body("idToken", nullValue());
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("email", new String[]{email}))
+                .when().post(ADMIN + ":lookup")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#GetAccountInfoResponse"))
+                .body("users", hasSize(1))
+                .body("users[0].localId", equalTo("admin-fixed-id"))
+                .body("users[0].emailVerified", equalTo(true))
+                .body("users[0].passwordHash", startsWith("fakeHash:salt="));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", "admin-fixed-id",
+                        "customAttributes", "{\"role\":\"admin\"}",
+                        "disableUser", true))
+                .when().post(ADMIN + ":update")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#SetAccountInfoResponse"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", email, "password", "secret123"))
+                .when().post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("USER_DISABLED"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", "admin-fixed-id"))
+                .when().post(ADMIN + ":delete")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#DeleteAccountResponse"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", new String[]{"admin-fixed-id"}))
+                .when().post(ADMIN + ":lookup")
+                .then()
+                .statusCode(200)
+                .body("$", not(org.hamcrest.Matchers.hasKey("users")));
+    }
+
+    @Test
+    void customTokenJsonFormCreatesUserWithClaims() throws Exception {
+        String token = "{\"uid\":\"custom-uid-1\",\"claims\":{\"role\":\"tester\"}}";
+        String idToken = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("token", token))
+                .when().post(CLIENT + ":signInWithCustomToken")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#VerifyCustomTokenResponse"))
+                .body("isNewUser", equalTo(true))
+                .extract().path("idToken");
+
+        Map<String, Object> payload = decodeSegment(idToken, 1);
+        assertEquals("tester", payload.get("role"));
+        assertEquals("custom", ((Map<?, ?>) payload.get("firebase")).get("sign_in_provider"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("token", "{\"uid\":\"custom-uid-1\",\"claims\":{\"firebase\":\"nope\"}}"))
+                .when().post(CLIENT + ":signInWithCustomToken")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("FORBIDDEN_CLAIM : firebase"));
+    }
+
+    @Test
+    void batchGetPaginatesByLocalIdAndEmulatorClearWorks() {
+        String project = "fb-batch";
+        String base = "/identitytoolkit.googleapis.com/v1/projects/" + project + "/accounts";
+        for (int i = 1; i <= 3; i++) {
+            given()
+                .urlEncodingEnabled(false)
+                    .contentType("application/json")
+                    .header("Authorization", "Bearer owner")
+                    .body(Map.of("localId", "user-" + i, "email", "u" + i + "@example.com",
+                            "password", "secret123"))
+                    .when().post(base)
+                    .then().statusCode(200);
+        }
+
+        String nextPageToken = given()
+                .urlEncodingEnabled(false)
+                .header("Authorization", "Bearer owner")
+                .queryParam("maxResults", 2)
+                .when().get(base + ":batchGet")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("identitytoolkit#DownloadAccountResponse"))
+                .body("users", hasSize(2))
+                .body("users[0].localId", equalTo("user-1"))
+                .extract().path("nextPageToken");
+        assertEquals("user-2", nextPageToken);
+
+        given()
+                .urlEncodingEnabled(false)
+                .header("Authorization", "Bearer owner")
+                .queryParam("maxResults", 2)
+                .queryParam("nextPageToken", nextPageToken)
+                .when().get(base + ":batchGet")
+                .then()
+                .statusCode(200)
+                .body("users", hasSize(1))
+                .body("users[0].localId", equalTo("user-3"))
+                .body("$", not(org.hamcrest.Matchers.hasKey("nextPageToken")));
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().delete("/emulator/v1/projects/" + project + "/accounts")
+                .then()
+                .statusCode(200);
+
+        given()
+                .urlEncodingEnabled(false)
+                .header("Authorization", "Bearer owner")
+                .when().get(base + ":batchGet")
+                .then()
+                .statusCode(200)
+                .body("$", not(org.hamcrest.Matchers.hasKey("users")));
+    }
+
+    @Test
+    void anonymousSignUpSetsAnonymousProvider() throws Exception {
+        String idToken = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of())
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(200)
+                .body("idToken", notNullValue())
+                .extract().path("idToken");
+
+        Map<String, Object> payload = decodeSegment(idToken, 1);
+        assertEquals("anonymous", payload.get("provider_id"));
+        assertEquals("anonymous", ((Map<?, ?>) payload.get("firebase")).get("sign_in_provider"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> decodeSegment(String jwt, int index) throws Exception {
+        String[] parts = jwt.split("\\.", -1);
+        return MAPPER.readValue(Base64.getUrlDecoder().decode(parts[index]), Map.class);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
@@ -284,6 +284,48 @@ class FirebaseAuthRestIntegrationTest {
     }
 
     @Test
+    void nonBearerAuthorizationIsRejectedOnAdminAndClientEndpoints() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Basic abc")
+                .body(Map.of("localId", "whoever"))
+                .when().post(ADMIN + ":lookup")
+                .then()
+                .statusCode(401)
+                .body("error.status", equalTo("UNAUTHENTICATED"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body(Map.of("localId", "whoever"))
+                .when().post(ADMIN + ":lookup")
+                .then()
+                .statusCode(401);
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Basic abc")
+                .body(Map.of("email", "x@example.com", "password", "secret123"))
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(403)
+                .body("error.message", equalTo("The request is missing a valid API key."));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer not-owner")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", "x@example.com", "password", "secret123"))
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(401)
+                .body("error.status", equalTo("UNAUTHENTICATED"));
+    }
+
+    @Test
     void anonymousSignUpSetsAnonymousProvider() throws Exception {
         String idToken = given()
                 .urlEncodingEnabled(false)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -49,5 +49,7 @@ floci-gcp:
       enabled: true
     resourcemanager:
       enabled: true
+    firebaseauth:
+      enabled: true
   docker:
     api-timeout: 30s


### PR DESCRIPTION
## Summary

Implements Identity Platform / Firebase Auth (`identitytoolkit.googleapis.com` v1) as a wire-compatible clone of the **official Firebase Auth emulator** — same paths (API hostname as path prefix, so `FIREBASE_AUTH_EMULATOR_HOST` just works on port 4588), same unsigned `alg:none` JWTs, same error strings.

Covers:
- Client sign-up/sign-in: email/password, anonymous, and custom-token flows (`accounts:signUp`, `:signInWithPassword`, `:signInWithCustomToken`)
- `accounts:lookup/update/delete` in both client (idToken) and admin (localId) modes
- firebase-admin user CRUD + `accounts:batchGet` (listUsers) / `accounts:batchDelete`
- `securetoken.googleapis.com/v1/token` refresh (JSON + form-urlencoded) and `validSince`-based token revocation
- `DELETE /emulator/v1/projects/{p}/accounts` test helper

Closes #44

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Behavior grounded in the Firebase Auth emulator source (`firebase-tools/src/emulator/auth`) and the identitytoolkit v1 discovery document — there is no proto for this API; the official emulator is the compatibility target.

Verified with **firebase-admin 9.9.0** via `FIREBASE_AUTH_EMULATOR_HOST` (6/6 in `sdk-test-java/FirebaseAuthTest`): createUser, getUserByEmail, custom claims roundtrip, `createCustomToken` → sign-in → `verifyIdToken` with merged claims, listUsers, `revokeRefreshTokens` → revoked-token rejection, deleteUser. Error envelope and canonical strings (`EMAIL_EXISTS`, `WEAK_PASSWORD : Password should be at least 6 characters`, …) match the emulator verbatim.

Includes two native-image fixes (`@RegisterForReflection` on Jackson models, `--initialize-at-run-time` for the SecureRandom holder) validated by a full Docker compat run against the native binary: 476 tests / 0 failures across all 7 suites.

Deferred (documented in `docs/services/firebase-auth.md`): OOB codes, email-link, IdP, phone, MFA, passkeys, tenants, session cookies, legacy v3 relyingparty paths.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)