### PR TITLE
feat(monitoring): close Cloud Monitoring parity gaps in time series read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Cloud SQL for PostgreSQL** | REST JSON | Instances (Postgres), control-plane lifecycle, long-running operations |
 | **Cloud Tasks** | gRPC | Queues (rate limits, retry config, pause/resume/purge), tasks (HTTP and App Engine targets, schedule time), `RunTask`; control plane only, tasks are tracked but not dispatched |
 | **Cloud Scheduler** | gRPC + REST JSON | Cron jobs with Pub/Sub, HTTP, and App Engine targets; `Pause`/`Resume`/`RunJob`; unix-cron + time zones; background tick fires due jobs (Pub/Sub publishes into the local backend) |
-| **Cloud Monitoring** | gRPC + REST JSON | Metric descriptors (create/get/list/delete), monitored resource descriptors, time series write (`CreateTimeSeries`) and read (`ListTimeSeries`) |
+| **Cloud Monitoring** | gRPC + REST JSON | Metric descriptors (create/get/list/delete), monitored resource descriptors, time series write (`CreateTimeSeries` with GCP validation rules) and read (`ListTimeSeries` with alignment/reduction subset and pagination) |
 | **Service Usage** | REST JSON | Enable/disable/list a project's services (`serviceusage.googleapis.com` v1) with done LROs; accept-and-succeed state store for Terraform `google_project_service`, Pulumi, and `gcloud services`; includes a minimal Cloud Resource Manager v1 `projects.get` for provider project lookups |
 | **Firebase Auth (Identity Platform)** | REST JSON | Identity Toolkit v1 wire-compatible with the official Auth emulator: email/password, anonymous and custom-token sign-in, unsigned emulator JWTs `firebase-admin` verifies, token refresh + revocation, admin user CRUD/list via `FIREBASE_AUTH_EMULATOR_HOST` |
 

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/MonitoringTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/MonitoringTest.java
@@ -5,7 +5,10 @@ import com.google.api.Metric;
 import com.google.api.MetricDescriptor;
 import com.google.api.MonitoredResource;
 import com.google.api.MonitoredResourceDescriptor;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceClient.ListMetricDescriptorsPagedResponse;
+import com.google.monitoring.v3.Aggregation;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
 import com.google.monitoring.v3.ListMetricDescriptorsRequest;
@@ -15,6 +18,7 @@ import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.TimeInterval;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class MonitoringTest {
@@ -37,6 +42,8 @@ class MonitoringTest {
     private static final String PROJECT_NAME = "projects/" + PROJECT_ID;
     private static final String METRIC_TYPE = "custom.googleapis.com/" + TestFixtures.uniqueName("test-metric");
     private static final String METRIC_NAME = PROJECT_NAME + "/metricDescriptors/" + METRIC_TYPE;
+    private static final String AGG_METRIC_TYPE = "custom.googleapis.com/" + TestFixtures.uniqueName("agg-metric");
+    private static final String AGG_METRIC_NAME = PROJECT_NAME + "/metricDescriptors/" + AGG_METRIC_TYPE;
 
     private static MetricServiceClient client;
 
@@ -198,8 +205,86 @@ class MonitoringTest {
 
     @Test
     @Order(6)
+    void aggregatedTimeSeriesQuery() {
+        Instant now = Instant.now();
+
+        // Two series (env=a, env=b) of the same auto-created metric
+        client.createTimeSeries(CreateTimeSeriesRequest.newBuilder()
+                .setName(PROJECT_NAME)
+                .addTimeSeries(gaugeSeries(AGG_METRIC_TYPE, "a", 5.0, now.minusSeconds(30)))
+                .addTimeSeries(gaugeSeries(AGG_METRIC_TYPE, "b", 7.0, now.minusSeconds(20)))
+                .build());
+
+        TimeInterval interval = TimeInterval.newBuilder()
+                .setStartTime(toTimestamp(now.minusSeconds(600)))
+                .setEndTime(toTimestamp(now))
+                .build();
+
+        List<TimeSeries> reduced = new ArrayList<>();
+        client.listTimeSeries(ListTimeSeriesRequest.newBuilder()
+                        .setName(PROJECT_NAME)
+                        .setFilter("metric.type = \"" + AGG_METRIC_TYPE + "\"")
+                        .setInterval(interval)
+                        .setAggregation(Aggregation.newBuilder()
+                                .setAlignmentPeriod(Duration.newBuilder().setSeconds(3600))
+                                .setPerSeriesAligner(Aggregation.Aligner.ALIGN_SUM)
+                                .setCrossSeriesReducer(Aggregation.Reducer.REDUCE_SUM))
+                        .build())
+                .iterateAll().forEach(reduced::add);
+
+        assertThat(reduced).hasSize(1);
+        assertThat(reduced.get(0).getPointsCount()).isEqualTo(1);
+        assertThat(reduced.get(0).getPoints(0).getValue().getDoubleValue()).isEqualTo(12.0);
+
+        // alignment_period below the 60s minimum is rejected
+        assertThatThrownBy(() -> client.listTimeSeries(ListTimeSeriesRequest.newBuilder()
+                        .setName(PROJECT_NAME)
+                        .setFilter("metric.type = \"" + AGG_METRIC_TYPE + "\"")
+                        .setInterval(interval)
+                        .setAggregation(Aggregation.newBuilder()
+                                .setAlignmentPeriod(Duration.newBuilder().setSeconds(30))
+                                .setPerSeriesAligner(Aggregation.Aligner.ALIGN_SUM))
+                        .build())
+                .iterateAll().forEach(ts -> {}))
+                .isInstanceOf(InvalidArgumentException.class);
+    }
+
+    @Test
+    @Order(7)
+    void listMetricDescriptorsPagination() {
+        ListMetricDescriptorsPagedResponse response = client.listMetricDescriptors(
+                ListMetricDescriptorsRequest.newBuilder()
+                        .setName(PROJECT_NAME)
+                        .setFilter("metric.type = starts_with(\"custom.googleapis.com\")")
+                        .setPageSize(1)
+                        .build());
+
+        assertThat(response.getPage().getValues()).hasSize(1);
+        assertThat(response.getPage().getNextPageToken()).isNotEmpty();
+
+        // SDK auto-paging follows the token and sees both descriptors
+        List<MetricDescriptor> all = new ArrayList<>();
+        response.iterateAll().forEach(all::add);
+        assertThat(all.stream().map(MetricDescriptor::getType))
+                .contains(METRIC_TYPE, AGG_METRIC_TYPE);
+    }
+
+    @Test
+    @Order(8)
+    void stalePointRejected() {
+        Instant stale = Instant.now().minusSeconds(600);
+        assertThatThrownBy(() -> client.createTimeSeries(CreateTimeSeriesRequest.newBuilder()
+                .setName(PROJECT_NAME)
+                .addTimeSeries(gaugeSeries(AGG_METRIC_TYPE, "a", 1.0, stale))
+                .build()))
+                .isInstanceOf(InvalidArgumentException.class);
+    }
+
+    @Test
+    @Order(9)
     void deleteMetricDescriptor() {
         client.deleteMetricDescriptor(METRIC_NAME);
+        client.deleteMetricDescriptor(AGG_METRIC_NAME);
 
         // Retrieve should now fail or not show in list
         List<MetricDescriptor> list = new ArrayList<>();
@@ -210,6 +295,22 @@ class MonitoringTest {
                 .iterateAll().forEach(list::add);
 
         assertThat(list).noneMatch(d -> d.getType().equals(METRIC_TYPE));
+    }
+
+    private static TimeSeries gaugeSeries(String metricType, String env, double value, Instant end) {
+        return TimeSeries.newBuilder()
+                .setMetric(Metric.newBuilder()
+                        .setType(metricType)
+                        .putLabels("env", env)
+                        .build())
+                .setResource(MonitoredResource.newBuilder()
+                        .setType("global")
+                        .build())
+                .addPoints(Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setEndTime(toTimestamp(end)).build())
+                        .setValue(TypedValue.newBuilder().setDoubleValue(value).build())
+                        .build())
+                .build();
     }
 
     private static Timestamp toTimestamp(Instant instant) {

--- a/docs/services/cloud-monitoring.md
+++ b/docs/services/cloud-monitoring.md
@@ -22,10 +22,65 @@ the API endpoint / transport channel and disabling credentials:
 
 ## Scope
 
-- Metric descriptors: `CreateMetricDescriptor`, `GetMetricDescriptor`, `ListMetricDescriptors`, `DeleteMetricDescriptor`.
+- Metric descriptors: `CreateMetricDescriptor` (upsert), `GetMetricDescriptor`, `ListMetricDescriptors`, `DeleteMetricDescriptor`.
 - Monitored resource descriptors: `ListMonitoredResourceDescriptors`, `GetMonitoredResourceDescriptor`.
-- Time series: `CreateTimeSeries` (write points) and `ListTimeSeries` (read back over a time interval).
+- Time series: `CreateTimeSeries` (write points) and `ListTimeSeries` (read back over a time interval,
+  raw or aggregated).
 - `TypedValue` point values (`bool`, `int64`, `double`, `string`, `distribution`) are preserved round-trip.
+- Pagination (`pageSize` / `pageToken` / `nextPageToken`) on all list methods. `ListMetricDescriptors`
+  clamps the page size to 10,000; `ListTimeSeries` clamps to 100,000, where under the `FULL` view the
+  page size limits the total number of points (a series may span pages) and under `HEADERS` it limits
+  the number of series.
+
+## Aggregation
+
+`ListTimeSeries` supports a subset of the real API's alignment/reduction:
+
+- **Per-series aligners**: `ALIGN_NONE`, `ALIGN_SUM`, `ALIGN_MEAN`, `ALIGN_MIN`, `ALIGN_MAX`,
+  `ALIGN_COUNT`, `ALIGN_DELTA`, `ALIGN_RATE`. Output kinds/types follow the proto:
+  `ALIGN_MEAN`/`ALIGN_RATE` → `DOUBLE`, `ALIGN_COUNT` → `INT64`, `ALIGN_DELTA` → kind `DELTA`,
+  `ALIGN_RATE` → kind `GAUGE`.
+- **Cross-series reducers**: `REDUCE_NONE`, `REDUCE_SUM`, `REDUCE_MEAN`, `REDUCE_MIN`, `REDUCE_MAX`,
+  `REDUCE_COUNT`, with `group_by_fields` (`resource.type`, `resource.label.<key>`, `metric.label.<key>`).
+- `alignment_period` must be at least 60 seconds and is required whenever an aligner other than
+  `ALIGN_NONE` is set; a reducer requires an aligner. Unsupported aligners/reducers are rejected with
+  `INVALID_ARGUMENT` rather than silently ignored.
+- Alignment buckets are anchored to the request interval's end time: each aligned point's `endTime`
+  falls on `interval.endTime - k * alignment_period`.
+- Over REST, pass `aggregation.alignmentPeriod` (e.g. `60s`), `aggregation.perSeriesAligner`,
+  `aggregation.crossSeriesReducer` and repeated `aggregation.groupByFields` query parameters.
+
+## Validation semantics
+
+Write-path rules matching the documented API behavior:
+
+- `CreateTimeSeries`: at most 200 `TimeSeries` per request; each series carries exactly one point;
+  the point's `endTime` must be at most 25 hours in the past and 5 minutes in the future, and must be
+  strictly newer than the most recent stored point of the same series (metric type + labels +
+  monitored resource). `GAUGE` intervals are point-in-time (`startTime` absent or equal to `endTime`);
+  `DELTA`/`CUMULATIVE` intervals require `startTime < endTime`.
+- Writing to a nonexistent metric auto-creates its descriptor: the kind must be `GAUGE` (default) or
+  `CUMULATIVE`, and the value type is inferred from the point (`BOOL`, `INT64`, `DOUBLE` or
+  `DISTRIBUTION`).
+- `CreateMetricDescriptor` is an upsert: re-creating an existing type updates it, but labels are
+  unioned — existing label keys are never removed. `BOOL`/`STRING` value types are only valid with
+  `GAUGE`. The metric type must be domain-prefixed (e.g. `custom.googleapis.com/...`).
+- `DeleteMetricDescriptor` only accepts user-created metrics (`custom.googleapis.com/` or
+  `external.googleapis.com/` prefixes).
+- `ListTimeSeries` requires a filter naming a single metric type (`metric.type = "..."`) and an
+  `interval.endTime`; the read interval is half-open `(startTime, endTime]`.
+
+### Documented deviations from real GCP
+
+- `CreateTimeSeries` is all-or-nothing: on any invalid series the whole request fails with
+  `INVALID_ARGUMENT` and nothing is written (real GCP writes the valid subset and reports partial
+  failures via `CreateTimeSeriesSummary` error details).
+- Alignment emits points only for buckets that contain data — no interpolation of empty periods for
+  `ALIGN_DELTA`/`ALIGN_RATE`.
+- `DISTRIBUTION` and `STRING` values cannot be aggregated.
+- A missing read `interval.startTime` is treated as unbounded (real GCP defaults it to the end time).
+- A single `CreateTimeSeries` request may carry multiple chronologically ordered points for the same
+  series across `TimeSeries` entries (real GCP rejects duplicate series identities per request).
 
 ## Quick Start
 

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringController.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringController.java
@@ -5,10 +5,9 @@ import com.google.api.MonitoredResourceDescriptor;
 import com.google.monitoring.v3.*;
 import com.google.protobuf.Empty;
 import io.floci.gcp.core.common.GcpGrpcController;
+import io.floci.gcp.core.common.PageToken;
 import io.grpc.stub.StreamObserver;
 import org.jboss.logging.Logger;
-
-import java.util.List;
 
 public class CloudMonitoringController extends MetricServiceGrpc.MetricServiceImplBase {
 
@@ -48,12 +47,14 @@ public class CloudMonitoringController extends MetricServiceGrpc.MetricServiceIm
     public void listMetricDescriptors(ListMetricDescriptorsRequest request, StreamObserver<ListMetricDescriptorsResponse> responseObserver) {
         LOG.debugf("listMetricDescriptors name=%s filter=%s", request.getName(), request.getFilter());
         try {
-            List<MetricDescriptor> descriptors = service.listMetricDescriptors(
+            PageToken.Page<MetricDescriptor> page = service.listMetricDescriptors(
                     request.getName(), request.getFilter(), request.getPageSize(), request.getPageToken());
-            ListMetricDescriptorsResponse response = ListMetricDescriptorsResponse.newBuilder()
-                    .addAllMetricDescriptors(descriptors)
-                    .build();
-            responseObserver.onNext(response);
+            ListMetricDescriptorsResponse.Builder response = ListMetricDescriptorsResponse.newBuilder()
+                    .addAllMetricDescriptors(page.items());
+            if (page.nextPageToken() != null) {
+                response.setNextPageToken(page.nextPageToken());
+            }
+            responseObserver.onNext(response.build());
             responseObserver.onCompleted();
         } catch (Exception e) {
             GcpGrpcController.grpcError(responseObserver, e);
@@ -77,11 +78,14 @@ public class CloudMonitoringController extends MetricServiceGrpc.MetricServiceIm
                                                  StreamObserver<ListMonitoredResourceDescriptorsResponse> responseObserver) {
         LOG.debugf("listMonitoredResourceDescriptors name=%s", request.getName());
         try {
-            List<MonitoredResourceDescriptor> list = service.listMonitoredResourceDescriptors(request.getName());
-            ListMonitoredResourceDescriptorsResponse response = ListMonitoredResourceDescriptorsResponse.newBuilder()
-                    .addAllResourceDescriptors(list)
-                    .build();
-            responseObserver.onNext(response);
+            PageToken.Page<MonitoredResourceDescriptor> page = service.listMonitoredResourceDescriptors(
+                    request.getName(), request.getPageSize(), request.getPageToken());
+            ListMonitoredResourceDescriptorsResponse.Builder response = ListMonitoredResourceDescriptorsResponse.newBuilder()
+                    .addAllResourceDescriptors(page.items());
+            if (page.nextPageToken() != null) {
+                response.setNextPageToken(page.nextPageToken());
+            }
+            responseObserver.onNext(response.build());
             responseObserver.onCompleted();
         } catch (Exception e) {
             GcpGrpcController.grpcError(responseObserver, e);
@@ -117,7 +121,7 @@ public class CloudMonitoringController extends MetricServiceGrpc.MetricServiceIm
     public void listTimeSeries(ListTimeSeriesRequest request, StreamObserver<ListTimeSeriesResponse> responseObserver) {
         LOG.debugf("listTimeSeries name=%s filter=%s", request.getName(), request.getFilter());
         try {
-            List<TimeSeries> list = service.listTimeSeries(
+            PageToken.Page<TimeSeries> page = service.listTimeSeries(
                     request.getName(),
                     request.getFilter(),
                     request.getInterval(),
@@ -126,10 +130,12 @@ public class CloudMonitoringController extends MetricServiceGrpc.MetricServiceIm
                     request.getPageSize(),
                     request.getPageToken()
             );
-            ListTimeSeriesResponse response = ListTimeSeriesResponse.newBuilder()
-                    .addAllTimeSeries(list)
-                    .build();
-            responseObserver.onNext(response);
+            ListTimeSeriesResponse.Builder response = ListTimeSeriesResponse.newBuilder()
+                    .addAllTimeSeries(page.items());
+            if (page.nextPageToken() != null) {
+                response.setNextPageToken(page.nextPageToken());
+            }
+            responseObserver.onNext(response.build());
             responseObserver.onCompleted();
         } catch (Exception e) {
             GcpGrpcController.grpcError(responseObserver, e);

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringHttpController.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringHttpController.java
@@ -4,6 +4,8 @@ import com.google.api.MetricDescriptor;
 import com.google.api.MonitoredResourceDescriptor;
 import com.google.monitoring.v3.*;
 import com.google.protobuf.Empty;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.PageToken;
 import io.floci.gcp.core.common.ProtoJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -31,13 +33,18 @@ public class CloudMonitoringHttpController {
 
     @GET
     @Path("/monitoredResourceDescriptors")
-    public Response listMonitoredResourceDescriptors(@PathParam("project") String project) {
+    public Response listMonitoredResourceDescriptors(@PathParam("project") String project,
+                                                     @QueryParam("pageSize") @DefaultValue("0") int pageSize,
+                                                     @QueryParam("pageToken") String pageToken) {
         LOG.debugf("HTTP GET listMonitoredResourceDescriptors project=%s", project);
-        List<MonitoredResourceDescriptor> list = service.listMonitoredResourceDescriptors("projects/" + project);
-        ListMonitoredResourceDescriptorsResponse response = ListMonitoredResourceDescriptorsResponse.newBuilder()
-                .addAllResourceDescriptors(list)
-                .build();
-        return json(ProtoJson.print(response));
+        PageToken.Page<MonitoredResourceDescriptor> page = service.listMonitoredResourceDescriptors(
+                "projects/" + project, pageSize, pageToken);
+        ListMonitoredResourceDescriptorsResponse.Builder response = ListMonitoredResourceDescriptorsResponse.newBuilder()
+                .addAllResourceDescriptors(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return json(ProtoJson.print(response.build()));
     }
 
     @GET
@@ -57,12 +64,14 @@ public class CloudMonitoringHttpController {
                                           @QueryParam("pageSize") @DefaultValue("0") int pageSize,
                                           @QueryParam("pageToken") String pageToken) {
         LOG.debugf("HTTP GET listMetricDescriptors project=%s filter=%s", project, filter);
-        List<MetricDescriptor> list = service.listMetricDescriptors(
+        PageToken.Page<MetricDescriptor> page = service.listMetricDescriptors(
                 "projects/" + project, filter, pageSize, pageToken);
-        ListMetricDescriptorsResponse response = ListMetricDescriptorsResponse.newBuilder()
-                .addAllMetricDescriptors(list)
-                .build();
-        return json(ProtoJson.print(response));
+        ListMetricDescriptorsResponse.Builder response = ListMetricDescriptorsResponse.newBuilder()
+                .addAllMetricDescriptors(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return json(ProtoJson.print(response.build()));
     }
 
     @POST
@@ -108,6 +117,10 @@ public class CloudMonitoringHttpController {
                                    @QueryParam("filter") String filter,
                                    @QueryParam("interval.startTime") String intervalStartTime,
                                    @QueryParam("interval.endTime") String intervalEndTime,
+                                   @QueryParam("aggregation.alignmentPeriod") String alignmentPeriod,
+                                   @QueryParam("aggregation.perSeriesAligner") String perSeriesAligner,
+                                   @QueryParam("aggregation.crossSeriesReducer") String crossSeriesReducer,
+                                   @QueryParam("aggregation.groupByFields") List<String> groupByFields,
                                    @QueryParam("view") @DefaultValue("FULL") String view,
                                    @QueryParam("pageSize") @DefaultValue("0") int pageSize,
                                    @QueryParam("pageToken") String pageToken) {
@@ -121,20 +134,61 @@ public class CloudMonitoringHttpController {
             interval.setEndTime(fromIso(intervalEndTime));
         }
 
-        List<TimeSeries> list = service.listTimeSeries(
+        PageToken.Page<TimeSeries> page = service.listTimeSeries(
                 "projects/" + project,
                 filter,
                 interval.build(),
-                Aggregation.getDefaultInstance(),
+                aggregation(alignmentPeriod, perSeriesAligner, crossSeriesReducer, groupByFields),
                 view,
                 pageSize,
                 pageToken
         );
 
-        ListTimeSeriesResponse response = ListTimeSeriesResponse.newBuilder()
-                .addAllTimeSeries(list)
-                .build();
-        return json(ProtoJson.print(response));
+        ListTimeSeriesResponse.Builder response = ListTimeSeriesResponse.newBuilder()
+                .addAllTimeSeries(page.items());
+        if (page.nextPageToken() != null) {
+            response.setNextPageToken(page.nextPageToken());
+        }
+        return json(ProtoJson.print(response.build()));
+    }
+
+    private static Aggregation aggregation(String alignmentPeriod, String perSeriesAligner,
+                                           String crossSeriesReducer, List<String> groupByFields) {
+        Aggregation.Builder builder = Aggregation.newBuilder();
+        if (alignmentPeriod != null && !alignmentPeriod.isBlank()) {
+            builder.setAlignmentPeriod(parseDuration(alignmentPeriod));
+        }
+        if (perSeriesAligner != null && !perSeriesAligner.isBlank()) {
+            builder.setPerSeriesAligner(parseEnum(Aggregation.Aligner.class, perSeriesAligner,
+                    "aggregation.perSeriesAligner"));
+        }
+        if (crossSeriesReducer != null && !crossSeriesReducer.isBlank()) {
+            builder.setCrossSeriesReducer(parseEnum(Aggregation.Reducer.class, crossSeriesReducer,
+                    "aggregation.crossSeriesReducer"));
+        }
+        if (groupByFields != null) {
+            builder.addAllGroupByFields(groupByFields);
+        }
+        return builder.build();
+    }
+
+    private static <E extends Enum<E>> E parseEnum(Class<E> type, String value, String param) {
+        try {
+            return Enum.valueOf(type, value);
+        } catch (IllegalArgumentException e) {
+            throw GcpException.invalidArgument("Invalid " + param + ": " + value);
+        }
+    }
+
+    private static com.google.protobuf.Duration parseDuration(String value) {
+        try {
+            String seconds = value.endsWith("s") ? value.substring(0, value.length() - 1) : value;
+            return com.google.protobuf.Duration.newBuilder()
+                    .setSeconds(Long.parseLong(seconds))
+                    .build();
+        } catch (NumberFormatException e) {
+            throw GcpException.invalidArgument("Invalid aggregation.alignmentPeriod: " + value);
+        }
     }
 
     private static Response json(String json) {

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringHttpController.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringHttpController.java
@@ -182,11 +182,9 @@ public class CloudMonitoringHttpController {
 
     private static com.google.protobuf.Duration parseDuration(String value) {
         try {
-            String seconds = value.endsWith("s") ? value.substring(0, value.length() - 1) : value;
-            return com.google.protobuf.Duration.newBuilder()
-                    .setSeconds(Long.parseLong(seconds))
-                    .build();
-        } catch (NumberFormatException e) {
+            // Proto Duration JSON allows fractional seconds ("60.5s"); Durations.parse handles both.
+            return com.google.protobuf.util.Durations.parse(value.endsWith("s") ? value : value + "s");
+        } catch (java.text.ParseException e) {
             throw GcpException.invalidArgument("Invalid aggregation.alignmentPeriod: " + value);
         }
     }

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringService.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringService.java
@@ -392,6 +392,10 @@ public class CloudMonitoringService {
                     "TimeSeries valueType %s does not match the point value type %s for %s",
                     ts.getValueType(), inferred, metricType));
         }
+        if (inferred == MetricDescriptor.ValueType.BOOL && kind != MetricDescriptor.MetricKind.GAUGE) {
+            throw GcpException.invalidArgument(
+                    "BOOL and STRING value types are only valid with GAUGE metric kind");
+        }
         return MetricDescriptor.newBuilder()
                 .setName(parentProject + "/metricDescriptors/" + metricType)
                 .setType(metricType)

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringService.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringService.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -246,8 +247,14 @@ public class CloudMonitoringService {
         }
 
         Instant now = clock.instant();
+        Set<String> batchMetricTypes = timeSeriesList.stream()
+                .map(ts -> ts.getMetric().getType())
+                .collect(Collectors.toSet());
         Map<String, Instant> latestByIdentity = new HashMap<>();
-        for (StoredTimeSeriesPoint pt : timeSeriesStore.scan(k -> true)) {
+        for (StoredTimeSeriesPoint pt : timeSeriesStore.scan(k -> {
+            int idx = k.indexOf('#');
+            return idx > 0 && batchMetricTypes.contains(k.substring(0, idx));
+        })) {
             latestByIdentity.merge(SeriesKey.of(pt).identityString(),
                     Instant.parse(pt.getEndTime()), (a, b) -> a.isAfter(b) ? a : b);
         }

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringService.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringService.java
@@ -16,6 +16,7 @@ import io.floci.gcp.core.common.ProtoJson;
 import io.floci.gcp.core.common.ServiceDescriptor;
 import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.ProjectAwareStorageBackend;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.core.common.GcpResourceNames;
@@ -27,20 +28,28 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class CloudMonitoringService {
 
     private static final Logger LOG = Logger.getLogger(CloudMonitoringService.class);
+
+    private static final int MAX_TIME_SERIES_PER_REQUEST = 200;
+    private static final int MAX_DESCRIPTOR_PAGE_SIZE = 10_000;
+    private static final int MAX_TIME_SERIES_PAGE_SIZE = 100_000;
+    private static final Duration MAX_POINT_AGE = Duration.ofHours(25);
+    private static final Duration MAX_POINT_FUTURE = Duration.ofMinutes(5);
 
     private static final List<MonitoredResourceDescriptor> DEFAULT_RESOURCE_DESCRIPTORS = List.of(
             MonitoredResourceDescriptor.newBuilder()
@@ -60,6 +69,7 @@ public class CloudMonitoringService {
 
     private final StorageBackend<String, String> descriptorStore;
     private final StorageBackend<String, StoredTimeSeriesPoint> timeSeriesStore;
+    private final Clock clock;
     private final AtomicLong sequence = new AtomicLong(0);
 
     private final ServiceRegistry serviceRegistry;
@@ -75,18 +85,28 @@ public class CloudMonitoringService {
                 new TypeReference<Map<String, String>>() {});
         this.timeSeriesStore = storageFactory.create("monitoring-timeseries", "monitoring-timeseries.json",
                 new TypeReference<Map<String, StoredTimeSeriesPoint>>() {});
+        this.clock = Clock.systemUTC();
         this.serviceRegistry = serviceRegistry;
         this.config = config;
         this.grpcServerManager = grpcServerManager;
+        this.sequence.set(maxStoredSequence(timeSeriesStore));
     }
 
     CloudMonitoringService(StorageBackend<String, String> descriptorStore,
                            StorageBackend<String, StoredTimeSeriesPoint> timeSeriesStore) {
+        this(descriptorStore, timeSeriesStore, Clock.systemUTC());
+    }
+
+    CloudMonitoringService(StorageBackend<String, String> descriptorStore,
+                           StorageBackend<String, StoredTimeSeriesPoint> timeSeriesStore,
+                           Clock clock) {
         this.descriptorStore = descriptorStore;
         this.timeSeriesStore = timeSeriesStore;
+        this.clock = clock;
         this.serviceRegistry = null;
         this.config = null;
         this.grpcServerManager = null;
+        this.sequence.set(maxStoredSequence(timeSeriesStore));
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -94,9 +114,16 @@ public class CloudMonitoringService {
                 .enabled(config.services().monitoring().enabled())
                 .storageKey("monitoring")
                 .protocol(ServiceProtocol.GRPC)
-                .resourceClasses(CloudMonitoringController.class)
+                .resourceClasses(CloudMonitoringController.class, CloudMonitoringHttpController.class)
                 .build());
         grpcServerManager.bind(new CloudMonitoringController(this));
+    }
+
+    private static long maxStoredSequence(StorageBackend<String, StoredTimeSeriesPoint> store) {
+        List<StoredTimeSeriesPoint> all = store instanceof ProjectAwareStorageBackend<StoredTimeSeriesPoint> projectAware
+                ? projectAware.scanAllProjects(k -> true)
+                : store.scan(k -> true);
+        return all.stream().mapToLong(StoredTimeSeriesPoint::getSequence).max().orElse(0);
     }
 
     // ── Metric Descriptors ───────────────────────────────────────────────────
@@ -106,6 +133,19 @@ public class CloudMonitoringService {
         if (type == null || type.isBlank()) {
             throw GcpException.invalidArgument("MetricDescriptor must have a non-empty type");
         }
+        int slash = type.indexOf('/');
+        if (slash <= 0 || !type.substring(0, slash).contains(".")) {
+            throw GcpException.invalidArgument(
+                    "Metric type must be of the form \"<domain>/<path>\", e.g. \"custom.googleapis.com/my_metric\": " + type);
+        }
+        boolean boolOrString = descriptor.getValueType() == MetricDescriptor.ValueType.BOOL
+                || descriptor.getValueType() == MetricDescriptor.ValueType.STRING;
+        if (boolOrString
+                && descriptor.getMetricKind() != MetricDescriptor.MetricKind.GAUGE
+                && descriptor.getMetricKind() != MetricDescriptor.MetricKind.METRIC_KIND_UNSPECIFIED) {
+            throw GcpException.invalidArgument(
+                    "BOOL and STRING value types are only valid with GAUGE metric kind");
+        }
 
         // Standardize name projects/{project}/metricDescriptors/{type}
         String name = descriptor.getName();
@@ -113,12 +153,21 @@ public class CloudMonitoringService {
             name = parentProject + "/metricDescriptors/" + type;
         }
 
-        MetricDescriptor populated = descriptor.toBuilder()
-                .setName(name)
-                .build();
+        MetricDescriptor.Builder builder = descriptor.toBuilder().setName(name);
 
+        // Upsert: an existing descriptor is updated, but metric labels are never removed.
+        descriptorStore.get(type)
+                .map(json -> ProtoJson.merge(json, MetricDescriptor.newBuilder()).build())
+                .ifPresent(existing -> {
+                    Map<String, LabelDescriptor> merged = new LinkedHashMap<>();
+                    existing.getLabelsList().forEach(l -> merged.put(l.getKey(), l));
+                    descriptor.getLabelsList().forEach(l -> merged.put(l.getKey(), l));
+                    builder.clearLabels().addAllLabels(merged.values());
+                });
+
+        MetricDescriptor populated = builder.build();
         descriptorStore.put(type, ProtoJson.print(populated));
-        LOG.debugf("Created metric descriptor type=%s name=%s", type, name);
+        LOG.debugf("Upserted metric descriptor type=%s name=%s", type, name);
         return populated;
     }
 
@@ -129,7 +178,8 @@ public class CloudMonitoringService {
                 .orElseThrow(() -> GcpException.notFound("Metric descriptor not found: " + name));
     }
 
-    public List<MetricDescriptor> listMetricDescriptors(String parentProject, String filter, int pageSize, String pageToken) {
+    public PageToken.Page<MetricDescriptor> listMetricDescriptors(String parentProject, String filter,
+                                                                  int pageSize, String pageToken) {
         List<MetricDescriptor> all = descriptorStore.scan(k -> true).stream()
                 .map(json -> ProtoJson.merge(json, MetricDescriptor.newBuilder()).build())
                 .sorted(Comparator.comparing(MetricDescriptor::getType))
@@ -142,11 +192,16 @@ public class CloudMonitoringService {
                     .toList();
         }
 
-        return all;
+        int effective = (pageSize <= 0 || pageSize > MAX_DESCRIPTOR_PAGE_SIZE)
+                ? MAX_DESCRIPTOR_PAGE_SIZE : pageSize;
+        return PageToken.paginate(all, effective, pageToken);
     }
 
     public void deleteMetricDescriptor(String name) {
         String type = parseMetricType(name);
+        if (!type.startsWith("custom.googleapis.com/") && !type.startsWith("external.googleapis.com/")) {
+            throw GcpException.invalidArgument("Only user-created custom metrics can be deleted: " + name);
+        }
         if (descriptorStore.get(type).isEmpty()) {
             throw GcpException.notFound("Metric descriptor not found: " + name);
         }
@@ -164,8 +219,10 @@ public class CloudMonitoringService {
 
     // ── Monitored Resource Descriptors ───────────────────────────────────────
 
-    public List<MonitoredResourceDescriptor> listMonitoredResourceDescriptors(String parentProject) {
-        return DEFAULT_RESOURCE_DESCRIPTORS;
+    public PageToken.Page<MonitoredResourceDescriptor> listMonitoredResourceDescriptors(String parentProject,
+                                                                                        int pageSize, String pageToken) {
+        int effective = pageSize <= 0 ? DEFAULT_RESOURCE_DESCRIPTORS.size() : pageSize;
+        return PageToken.paginate(DEFAULT_RESOURCE_DESCRIPTORS, effective, pageToken);
     }
 
     public MonitoredResourceDescriptor getMonitoredResourceDescriptor(String name) {
@@ -182,17 +239,39 @@ public class CloudMonitoringService {
         if (timeSeriesList.isEmpty()) {
             throw GcpException.invalidArgument("CreateTimeSeriesRequest must contain at least one time series");
         }
+        if (timeSeriesList.size() > MAX_TIME_SERIES_PER_REQUEST) {
+            throw GcpException.invalidArgument(String.format(
+                    "A maximum of %d TimeSeries can be written per request (got %d)",
+                    MAX_TIME_SERIES_PER_REQUEST, timeSeriesList.size()));
+        }
+
+        Instant now = clock.instant();
+        Map<String, Instant> latestByIdentity = new HashMap<>();
+        for (StoredTimeSeriesPoint pt : timeSeriesStore.scan(k -> true)) {
+            latestByIdentity.merge(SeriesKey.of(pt).identityString(),
+                    Instant.parse(pt.getEndTime()), (a, b) -> a.isAfter(b) ? a : b);
+        }
+
+        // Pass 1: validate everything, stage writes; nothing is persisted on failure.
+        Map<String, MetricDescriptor> pendingDescriptors = new LinkedHashMap<>();
+        List<StoredTimeSeriesPoint> staged = new ArrayList<>();
 
         for (TimeSeries ts : timeSeriesList) {
             String metricType = ts.getMetric().getType();
             if (metricType == null || metricType.isBlank()) {
                 throw GcpException.invalidArgument("TimeSeries metric type is required");
             }
+            if (ts.getPointsCount() != 1) {
+                throw GcpException.invalidArgument(String.format(
+                        "Each TimeSeries must contain exactly one Point (got %d for %s)",
+                        ts.getPointsCount(), metricType));
+            }
 
             MetricDescriptor desc = descriptorStore.get(metricType)
                     .map(json -> ProtoJson.merge(json, MetricDescriptor.newBuilder()).build())
-                    .orElse(null);
+                    .orElseGet(() -> pendingDescriptors.get(metricType));
 
+            Point pt = ts.getPoints(0);
             if (desc != null) {
                 // Validate kind and value type
                 if (ts.getMetricKind() != MetricDescriptor.MetricKind.METRIC_KIND_UNSPECIFIED
@@ -208,118 +287,195 @@ public class CloudMonitoringService {
                             ts.getValueType(), desc.getValueType(), metricType));
                 }
             } else {
-                // Auto-create metric descriptor
-                desc = MetricDescriptor.newBuilder()
-                        .setName(parentProject + "/metricDescriptors/" + metricType)
-                        .setType(metricType)
-                        .setMetricKind(ts.getMetricKind() != MetricDescriptor.MetricKind.METRIC_KIND_UNSPECIFIED
-                                ? ts.getMetricKind() : MetricDescriptor.MetricKind.GAUGE)
-                        .setValueType(ts.getValueType() != MetricDescriptor.ValueType.VALUE_TYPE_UNSPECIFIED
-                                ? ts.getValueType() : MetricDescriptor.ValueType.DOUBLE)
-                        .build();
-                descriptorStore.put(metricType, ProtoJson.print(desc));
-                LOG.debugf("Auto-created metric descriptor type=%s", metricType);
+                desc = autoCreateDescriptor(parentProject, ts, metricType, pt);
+                pendingDescriptors.put(metricType, desc);
+                LOG.debugf("Staged auto-created metric descriptor type=%s", metricType);
             }
 
             MetricDescriptor.MetricKind kind = desc.getMetricKind();
             MetricDescriptor.ValueType valType = desc.getValueType();
 
-            for (Point pt : ts.getPointsList()) {
-                // Validate interval
-                Instant start = pt.getInterval().hasStartTime() ? toInstant(pt.getInterval().getStartTime()) : Instant.MIN;
-                Instant end = pt.getInterval().hasEndTime() ? toInstant(pt.getInterval().getEndTime()) : Instant.MIN;
-
-                if ((kind == MetricDescriptor.MetricKind.DELTA || kind == MetricDescriptor.MetricKind.CUMULATIVE)
-                        && !start.isBefore(end)) {
+            // Validate interval
+            if (!pt.getInterval().hasEndTime()) {
+                throw GcpException.invalidArgument("Point interval end_time is required for " + metricType);
+            }
+            Instant end = toInstant(pt.getInterval().getEndTime());
+            if (end.isBefore(now.minus(MAX_POINT_AGE)) || end.isAfter(now.plus(MAX_POINT_FUTURE))) {
+                throw GcpException.invalidArgument(String.format(
+                        "Point end_time (%s) must be no more than 25 hours in the past and 5 minutes in the future",
+                        end));
+            }
+            Instant start;
+            if (kind == MetricDescriptor.MetricKind.GAUGE) {
+                start = pt.getInterval().hasStartTime() ? toInstant(pt.getInterval().getStartTime()) : end;
+                if (!start.equals(end)) {
                     throw GcpException.invalidArgument(String.format(
-                            "For DELTA/CUMULATIVE metric %s, startTime (%s) must be before endTime (%s)",
+                            "For GAUGE metric %s, startTime (%s) must be absent or equal to endTime (%s)",
                             metricType, start, end));
                 }
-
-                // Validate TypedValue case matches ValueType
-                TypedValue val = pt.getValue();
-                switch (valType) {
-                    case BOOL -> {
-                        if (val.getValueCase() != TypedValue.ValueCase.BOOL_VALUE) {
-                            throw GcpException.invalidArgument("Point value does not match VALUE_TYPE BOOL");
-                        }
-                    }
-                    case INT64 -> {
-                        if (val.getValueCase() != TypedValue.ValueCase.INT64_VALUE) {
-                            throw GcpException.invalidArgument("Point value does not match VALUE_TYPE INT64");
-                        }
-                    }
-                    case DOUBLE -> {
-                        if (val.getValueCase() != TypedValue.ValueCase.DOUBLE_VALUE) {
-                            throw GcpException.invalidArgument("Point value does not match VALUE_TYPE DOUBLE");
-                        }
-                    }
-                    case STRING -> {
-                        if (val.getValueCase() != TypedValue.ValueCase.STRING_VALUE) {
-                            throw GcpException.invalidArgument("Point value does not match VALUE_TYPE STRING");
-                        }
-                    }
-                    case DISTRIBUTION -> {
-                        if (val.getValueCase() != TypedValue.ValueCase.DISTRIBUTION_VALUE) {
-                            throw GcpException.invalidArgument("Point value does not match VALUE_TYPE DISTRIBUTION");
-                        }
-                    }
-                    default -> {}
+            } else {
+                if (!pt.getInterval().hasStartTime()) {
+                    throw GcpException.invalidArgument(String.format(
+                            "For %s metric %s, a non-zero interval with startTime before endTime is required",
+                            kind, metricType));
                 }
-
-                // Store point
-                StoredTimeSeriesPoint storedPoint = new StoredTimeSeriesPoint();
-                storedPoint.setMetricType(metricType);
-                storedPoint.setMetricLabels(ts.getMetric().getLabelsMap());
-                storedPoint.setResourceType(ts.getResource().getType());
-                storedPoint.setResourceLabels(ts.getResource().getLabelsMap());
-                storedPoint.setMetricKind(kind.name());
-                storedPoint.setValueType(valType.name());
-                storedPoint.setStartTime(start.toString());
-                storedPoint.setEndTime(end.toString());
-                storedPoint.setValueJson(ProtoJson.print(val));
-                storedPoint.setSequence(sequence.incrementAndGet());
-
-                timeSeriesStore.put(key(storedPoint), storedPoint);
+                start = toInstant(pt.getInterval().getStartTime());
+                if (!start.isBefore(end)) {
+                    throw GcpException.invalidArgument(String.format(
+                            "For %s metric %s, startTime (%s) must be before endTime (%s)",
+                            kind, metricType, start, end));
+                }
             }
+
+            validateValueMatchesType(pt.getValue(), valType, metricType);
+
+            // Freshness: the new point must be more recent than any other point in its series
+            String identity = new SeriesKey(metricType, ts.getMetric().getLabelsMap(),
+                    ts.getResource().getType(), ts.getResource().getLabelsMap(), "", "").identityString();
+            Instant latest = latestByIdentity.get(identity);
+            if (latest != null && !end.isAfter(latest)) {
+                throw GcpException.invalidArgument(String.format(
+                        "Point end_time (%s) must be more recent than the most recent existing point (%s) for %s",
+                        end, latest, metricType));
+            }
+            latestByIdentity.put(identity, end);
+
+            StoredTimeSeriesPoint storedPoint = new StoredTimeSeriesPoint();
+            storedPoint.setMetricType(metricType);
+            storedPoint.setMetricLabels(ts.getMetric().getLabelsMap());
+            storedPoint.setResourceType(ts.getResource().getType());
+            storedPoint.setResourceLabels(ts.getResource().getLabelsMap());
+            storedPoint.setMetricKind(kind.name());
+            storedPoint.setValueType(valType.name());
+            storedPoint.setStartTime(start.toString());
+            storedPoint.setEndTime(end.toString());
+            storedPoint.setValueJson(ProtoJson.print(pt.getValue()));
+            staged.add(storedPoint);
+        }
+
+        // Pass 2: persist descriptors, then points.
+        pendingDescriptors.forEach((type, desc) -> descriptorStore.put(type, ProtoJson.print(desc)));
+        for (StoredTimeSeriesPoint storedPoint : staged) {
+            storedPoint.setSequence(sequence.incrementAndGet());
+            timeSeriesStore.put(key(storedPoint), storedPoint);
         }
         LOG.debugf("Successfully ingested %d time series", timeSeriesList.size());
     }
 
-    public List<TimeSeries> listTimeSeries(String parentProject, String filter, TimeInterval requestInterval,
-                                           Aggregation aggregation, String view, int pageSize, String pageToken) {
-        Predicate<StoredTimeSeriesPoint> filterPredicate = TimeSeriesFilter.parse(filter);
+    private static MetricDescriptor autoCreateDescriptor(String parentProject, TimeSeries ts,
+                                                         String metricType, Point pt) {
+        MetricDescriptor.MetricKind kind = ts.getMetricKind() != MetricDescriptor.MetricKind.METRIC_KIND_UNSPECIFIED
+                ? ts.getMetricKind() : MetricDescriptor.MetricKind.GAUGE;
+        if (kind != MetricDescriptor.MetricKind.GAUGE && kind != MetricDescriptor.MetricKind.CUMULATIVE) {
+            throw GcpException.invalidArgument(String.format(
+                    "Auto-created metric %s must have metric kind GAUGE or CUMULATIVE (got %s)", metricType, kind));
+        }
+        MetricDescriptor.ValueType inferred = switch (pt.getValue().getValueCase()) {
+            case BOOL_VALUE -> MetricDescriptor.ValueType.BOOL;
+            case INT64_VALUE -> MetricDescriptor.ValueType.INT64;
+            case DOUBLE_VALUE -> MetricDescriptor.ValueType.DOUBLE;
+            case DISTRIBUTION_VALUE -> MetricDescriptor.ValueType.DISTRIBUTION;
+            default -> throw GcpException.invalidArgument(String.format(
+                    "Auto-created metric %s must have a BOOL, INT64, DOUBLE or DISTRIBUTION point value (got %s)",
+                    metricType, pt.getValue().getValueCase()));
+        };
+        if (ts.getValueType() != MetricDescriptor.ValueType.VALUE_TYPE_UNSPECIFIED
+                && ts.getValueType() != inferred) {
+            throw GcpException.invalidArgument(String.format(
+                    "TimeSeries valueType %s does not match the point value type %s for %s",
+                    ts.getValueType(), inferred, metricType));
+        }
+        return MetricDescriptor.newBuilder()
+                .setName(parentProject + "/metricDescriptors/" + metricType)
+                .setType(metricType)
+                .setMetricKind(kind)
+                .setValueType(inferred)
+                .build();
+    }
 
+    private static void validateValueMatchesType(TypedValue val, MetricDescriptor.ValueType valType,
+                                                 String metricType) {
+        boolean matches = switch (valType) {
+            case BOOL -> val.getValueCase() == TypedValue.ValueCase.BOOL_VALUE;
+            case INT64 -> val.getValueCase() == TypedValue.ValueCase.INT64_VALUE;
+            case DOUBLE -> val.getValueCase() == TypedValue.ValueCase.DOUBLE_VALUE;
+            case STRING -> val.getValueCase() == TypedValue.ValueCase.STRING_VALUE;
+            case DISTRIBUTION -> val.getValueCase() == TypedValue.ValueCase.DISTRIBUTION_VALUE;
+            default -> true;
+        };
+        if (!matches) {
+            throw GcpException.invalidArgument(String.format(
+                    "Point value does not match VALUE_TYPE %s for %s", valType, metricType));
+        }
+    }
+
+    public PageToken.Page<TimeSeries> listTimeSeries(String parentProject, String filter,
+                                                     TimeInterval requestInterval, Aggregation aggregation,
+                                                     String view, int pageSize, String pageToken) {
+        if (filter == null || filter.isBlank()) {
+            throw GcpException.invalidArgument("filter is required");
+        }
+        TimeSeriesFilter.ParsedFilter parsedFilter = TimeSeriesFilter.parseFilter(filter);
+        if (parsedFilter.metricTypeEquality() == null) {
+            throw GcpException.invalidArgument(
+                    "The filter must specify a single metric type using a metric.type = \"...\" clause");
+        }
+        if (!requestInterval.hasEndTime()) {
+            throw GcpException.invalidArgument("interval.end_time is required");
+        }
+        Instant reqEnd = toInstant(requestInterval.getEndTime());
         Instant reqStart = requestInterval.hasStartTime() ? toInstant(requestInterval.getStartTime()) : Instant.MIN;
-        Instant reqEnd = requestInterval.hasEndTime() ? toInstant(requestInterval.getEndTime()) : Instant.MAX;
+        if (requestInterval.hasStartTime() && !reqStart.isBefore(reqEnd)) {
+            throw GcpException.invalidArgument(String.format(
+                    "interval startTime (%s) must be before endTime (%s)", reqStart, reqEnd));
+        }
 
+        TimeSeriesAggregator.validate(aggregation);
+
+        // Reads are half-open: (startTime, endTime]
         List<StoredTimeSeriesPoint> matchedPoints = timeSeriesStore.scan(k -> true).stream()
-                .filter(filterPredicate)
+                .filter(parsedFilter.predicate())
                 .filter(pt -> {
                     Instant ptEnd = Instant.parse(pt.getEndTime());
-                    return !ptEnd.isBefore(reqStart) && !ptEnd.isAfter(reqEnd);
+                    return ptEnd.isAfter(reqStart) && !ptEnd.isAfter(reqEnd);
                 })
                 .toList();
 
-        // Group points by SeriesKey (metric type, resource type, labels, etc.)
         Map<SeriesKey, List<StoredTimeSeriesPoint>> groups = matchedPoints.stream()
-                .collect(Collectors.groupingBy(pt -> new SeriesKey(
-                        pt.getMetricType(),
-                        pt.getMetricLabels(),
-                        pt.getResourceType(),
-                        pt.getResourceLabels(),
-                        pt.getMetricKind(),
-                        pt.getValueType()
-                )));
+                .collect(Collectors.groupingBy(SeriesKey::of, LinkedHashMap::new, Collectors.toList()));
 
+        List<TimeSeries> series = aggregation.getPerSeriesAligner() != Aggregation.Aligner.ALIGN_NONE
+                ? TimeSeriesAggregator.aggregate(groups, aggregation, reqEnd)
+                : buildRawSeries(groups);
+
+        int effective = (pageSize <= 0 || pageSize > MAX_TIME_SERIES_PAGE_SIZE)
+                ? MAX_TIME_SERIES_PAGE_SIZE : pageSize;
+
+        if ("HEADERS".equalsIgnoreCase(view)) {
+            List<TimeSeries> headers = series.stream()
+                    .map(ts -> ts.toBuilder().clearPoints().build())
+                    .toList();
+            return PageToken.paginate(headers, effective, pageToken);
+        }
+        return paginateByPoints(series, effective, pageToken);
+    }
+
+    private static List<TimeSeries> buildRawSeries(Map<SeriesKey, List<StoredTimeSeriesPoint>> groups) {
         List<TimeSeries> result = new ArrayList<>();
-        boolean headersOnly = "HEADERS".equalsIgnoreCase(view);
-
         for (Map.Entry<SeriesKey, List<StoredTimeSeriesPoint>> entry : groups.entrySet()) {
             SeriesKey key = entry.getKey();
-            List<StoredTimeSeriesPoint> pts = entry.getValue();
+            List<Point> protoPoints = entry.getValue().stream()
+                    .map(pt -> Point.newBuilder()
+                            .setInterval(TimeInterval.newBuilder()
+                                    .setStartTime(fromIso(pt.getStartTime()))
+                                    .setEndTime(fromIso(pt.getEndTime()))
+                                    .build())
+                            .setValue(ProtoJson.merge(pt.getValueJson(), TypedValue.newBuilder()).build())
+                            .build())
+                    .sorted(Comparator.comparing((Point p) -> toInstant(p.getInterval().getEndTime())).reversed())
+                    .toList();
 
-            TimeSeries.Builder builder = TimeSeries.newBuilder()
+            result.add(TimeSeries.newBuilder()
                     .setMetric(com.google.api.Metric.newBuilder()
                             .setType(key.metricType())
                             .putAllLabels(key.metricLabels())
@@ -329,30 +485,48 @@ public class CloudMonitoringService {
                             .putAllLabels(key.resourceLabels())
                             .build())
                     .setMetricKind(MetricDescriptor.MetricKind.valueOf(key.metricKind()))
-                    .setValueType(MetricDescriptor.ValueType.valueOf(key.valueType()));
+                    .setValueType(MetricDescriptor.ValueType.valueOf(key.valueType()))
+                    .addAllPoints(protoPoints)
+                    .build());
+        }
+        result.sort(Comparator.comparing((TimeSeries ts) -> ts.getMetric().getType())
+                .thenComparing(ts -> ts.getMetric().getLabelsMap().toString())
+                .thenComparing(ts -> ts.getResource().getLabelsMap().toString()));
+        return result;
+    }
 
-            if (!headersOnly) {
-                // Map points and sort them descending by endTime (most recent first)
-                List<Point> protoPoints = pts.stream()
-                        .map(pt -> Point.newBuilder()
-                                .setInterval(TimeInterval.newBuilder()
-                                        .setStartTime(fromIso(pt.getStartTime()))
-                                        .setEndTime(fromIso(pt.getEndTime()))
-                                        .build())
-                                .setValue(ProtoJson.merge(pt.getValueJson(), TypedValue.newBuilder()).build())
-                                .build())
-                        .sorted(Comparator.comparing((Point p) -> toInstant(p.getInterval().getEndTime())).reversed())
-                        .toList();
-                builder.addAllPoints(protoPoints);
+    // Under the FULL view, page size limits the total number of Points; a series may span pages.
+    private static PageToken.Page<TimeSeries> paginateByPoints(List<TimeSeries> series, int maxPoints,
+                                                               String pageToken) {
+        int offset = PageToken.decode(pageToken);
+        int totalPoints = series.stream().mapToInt(TimeSeries::getPointsCount).sum();
+
+        List<TimeSeries> out = new ArrayList<>();
+        int position = 0;
+        int taken = 0;
+        for (TimeSeries ts : series) {
+            if (taken >= maxPoints) {
+                break;
             }
-
-            result.add(builder.build());
+            int count = ts.getPointsCount();
+            if (position + count <= offset) {
+                position += count;
+                continue;
+            }
+            int from = Math.max(0, offset - position);
+            int to = Math.min(count, from + (maxPoints - taken));
+            if (from < to) {
+                out.add(ts.toBuilder()
+                        .clearPoints()
+                        .addAllPoints(ts.getPointsList().subList(from, to))
+                        .build());
+                taken += to - from;
+            }
+            position += count;
         }
 
-        // Sort time series by metric type for stability
-        result.sort(Comparator.comparing(ts -> ts.getMetric().getType()));
-
-        return result;
+        String next = offset + taken < totalPoints ? PageToken.encode(offset + taken) : null;
+        return new PageToken.Page<>(out, next);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -405,13 +579,4 @@ public class CloudMonitoringService {
         }
         return true;
     }
-
-    private record SeriesKey(
-            String metricType,
-            Map<String, String> metricLabels,
-            String resourceType,
-            Map<String, String> resourceLabels,
-            String metricKind,
-            String valueType
-    ) {}
 }

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/SeriesKey.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/SeriesKey.java
@@ -1,0 +1,46 @@
+package io.floci.gcp.services.cloudmonitoring;
+
+import io.floci.gcp.services.cloudmonitoring.model.StoredTimeSeriesPoint;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+record SeriesKey(
+        String metricType,
+        Map<String, String> metricLabels,
+        String resourceType,
+        Map<String, String> resourceLabels,
+        String metricKind,
+        String valueType
+) {
+
+    static SeriesKey of(StoredTimeSeriesPoint pt) {
+        return new SeriesKey(
+                pt.getMetricType(),
+                pt.getMetricLabels() != null ? pt.getMetricLabels() : Map.of(),
+                pt.getResourceType(),
+                pt.getResourceLabels() != null ? pt.getResourceLabels() : Map.of(),
+                pt.getMetricKind(),
+                pt.getValueType());
+    }
+
+    String identityString() {
+        return metricType + "|" + resourceType
+                + "|" + sortedLabels(metricLabels)
+                + "|" + sortedLabels(resourceLabels);
+    }
+
+    String canonicalString() {
+        return identityString() + "|" + metricKind + "|" + valueType;
+    }
+
+    private static String sortedLabels(Map<String, String> labels) {
+        if (labels == null || labels.isEmpty()) {
+            return "";
+        }
+        return new TreeMap<>(labels).entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/TimeSeriesAggregator.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/TimeSeriesAggregator.java
@@ -1,0 +1,359 @@
+package io.floci.gcp.services.cloudmonitoring;
+
+import com.google.api.Metric;
+import com.google.api.MetricDescriptor;
+import com.google.api.MonitoredResource;
+import com.google.monitoring.v3.Aggregation;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.Timestamp;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.ProtoJson;
+import io.floci.gcp.services.cloudmonitoring.model.StoredTimeSeriesPoint;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+final class TimeSeriesAggregator {
+
+    private static final Set<Aggregation.Aligner> SUPPORTED_ALIGNERS = EnumSet.of(
+            Aggregation.Aligner.ALIGN_NONE,
+            Aggregation.Aligner.ALIGN_SUM,
+            Aggregation.Aligner.ALIGN_MEAN,
+            Aggregation.Aligner.ALIGN_MIN,
+            Aggregation.Aligner.ALIGN_MAX,
+            Aggregation.Aligner.ALIGN_COUNT,
+            Aggregation.Aligner.ALIGN_DELTA,
+            Aggregation.Aligner.ALIGN_RATE);
+
+    private static final Set<Aggregation.Reducer> SUPPORTED_REDUCERS = EnumSet.of(
+            Aggregation.Reducer.REDUCE_NONE,
+            Aggregation.Reducer.REDUCE_SUM,
+            Aggregation.Reducer.REDUCE_MEAN,
+            Aggregation.Reducer.REDUCE_MIN,
+            Aggregation.Reducer.REDUCE_MAX,
+            Aggregation.Reducer.REDUCE_COUNT);
+
+    private TimeSeriesAggregator() {}
+
+    static void validate(Aggregation agg) {
+        Aggregation.Aligner aligner = agg.getPerSeriesAligner();
+        Aggregation.Reducer reducer = agg.getCrossSeriesReducer();
+
+        if (aligner == Aggregation.Aligner.UNRECOGNIZED || !SUPPORTED_ALIGNERS.contains(aligner)) {
+            throw GcpException.invalidArgument("Unsupported per_series_aligner: " + agg.getPerSeriesAlignerValue());
+        }
+        if (reducer == Aggregation.Reducer.UNRECOGNIZED || !SUPPORTED_REDUCERS.contains(reducer)) {
+            throw GcpException.invalidArgument("Unsupported cross_series_reducer: " + agg.getCrossSeriesReducerValue());
+        }
+        if (reducer != Aggregation.Reducer.REDUCE_NONE && aligner == Aggregation.Aligner.ALIGN_NONE) {
+            throw GcpException.invalidArgument(
+                    "If cross_series_reducer is specified, per_series_aligner must be specified and not ALIGN_NONE");
+        }
+        if (aligner != Aggregation.Aligner.ALIGN_NONE
+                && (!agg.hasAlignmentPeriod() || agg.getAlignmentPeriod().getSeconds() < 60)) {
+            throw GcpException.invalidArgument(
+                    "alignment_period must be specified and at least 60 seconds when a per_series_aligner is set");
+        }
+    }
+
+    static List<TimeSeries> aggregate(Map<SeriesKey, List<StoredTimeSeriesPoint>> groups,
+                                      Aggregation agg, Instant reqEnd) {
+        Aggregation.Aligner aligner = agg.getPerSeriesAligner();
+        Aggregation.Reducer reducer = agg.getCrossSeriesReducer();
+        Duration period = Duration.ofSeconds(agg.getAlignmentPeriod().getSeconds(),
+                agg.getAlignmentPeriod().getNanos());
+
+        List<AlignedSeries> aligned = new ArrayList<>();
+        for (Map.Entry<SeriesKey, List<StoredTimeSeriesPoint>> entry : groups.entrySet()) {
+            aligned.add(alignSeries(entry.getKey(), entry.getValue(), aligner, period, reqEnd));
+        }
+
+        List<TimeSeries> result = reducer == Aggregation.Reducer.REDUCE_NONE
+                ? aligned.stream().map(s -> toTimeSeries(s, period)).toList()
+                : reduce(aligned, reducer, agg.getGroupByFieldsList(), period);
+
+        return result.stream()
+                .sorted(Comparator.comparing((TimeSeries ts) -> ts.getMetric().getType())
+                        .thenComparing(ts -> ts.getMetric().getLabelsMap().toString())
+                        .thenComparing(ts -> ts.getResource().getLabelsMap().toString()))
+                .toList();
+    }
+
+    // ── Per-series alignment ────────────────────────────────────────────────
+
+    private record AlignedSeries(
+            SeriesKey key,
+            MetricDescriptor.MetricKind outKind,
+            MetricDescriptor.ValueType outType,
+            TreeMap<Instant, Double> buckets) {}
+
+    private static AlignedSeries alignSeries(SeriesKey key, List<StoredTimeSeriesPoint> points,
+                                             Aggregation.Aligner aligner, Duration period, Instant reqEnd) {
+        MetricDescriptor.MetricKind inKind = MetricDescriptor.MetricKind.valueOf(key.metricKind());
+        MetricDescriptor.ValueType inType = MetricDescriptor.ValueType.valueOf(key.valueType());
+        checkAlignerCompatibility(aligner, inKind, inType, key.metricType());
+
+        long periodMs = period.toMillis();
+        long reqEndMs = reqEnd.toEpochMilli();
+
+        Map<Long, List<StoredTimeSeriesPoint>> byBucket = new LinkedHashMap<>();
+        for (StoredTimeSeriesPoint pt : points) {
+            long k = Math.floorDiv(reqEndMs - Instant.parse(pt.getEndTime()).toEpochMilli(), periodMs);
+            byBucket.computeIfAbsent(k, x -> new ArrayList<>()).add(pt);
+        }
+
+        TreeMap<Instant, Double> buckets = new TreeMap<>();
+        for (Map.Entry<Long, List<StoredTimeSeriesPoint>> bucket : byBucket.entrySet()) {
+            Instant bucketEnd = Instant.ofEpochMilli(reqEndMs - bucket.getKey() * periodMs);
+            List<StoredTimeSeriesPoint> pts = bucket.getValue().stream()
+                    .sorted(Comparator.comparing(p -> Instant.parse(p.getEndTime())))
+                    .toList();
+            buckets.put(bucketEnd, alignBucket(pts, aligner, inKind, period));
+        }
+
+        return new AlignedSeries(key, outputKind(aligner, inKind), outputType(aligner, inType), buckets);
+    }
+
+    private static void checkAlignerCompatibility(Aggregation.Aligner aligner,
+                                                  MetricDescriptor.MetricKind kind,
+                                                  MetricDescriptor.ValueType type,
+                                                  String metricType) {
+        boolean numeric = type == MetricDescriptor.ValueType.INT64 || type == MetricDescriptor.ValueType.DOUBLE;
+        switch (aligner) {
+            case ALIGN_DELTA, ALIGN_RATE -> {
+                if (kind != MetricDescriptor.MetricKind.CUMULATIVE && kind != MetricDescriptor.MetricKind.DELTA) {
+                    throw GcpException.invalidArgument(String.format(
+                            "%s is only valid for CUMULATIVE and DELTA metrics; %s has kind %s",
+                            aligner, metricType, kind));
+                }
+                if (!numeric) {
+                    throw GcpException.invalidArgument(String.format(
+                            "%s requires numeric values; %s has value type %s", aligner, metricType, type));
+                }
+            }
+            case ALIGN_COUNT -> {
+                checkGaugeOrDelta(aligner, kind, metricType);
+                if (!numeric && type != MetricDescriptor.ValueType.BOOL) {
+                    throw GcpException.invalidArgument(String.format(
+                            "%s requires numeric or Boolean values; %s has value type %s", aligner, metricType, type));
+                }
+            }
+            default -> {
+                checkGaugeOrDelta(aligner, kind, metricType);
+                if (!numeric) {
+                    throw GcpException.invalidArgument(String.format(
+                            "%s requires numeric values; %s has value type %s", aligner, metricType, type));
+                }
+            }
+        }
+    }
+
+    private static void checkGaugeOrDelta(Aggregation.Aligner aligner,
+                                          MetricDescriptor.MetricKind kind, String metricType) {
+        if (kind != MetricDescriptor.MetricKind.GAUGE && kind != MetricDescriptor.MetricKind.DELTA) {
+            throw GcpException.invalidArgument(String.format(
+                    "%s is only valid for GAUGE and DELTA metrics; %s has kind %s", aligner, metricType, kind));
+        }
+    }
+
+    private static double alignBucket(List<StoredTimeSeriesPoint> pts, Aggregation.Aligner aligner,
+                                      MetricDescriptor.MetricKind inKind, Duration period) {
+        List<Double> values = pts.stream().map(TimeSeriesAggregator::numericValue).toList();
+        return switch (aligner) {
+            case ALIGN_SUM -> values.stream().mapToDouble(Double::doubleValue).sum();
+            case ALIGN_MEAN -> values.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+            case ALIGN_MIN -> values.stream().mapToDouble(Double::doubleValue).min().orElse(0);
+            case ALIGN_MAX -> values.stream().mapToDouble(Double::doubleValue).max().orElse(0);
+            case ALIGN_COUNT -> values.size();
+            case ALIGN_DELTA -> delta(values, inKind);
+            case ALIGN_RATE -> delta(values, inKind) / Math.max(1, period.toSeconds());
+            default -> throw GcpException.invalidArgument("Unsupported per_series_aligner: " + aligner);
+        };
+    }
+
+    private static double delta(List<Double> values, MetricDescriptor.MetricKind inKind) {
+        if (inKind == MetricDescriptor.MetricKind.CUMULATIVE) {
+            return values.get(values.size() - 1) - values.get(0);
+        }
+        return values.stream().mapToDouble(Double::doubleValue).sum();
+    }
+
+    private static double numericValue(StoredTimeSeriesPoint pt) {
+        TypedValue value = ProtoJson.merge(pt.getValueJson(), TypedValue.newBuilder()).build();
+        return switch (value.getValueCase()) {
+            case INT64_VALUE -> value.getInt64Value();
+            case DOUBLE_VALUE -> value.getDoubleValue();
+            case BOOL_VALUE -> value.getBoolValue() ? 1 : 0;
+            default -> throw GcpException.invalidArgument(
+                    "Values of type " + value.getValueCase() + " cannot be aggregated");
+        };
+    }
+
+    private static MetricDescriptor.MetricKind outputKind(Aggregation.Aligner aligner,
+                                                          MetricDescriptor.MetricKind inKind) {
+        return switch (aligner) {
+            case ALIGN_DELTA -> MetricDescriptor.MetricKind.DELTA;
+            case ALIGN_RATE -> MetricDescriptor.MetricKind.GAUGE;
+            default -> inKind;
+        };
+    }
+
+    private static MetricDescriptor.ValueType outputType(Aggregation.Aligner aligner,
+                                                         MetricDescriptor.ValueType inType) {
+        return switch (aligner) {
+            case ALIGN_MEAN, ALIGN_RATE -> MetricDescriptor.ValueType.DOUBLE;
+            case ALIGN_COUNT -> MetricDescriptor.ValueType.INT64;
+            default -> inType;
+        };
+    }
+
+    // ── Cross-series reduction ──────────────────────────────────────────────
+
+    private static List<TimeSeries> reduce(List<AlignedSeries> aligned, Aggregation.Reducer reducer,
+                                           List<String> groupByFields, Duration period) {
+        List<GroupByField> fields = groupByFields.stream().map(GroupByField::parse).toList();
+
+        Map<String, List<AlignedSeries>> groups = new LinkedHashMap<>();
+        for (AlignedSeries series : aligned) {
+            StringBuilder key = new StringBuilder(series.key().metricType())
+                    .append("|").append(series.key().resourceType());
+            for (GroupByField field : fields) {
+                key.append("|").append(field.valueOf(series.key()));
+            }
+            groups.computeIfAbsent(key.toString(), k -> new ArrayList<>()).add(series);
+        }
+
+        List<TimeSeries> result = new ArrayList<>();
+        for (List<AlignedSeries> members : groups.values()) {
+            AlignedSeries first = members.get(0);
+            TreeMap<Instant, Double> reducedBuckets = new TreeMap<>();
+            TreeMap<Instant, List<Double>> byTimestamp = new TreeMap<>();
+            for (AlignedSeries member : members) {
+                member.buckets().forEach((ts, v) ->
+                        byTimestamp.computeIfAbsent(ts, x -> new ArrayList<>()).add(v));
+            }
+            byTimestamp.forEach((ts, values) -> reducedBuckets.put(ts, reduceValues(values, reducer)));
+
+            Map<String, String> metricLabels = new TreeMap<>();
+            Map<String, String> resourceLabels = new TreeMap<>();
+            for (GroupByField field : fields) {
+                field.copyLabel(first.key(), metricLabels, resourceLabels);
+            }
+
+            MetricDescriptor.ValueType outType = switch (reducer) {
+                case REDUCE_MEAN -> MetricDescriptor.ValueType.DOUBLE;
+                case REDUCE_COUNT -> MetricDescriptor.ValueType.INT64;
+                default -> first.outType();
+            };
+
+            SeriesKey outKey = new SeriesKey(first.key().metricType(), metricLabels,
+                    first.key().resourceType(), resourceLabels,
+                    first.outKind().name(), outType.name());
+            result.add(toTimeSeries(new AlignedSeries(outKey, first.outKind(), outType, reducedBuckets), period));
+        }
+        return result;
+    }
+
+    private static double reduceValues(List<Double> values, Aggregation.Reducer reducer) {
+        return switch (reducer) {
+            case REDUCE_SUM -> values.stream().mapToDouble(Double::doubleValue).sum();
+            case REDUCE_MEAN -> values.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+            case REDUCE_MIN -> values.stream().mapToDouble(Double::doubleValue).min().orElse(0);
+            case REDUCE_MAX -> values.stream().mapToDouble(Double::doubleValue).max().orElse(0);
+            case REDUCE_COUNT -> values.size();
+            default -> throw GcpException.invalidArgument("Unsupported cross_series_reducer: " + reducer);
+        };
+    }
+
+    private record GroupByField(boolean metricLabel, String labelKey) {
+
+        static GroupByField parse(String field) {
+            if (field.equals("resource.type")) {
+                return new GroupByField(false, null);
+            }
+            for (String prefix : List.of("resource.label.", "resource.labels.")) {
+                if (field.startsWith(prefix)) {
+                    return new GroupByField(false, field.substring(prefix.length()));
+                }
+            }
+            for (String prefix : List.of("metric.label.", "metric.labels.")) {
+                if (field.startsWith(prefix)) {
+                    return new GroupByField(true, field.substring(prefix.length()));
+                }
+            }
+            throw GcpException.invalidArgument("Unsupported group_by field: " + field);
+        }
+
+        String valueOf(SeriesKey key) {
+            if (labelKey == null) {
+                return "";
+            }
+            Map<String, String> labels = metricLabel ? key.metricLabels() : key.resourceLabels();
+            return labels.getOrDefault(labelKey, "");
+        }
+
+        void copyLabel(SeriesKey key, Map<String, String> metricLabels, Map<String, String> resourceLabels) {
+            if (labelKey == null) {
+                return;
+            }
+            Map<String, String> source = metricLabel ? key.metricLabels() : key.resourceLabels();
+            String value = source.get(labelKey);
+            if (value != null) {
+                (metricLabel ? metricLabels : resourceLabels).put(labelKey, value);
+            }
+        }
+    }
+
+    // ── Output ──────────────────────────────────────────────────────────────
+
+    private static TimeSeries toTimeSeries(AlignedSeries series, Duration period) {
+        TimeSeries.Builder builder = TimeSeries.newBuilder()
+                .setMetric(Metric.newBuilder()
+                        .setType(series.key().metricType())
+                        .putAllLabels(series.key().metricLabels())
+                        .build())
+                .setResource(MonitoredResource.newBuilder()
+                        .setType(series.key().resourceType())
+                        .putAllLabels(series.key().resourceLabels())
+                        .build())
+                .setMetricKind(series.outKind())
+                .setValueType(series.outType());
+
+        series.buckets().descendingMap().forEach((bucketEnd, value) -> {
+            TimeInterval.Builder interval = TimeInterval.newBuilder().setEndTime(timestamp(bucketEnd));
+            if (series.outKind() == MetricDescriptor.MetricKind.DELTA
+                    || series.outKind() == MetricDescriptor.MetricKind.CUMULATIVE) {
+                interval.setStartTime(timestamp(bucketEnd.minus(period)));
+            } else {
+                interval.setStartTime(timestamp(bucketEnd));
+            }
+            TypedValue.Builder typed = TypedValue.newBuilder();
+            if (series.outType() == MetricDescriptor.ValueType.INT64) {
+                typed.setInt64Value(Math.round(value));
+            } else {
+                typed.setDoubleValue(value);
+            }
+            builder.addPoints(Point.newBuilder().setInterval(interval).setValue(typed).build());
+        });
+
+        return builder.build();
+    }
+
+    private static Timestamp timestamp(Instant instant) {
+        return Timestamp.newBuilder()
+                .setSeconds(instant.getEpochSecond())
+                .setNanos(instant.getNano())
+                .build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/cloudmonitoring/TimeSeriesFilter.java
+++ b/src/main/java/io/floci/gcp/services/cloudmonitoring/TimeSeriesFilter.java
@@ -3,6 +3,7 @@ package io.floci.gcp.services.cloudmonitoring;
 import io.floci.gcp.services.cloudmonitoring.model.StoredTimeSeriesPoint;
 import org.jboss.logging.Logger;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -13,52 +14,86 @@ public final class TimeSeriesFilter {
 
     private static final Pattern CLAUSE =
             Pattern.compile("^(\\S+?)\\s*(=)\\s*(.+)$");
+    private static final Pattern STARTS_WITH =
+            Pattern.compile("^starts_with\\(\\s*\"(.*)\"\\s*\\)$");
+
+    public record ParsedFilter(Predicate<StoredTimeSeriesPoint> predicate, String metricTypeEquality) {}
 
     private TimeSeriesFilter() {}
 
     public static Predicate<StoredTimeSeriesPoint> parse(String filter) {
+        return parseFilter(filter).predicate();
+    }
+
+    public static ParsedFilter parseFilter(String filter) {
         if (filter == null || filter.isBlank()) {
-            return point -> true;
+            return new ParsedFilter(point -> true, null);
         }
         Predicate<StoredTimeSeriesPoint> predicate = point -> true;
+        String metricTypeEquality = null;
         // Split by AND, keeping in mind case insensitivity
         for (String clause : filter.split("(?i)\\s+AND\\s+")) {
             String trimmed = clause.trim();
             if (trimmed.isEmpty()) {
                 continue;
             }
-            predicate = predicate.and(parseClause(trimmed));
+            ParsedClause parsed = parseClause(trimmed);
+            predicate = predicate.and(parsed.predicate());
+            if (parsed.metricTypeEquality() != null) {
+                metricTypeEquality = parsed.metricTypeEquality();
+            }
         }
-        return predicate;
+        return new ParsedFilter(predicate, metricTypeEquality);
     }
 
-    private static Predicate<StoredTimeSeriesPoint> parseClause(String clause) {
+    private record ParsedClause(Predicate<StoredTimeSeriesPoint> predicate, String metricTypeEquality) {}
+
+    private static ParsedClause parseClause(String clause) {
         Matcher m = CLAUSE.matcher(clause);
         if (!m.matches()) {
             LOG.debugf("Ignoring unrecognized monitoring filter clause: %s", clause);
-            return point -> true;
+            return new ParsedClause(point -> true, null);
         }
         String field = m.group(1);
-        String op = m.group(2);
-        String value = unquote(m.group(3).trim());
+        String rawValue = m.group(3).trim();
 
+        Matcher sw = STARTS_WITH.matcher(rawValue);
+        boolean startsWith = sw.matches();
+        String value = startsWith ? sw.group(1) : unquote(rawValue);
+
+        Function<StoredTimeSeriesPoint, String> extractor = extractor(field);
+        if (extractor == null) {
+            LOG.debugf("Ignoring unsupported monitoring filter field: %s", field);
+            return new ParsedClause(point -> true, null);
+        }
+
+        Predicate<StoredTimeSeriesPoint> predicate = startsWith
+                ? point -> {
+                    String actual = extractor.apply(point);
+                    return actual != null && actual.startsWith(value);
+                }
+                : point -> value.equals(extractor.apply(point));
+
+        String metricTypeEquality = !startsWith && field.equalsIgnoreCase("metric.type") ? value : null;
+        return new ParsedClause(predicate, metricTypeEquality);
+    }
+
+    private static Function<StoredTimeSeriesPoint, String> extractor(String field) {
         if (field.equalsIgnoreCase("metric.type")) {
-            return point -> value.equals(point.getMetricType());
+            return StoredTimeSeriesPoint::getMetricType;
         }
         if (field.equalsIgnoreCase("resource.type")) {
-            return point -> value.equals(point.getResourceType());
+            return StoredTimeSeriesPoint::getResourceType;
         }
         if (field.startsWith("metric.labels.")) {
             String labelKey = field.substring("metric.labels.".length());
-            return point -> point.getMetricLabels() != null && value.equals(point.getMetricLabels().get(labelKey));
+            return point -> point.getMetricLabels() != null ? point.getMetricLabels().get(labelKey) : null;
         }
         if (field.startsWith("resource.labels.")) {
             String labelKey = field.substring("resource.labels.".length());
-            return point -> point.getResourceLabels() != null && value.equals(point.getResourceLabels().get(labelKey));
+            return point -> point.getResourceLabels() != null ? point.getResourceLabels().get(labelKey) : null;
         }
-
-        LOG.debugf("Ignoring unsupported monitoring filter field: %s", field);
-        return point -> true;
+        return null;
     }
 
     private static String unquote(String s) {

--- a/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringDisabledRestIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.cloudmonitoring;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(CloudMonitoringDisabledRestIntegrationTest.DisabledMonitoringProfile.class)
+class CloudMonitoringDisabledRestIntegrationTest {
+
+    @Test
+    void disabledMonitoringRestServiceReturnsUnavailableWrapper() {
+        given()
+                .when().get("/v3/projects/monitoring-disabled/metricDescriptors")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service monitoring is not enabled."));
+    }
+
+    public static class DisabledMonitoringProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.monitoring.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringRestIntegrationTest.java
@@ -1,0 +1,163 @@
+package io.floci.gcp.services.cloudmonitoring;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.emptyString;
+
+@QuarkusTest
+class CloudMonitoringRestIntegrationTest {
+
+    private static final String PROJECT = "monitoring-rest-it";
+    private static final String METRIC = "custom.googleapis.com/rest_it/requests";
+    private static final String BASE = "/v3/projects/" + PROJECT;
+
+    @Test
+    void metricDescriptorAndTimeSeriesRestLifecycle() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant older = now.minusSeconds(120);
+        Instant newer = now.minusSeconds(60);
+
+        // Create descriptor with one label
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "type": "%s",
+                          "metricKind": "GAUGE",
+                          "valueType": "DOUBLE",
+                          "labels": [{"key": "env", "description": "environment"}]
+                        }
+                        """.formatted(METRIC))
+                .when().post(BASE + "/metricDescriptors")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(PROJECT_NAME + "/metricDescriptors/" + METRIC))
+                .body("type", equalTo(METRIC))
+                .body("labels", hasSize(1));
+
+        // Upsert with a new label: labels are unioned, never removed
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "type": "%s",
+                          "metricKind": "GAUGE",
+                          "valueType": "DOUBLE",
+                          "labels": [{"key": "region", "description": "region"}]
+                        }
+                        """.formatted(METRIC))
+                .when().post(BASE + "/metricDescriptors")
+                .then()
+                .statusCode(200)
+                .body("labels", hasSize(2));
+
+        // Second descriptor, then page through with pageSize=1
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"type": "custom.googleapis.com/rest_it/other", "metricKind": "GAUGE", "valueType": "INT64"}
+                        """)
+                .when().post(BASE + "/metricDescriptors")
+                .then()
+                .statusCode(200);
+
+        String nextPageToken = given()
+                .queryParam("pageSize", 1)
+                .when().get(BASE + "/metricDescriptors")
+                .then()
+                .statusCode(200)
+                .body("metricDescriptors", hasSize(1))
+                .body("nextPageToken", not(emptyString()))
+                .extract().path("nextPageToken");
+
+        given()
+                .queryParam("pageSize", 1)
+                .queryParam("pageToken", nextPageToken)
+                .when().get(BASE + "/metricDescriptors")
+                .then()
+                .statusCode(200)
+                .body("metricDescriptors", hasSize(1));
+
+        // Write two chronological points
+        writePoint(3.5, older);
+        writePoint(4.5, newer);
+
+        // Read them back newest-first
+        given()
+                .queryParam("filter", "metric.type = \"" + METRIC + "\"")
+                .queryParam("interval.startTime", now.minusSeconds(3600).toString())
+                .queryParam("interval.endTime", now.toString())
+                .when().get(BASE + "/timeSeries")
+                .then()
+                .statusCode(200)
+                .body("timeSeries", hasSize(1))
+                .body("timeSeries[0].points", hasSize(2))
+                .body("timeSeries[0].points[0].interval.endTime", equalTo(newer.toString()))
+                .body("timeSeries[0].points[0].value.doubleValue", equalTo(4.5f))
+                .body("timeSeries[0].points[1].interval.endTime", equalTo(older.toString()));
+
+        // Aggregated query via aggregation.* query params
+        given()
+                .queryParam("filter", "metric.type = \"" + METRIC + "\"")
+                .queryParam("interval.startTime", now.minusSeconds(3600).toString())
+                .queryParam("interval.endTime", now.toString())
+                .queryParam("aggregation.alignmentPeriod", "3600s")
+                .queryParam("aggregation.perSeriesAligner", "ALIGN_SUM")
+                .queryParam("aggregation.crossSeriesReducer", "REDUCE_SUM")
+                .when().get(BASE + "/timeSeries")
+                .then()
+                .statusCode(200)
+                .body("timeSeries", hasSize(1))
+                .body("timeSeries[0].points", hasSize(1))
+                .body("timeSeries[0].points[0].value.doubleValue", equalTo(8.0f));
+    }
+
+    @Test
+    void listTimeSeriesWithoutFilterReturnsInvalidArgument() {
+        given()
+                .queryParam("interval.endTime", Instant.now().toString())
+                .when().get(BASE + "/timeSeries")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    void deleteSystemMetricReturnsInvalidArgument() {
+        given()
+                .when().delete(BASE + "/metricDescriptors/compute.googleapis.com/instance/cpu/usage_time")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    private static final String PROJECT_NAME = "projects/" + PROJECT;
+
+    private static void writePoint(double value, Instant end) {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "timeSeries": [{
+                            "metric": {"type": "%s", "labels": {"env": "local"}},
+                            "resource": {"type": "global"},
+                            "points": [{
+                              "interval": {"endTime": "%s"},
+                              "value": {"doubleValue": %s}
+                            }]
+                          }]
+                        }
+                        """.formatted(METRIC, end, value))
+                .when().post(BASE + "/timeSeries")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringRestIntegrationTest.java
@@ -121,6 +121,19 @@ class CloudMonitoringRestIntegrationTest {
     }
 
     @Test
+    void fractionalAlignmentPeriodIsAccepted() {
+        given()
+                .queryParam("filter", "metric.type = \"custom.googleapis.com/fractional\"")
+                .queryParam("interval.startTime", Instant.now().minusSeconds(600).toString())
+                .queryParam("interval.endTime", Instant.now().toString())
+                .queryParam("aggregation.alignmentPeriod", "60.5s")
+                .queryParam("aggregation.perSeriesAligner", "ALIGN_SUM")
+                .when().get(BASE + "/timeSeries")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
     void listTimeSeriesWithoutFilterReturnsInvalidArgument() {
         given()
                 .queryParam("interval.endTime", Instant.now().toString())

--- a/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringServiceTest.java
@@ -246,6 +246,23 @@ class CloudMonitoringServiceTest {
         assertEquals("INVALID_ARGUMENT", deltaEx.getGcpStatus());
     }
 
+    @Test
+    void autoCreateRejectsBoolValueWithCumulativeKind() {
+        TimeSeries boolCumulative = cumulativePoint(METRIC, 1, NOW.minusSeconds(120), NOW.minusSeconds(60)).toBuilder()
+                .setPoints(0, Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder()
+                                .setStartTime(ts(NOW.minusSeconds(120)))
+                                .setEndTime(ts(NOW.minusSeconds(60))))
+                        .setValue(TypedValue.newBuilder().setBoolValue(true)))
+                .build();
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createTimeSeries(PROJECT, List.of(boolCumulative)));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertThrows(GcpException.class,
+                () -> service.getMetricDescriptor(PROJECT + "/metricDescriptors/" + METRIC));
+    }
+
     // ── ListTimeSeries validation ────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudmonitoring/CloudMonitoringServiceTest.java
@@ -1,0 +1,582 @@
+package io.floci.gcp.services.cloudmonitoring;
+
+import com.google.api.LabelDescriptor;
+import com.google.api.Metric;
+import com.google.api.MetricDescriptor;
+import com.google.api.MonitoredResource;
+import com.google.api.MonitoredResourceDescriptor;
+import com.google.monitoring.v3.Aggregation;
+import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.TimeInterval;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.monitoring.v3.TypedValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.cloudmonitoring.model.StoredTimeSeriesPoint;
+import io.floci.gcp.core.storage.StorageBackend;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CloudMonitoringServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-07T12:00:00Z");
+    private static final String PROJECT = "projects/p1";
+    private static final String METRIC = "custom.googleapis.com/test/metric";
+
+    private CloudMonitoringService service;
+    private StorageBackend<String, StoredTimeSeriesPoint> timeSeriesStore;
+
+    @BeforeEach
+    void setUp() {
+        timeSeriesStore = new InMemoryStorage<>();
+        service = new CloudMonitoringService(new InMemoryStorage<>(), timeSeriesStore,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    // ── Metric descriptors ───────────────────────────────────────────────────
+
+    @Test
+    void createDescriptorRequiresDomainPrefixedType() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createMetricDescriptor(PROJECT, descriptor("no-domain-metric").build()));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+
+        MetricDescriptor created = service.createMetricDescriptor(PROJECT, descriptor(METRIC).build());
+        assertEquals(PROJECT + "/metricDescriptors/" + METRIC, created.getName());
+    }
+
+    @Test
+    void boolValueTypeWithNonGaugeKindRejected() {
+        MetricDescriptor descriptor = descriptor(METRIC)
+                .setMetricKind(MetricDescriptor.MetricKind.CUMULATIVE)
+                .setValueType(MetricDescriptor.ValueType.BOOL)
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createMetricDescriptor(PROJECT, descriptor));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void createDescriptorUpsertsAndUnionsLabels() {
+        service.createMetricDescriptor(PROJECT, descriptor(METRIC)
+                .addLabels(LabelDescriptor.newBuilder().setKey("a").setDescription("first"))
+                .build());
+        MetricDescriptor updated = service.createMetricDescriptor(PROJECT, descriptor(METRIC)
+                .addLabels(LabelDescriptor.newBuilder().setKey("b").setDescription("second"))
+                .build());
+
+        assertEquals(2, updated.getLabelsCount());
+        assertEquals(List.of("a", "b"), updated.getLabelsList().stream().map(LabelDescriptor::getKey).toList());
+
+        MetricDescriptor redefined = service.createMetricDescriptor(PROJECT, descriptor(METRIC)
+                .addLabels(LabelDescriptor.newBuilder().setKey("a").setDescription("redefined"))
+                .build());
+        assertEquals(2, redefined.getLabelsCount());
+        assertEquals("redefined", redefined.getLabels(0).getDescription());
+    }
+
+    @Test
+    void deleteSystemMetricRejected() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.deleteMetricDescriptor(PROJECT + "/metricDescriptors/compute.googleapis.com/instance/cpu/usage_time"));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void deleteCustomMetricCascadesPoints() {
+        write(gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(60)));
+        assertEquals(1, timeSeriesStore.scan(k -> true).size());
+
+        service.deleteMetricDescriptor(PROJECT + "/metricDescriptors/" + METRIC);
+        assertEquals(0, timeSeriesStore.scan(k -> true).size());
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.deleteMetricDescriptor(PROJECT + "/metricDescriptors/" + METRIC));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    // ── CreateTimeSeries validation ──────────────────────────────────────────
+
+    @Test
+    void moreThan200TimeSeriesRejected() {
+        List<TimeSeries> batch = IntStream.rangeClosed(1, 201)
+                .mapToObj(i -> gaugePoint("custom.googleapis.com/m" + i, Map.of(), i, NOW.minusSeconds(60)))
+                .toList();
+        GcpException ex = assertThrows(GcpException.class, () -> service.createTimeSeries(PROJECT, batch));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void exactlyOnePointPerSeriesRequired() {
+        TimeSeries twoPoints = gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(120)).toBuilder()
+                .addPoints(Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setEndTime(ts(NOW.minusSeconds(60))))
+                        .setValue(TypedValue.newBuilder().setDoubleValue(2.0)))
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createTimeSeries(PROJECT, List.of(twoPoints)));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void missingEndTimeRejected() {
+        TimeSeries series = gaugePoint(METRIC, Map.of(), 1.0, NOW).toBuilder()
+                .setPoints(0, Point.newBuilder().setValue(TypedValue.newBuilder().setDoubleValue(1.0)))
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createTimeSeries(PROJECT, List.of(series)));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void endTimeOutsideWriteWindowRejected() {
+        GcpException past = assertThrows(GcpException.class,
+                () -> write(gaugePoint(METRIC, Map.of(), 1.0, NOW.minus(java.time.Duration.ofHours(26)))));
+        assertEquals("INVALID_ARGUMENT", past.getGcpStatus());
+
+        GcpException future = assertThrows(GcpException.class,
+                () -> write(gaugePoint(METRIC, Map.of(), 1.0, NOW.plus(java.time.Duration.ofMinutes(10)))));
+        assertEquals("INVALID_ARGUMENT", future.getGcpStatus());
+    }
+
+    @Test
+    void gaugeStartTimeMustEqualEndTime() {
+        Instant end = NOW.minusSeconds(60);
+        TimeSeries badStart = gaugePoint(METRIC, Map.of(), 1.0, end).toBuilder()
+                .setPoints(0, Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder()
+                                .setStartTime(ts(end.minusSeconds(30)))
+                                .setEndTime(ts(end)))
+                        .setValue(TypedValue.newBuilder().setDoubleValue(1.0)))
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createTimeSeries(PROJECT, List.of(badStart)));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+
+        TimeSeries okStart = gaugePoint(METRIC, Map.of(), 1.0, end).toBuilder()
+                .setPoints(0, Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setStartTime(ts(end)).setEndTime(ts(end)))
+                        .setValue(TypedValue.newBuilder().setDoubleValue(1.0)))
+                .build();
+        assertDoesNotThrow(() -> service.createTimeSeries(PROJECT, List.of(okStart)));
+    }
+
+    @Test
+    void cumulativeRequiresStartBeforeEnd() {
+        Instant end = NOW.minusSeconds(60);
+        GcpException sameStart = assertThrows(GcpException.class,
+                () -> write(cumulativePoint(METRIC, 10, end, end)));
+        assertEquals("INVALID_ARGUMENT", sameStart.getGcpStatus());
+
+        assertDoesNotThrow(() -> write(cumulativePoint(METRIC, 10, end.minusSeconds(600), end)));
+    }
+
+    @Test
+    void stalePointRejected() {
+        write(gaugePoint(METRIC, Map.of("id", "a"), 1.0, NOW.minusSeconds(60)));
+
+        GcpException older = assertThrows(GcpException.class,
+                () -> write(gaugePoint(METRIC, Map.of("id", "a"), 2.0, NOW.minusSeconds(120))));
+        assertEquals("INVALID_ARGUMENT", older.getGcpStatus());
+
+        GcpException same = assertThrows(GcpException.class,
+                () -> write(gaugePoint(METRIC, Map.of("id", "a"), 2.0, NOW.minusSeconds(60))));
+        assertEquals("INVALID_ARGUMENT", same.getGcpStatus());
+
+        // A different label value is an independent series
+        assertDoesNotThrow(() -> write(gaugePoint(METRIC, Map.of("id", "b"), 2.0, NOW.minusSeconds(120))));
+    }
+
+    @Test
+    void batchWritesNothingOnFailure() {
+        TimeSeries valid = gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(60));
+        TimeSeries invalid = gaugePoint("custom.googleapis.com/other", Map.of(), 1.0,
+                NOW.plus(java.time.Duration.ofMinutes(10)));
+
+        assertThrows(GcpException.class, () -> service.createTimeSeries(PROJECT, List.of(valid, invalid)));
+
+        assertEquals(0, timeSeriesStore.scan(k -> true).size());
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.getMetricDescriptor(PROJECT + "/metricDescriptors/" + METRIC));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void autoCreateInfersValueTypeFromPoint() {
+        TimeSeries int64Series = gaugePoint(METRIC, Map.of(), 0, NOW.minusSeconds(60)).toBuilder()
+                .setPoints(0, Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setEndTime(ts(NOW.minusSeconds(60))))
+                        .setValue(TypedValue.newBuilder().setInt64Value(42)))
+                .build();
+        service.createTimeSeries(PROJECT, List.of(int64Series));
+
+        MetricDescriptor desc = service.getMetricDescriptor(PROJECT + "/metricDescriptors/" + METRIC);
+        assertEquals(MetricDescriptor.ValueType.INT64, desc.getValueType());
+        assertEquals(MetricDescriptor.MetricKind.GAUGE, desc.getMetricKind());
+    }
+
+    @Test
+    void autoCreateRejectsStringValuesAndDeltaKind() {
+        TimeSeries stringSeries = gaugePoint(METRIC, Map.of(), 0, NOW.minusSeconds(60)).toBuilder()
+                .setPoints(0, Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setEndTime(ts(NOW.minusSeconds(60))))
+                        .setValue(TypedValue.newBuilder().setStringValue("nope")))
+                .build();
+        GcpException stringEx = assertThrows(GcpException.class,
+                () -> service.createTimeSeries(PROJECT, List.of(stringSeries)));
+        assertEquals("INVALID_ARGUMENT", stringEx.getGcpStatus());
+
+        TimeSeries deltaSeries = cumulativePoint(METRIC, 5, NOW.minusSeconds(120), NOW.minusSeconds(60)).toBuilder()
+                .setMetricKind(MetricDescriptor.MetricKind.DELTA)
+                .build();
+        GcpException deltaEx = assertThrows(GcpException.class,
+                () -> service.createTimeSeries(PROJECT, List.of(deltaSeries)));
+        assertEquals("INVALID_ARGUMENT", deltaEx.getGcpStatus());
+    }
+
+    // ── ListTimeSeries validation ────────────────────────────────────────────
+
+    @Test
+    void listTimeSeriesRequiresFilterWithMetricType() {
+        TimeInterval interval = interval(NOW.minusSeconds(3600), NOW);
+
+        assertEquals("INVALID_ARGUMENT", assertThrows(GcpException.class,
+                () -> list("", interval)).getGcpStatus());
+        assertEquals("INVALID_ARGUMENT", assertThrows(GcpException.class,
+                () -> list("resource.type = \"global\"", interval)).getGcpStatus());
+        assertEquals("INVALID_ARGUMENT", assertThrows(GcpException.class,
+                () -> list("metric.type = starts_with(\"custom.\")", interval)).getGcpStatus());
+    }
+
+    @Test
+    void listTimeSeriesRequiresEndTime() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> list(typeFilter(), TimeInterval.getDefaultInstance()));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void listTimeSeriesIntervalIsHalfOpen() {
+        Instant t1 = NOW.minusSeconds(120);
+        Instant t2 = NOW.minusSeconds(60);
+        write(gaugePoint(METRIC, Map.of(), 1.0, t1));
+        write(gaugePoint(METRIC, Map.of(), 2.0, t2));
+
+        List<TimeSeries> series = list(typeFilter(), interval(t1, t2)).items();
+        assertEquals(1, series.size());
+        assertEquals(1, series.get(0).getPointsCount());
+        assertEquals(2.0, series.get(0).getPoints(0).getValue().getDoubleValue());
+    }
+
+    @Test
+    void filterSupportsStartsWithAndExtractsMetricType() {
+        TimeSeriesFilter.ParsedFilter parsed = TimeSeriesFilter.parseFilter(
+                "metric.type = \"" + METRIC + "\" AND metric.labels.id = starts_with(\"prod-\")");
+        assertEquals(METRIC, parsed.metricTypeEquality());
+
+        StoredTimeSeriesPoint prod = new StoredTimeSeriesPoint();
+        prod.setMetricType(METRIC);
+        prod.setMetricLabels(Map.of("id", "prod-1"));
+        StoredTimeSeriesPoint dev = new StoredTimeSeriesPoint();
+        dev.setMetricType(METRIC);
+        dev.setMetricLabels(Map.of("id", "dev-1"));
+
+        assertTrue(parsed.predicate().test(prod));
+        assertFalse(parsed.predicate().test(dev));
+
+        assertNull(TimeSeriesFilter.parseFilter("metric.type = starts_with(\"custom.\")").metricTypeEquality());
+    }
+
+    // ── Aggregation ──────────────────────────────────────────────────────────
+
+    @Test
+    void aggregationValidationRejectsBadRequests() {
+        write(gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(30)));
+        TimeInterval interval = interval(NOW.minusSeconds(3600), NOW);
+
+        Aggregation shortPeriod = Aggregation.newBuilder()
+                .setPerSeriesAligner(Aggregation.Aligner.ALIGN_SUM)
+                .setAlignmentPeriod(Duration.newBuilder().setSeconds(59))
+                .build();
+        assertEquals("INVALID_ARGUMENT", assertThrows(GcpException.class,
+                () -> list(typeFilter(), interval, shortPeriod)).getGcpStatus());
+
+        Aggregation reducerWithoutAligner = Aggregation.newBuilder()
+                .setCrossSeriesReducer(Aggregation.Reducer.REDUCE_SUM)
+                .build();
+        assertEquals("INVALID_ARGUMENT", assertThrows(GcpException.class,
+                () -> list(typeFilter(), interval, reducerWithoutAligner)).getGcpStatus());
+
+        Aggregation unsupported = Aggregation.newBuilder()
+                .setPerSeriesAligner(Aggregation.Aligner.ALIGN_PERCENTILE_99)
+                .setAlignmentPeriod(Duration.newBuilder().setSeconds(60))
+                .build();
+        assertEquals("INVALID_ARGUMENT", assertThrows(GcpException.class,
+                () -> list(typeFilter(), interval, unsupported)).getGcpStatus());
+    }
+
+    @Test
+    void alignSumBucketsPointsOnPeriodBoundaries() {
+        write(gaugePoint(METRIC, Map.of(), 4.0, NOW.minusSeconds(90)));
+        write(gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(30)));
+        write(gaugePoint(METRIC, Map.of(), 2.0, NOW.minusSeconds(10)));
+
+        List<TimeSeries> series = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW),
+                aligned(Aggregation.Aligner.ALIGN_SUM, 60)).items();
+
+        assertEquals(1, series.size());
+        List<Point> points = series.get(0).getPointsList();
+        assertEquals(2, points.size());
+        assertEquals(NOW, toInstant(points.get(0).getInterval().getEndTime()));
+        assertEquals(3.0, points.get(0).getValue().getDoubleValue());
+        assertEquals(NOW.minusSeconds(60), toInstant(points.get(1).getInterval().getEndTime()));
+        assertEquals(4.0, points.get(1).getValue().getDoubleValue());
+    }
+
+    @Test
+    void alignMeanAndCountChangeOutputTypes() {
+        TimeSeries int1 = intGaugePoint(METRIC, 10, NOW.minusSeconds(30));
+        TimeSeries int2 = intGaugePoint(METRIC, 20, NOW.minusSeconds(10));
+        service.createTimeSeries(PROJECT, List.of(int1));
+        service.createTimeSeries(PROJECT, List.of(int2));
+
+        TimeSeries mean = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW),
+                aligned(Aggregation.Aligner.ALIGN_MEAN, 60)).items().get(0);
+        assertEquals(MetricDescriptor.ValueType.DOUBLE, mean.getValueType());
+        assertEquals(15.0, mean.getPoints(0).getValue().getDoubleValue());
+
+        TimeSeries count = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW),
+                aligned(Aggregation.Aligner.ALIGN_COUNT, 60)).items().get(0);
+        assertEquals(MetricDescriptor.ValueType.INT64, count.getValueType());
+        assertEquals(2, count.getPoints(0).getValue().getInt64Value());
+    }
+
+    @Test
+    void alignDeltaAndRateOnCumulative() {
+        Instant start = NOW.minusSeconds(600);
+        write(cumulativePoint(METRIC, 10, start, NOW.minusSeconds(90)));
+        write(cumulativePoint(METRIC, 25, start, NOW.minusSeconds(30)));
+
+        TimeSeries delta = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW),
+                aligned(Aggregation.Aligner.ALIGN_DELTA, 120)).items().get(0);
+        assertEquals(MetricDescriptor.MetricKind.DELTA, delta.getMetricKind());
+        assertEquals(15.0, delta.getPoints(0).getValue().getDoubleValue());
+        assertEquals(NOW.minusSeconds(120), toInstant(delta.getPoints(0).getInterval().getStartTime()));
+
+        TimeSeries rate = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW),
+                aligned(Aggregation.Aligner.ALIGN_RATE, 120)).items().get(0);
+        assertEquals(MetricDescriptor.MetricKind.GAUGE, rate.getMetricKind());
+        assertEquals(MetricDescriptor.ValueType.DOUBLE, rate.getValueType());
+        assertEquals(15.0 / 120, rate.getPoints(0).getValue().getDoubleValue(), 1e-9);
+    }
+
+    @Test
+    void alignDeltaOnGaugeRejected() {
+        write(gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(30)));
+        GcpException ex = assertThrows(GcpException.class,
+                () -> list(typeFilter(), interval(NOW.minusSeconds(3600), NOW),
+                        aligned(Aggregation.Aligner.ALIGN_DELTA, 60)));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void reduceSumCollapsesSeriesAndGroupByPartitions() {
+        write(gaugePoint(METRIC, Map.of(), Map.of("zone", "us-a"), 5.0, NOW.minusSeconds(30)));
+        write(gaugePoint(METRIC, Map.of(), Map.of("zone", "us-b"), 7.0, NOW.minusSeconds(20)));
+
+        Aggregation reduced = aligned(Aggregation.Aligner.ALIGN_SUM, 60).toBuilder()
+                .setCrossSeriesReducer(Aggregation.Reducer.REDUCE_SUM)
+                .build();
+        List<TimeSeries> collapsed = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW), reduced).items();
+        assertEquals(1, collapsed.size());
+        assertEquals(12.0, collapsed.get(0).getPoints(0).getValue().getDoubleValue());
+        assertTrue(collapsed.get(0).getResource().getLabelsMap().isEmpty());
+
+        Aggregation grouped = reduced.toBuilder().addGroupByFields("resource.label.zone").build();
+        List<TimeSeries> partitioned = list(typeFilter(), interval(NOW.minusSeconds(3600), NOW), grouped).items();
+        assertEquals(2, partitioned.size());
+        assertEquals(Map.of("zone", "us-a"), partitioned.get(0).getResource().getLabelsMap());
+        assertEquals(5.0, partitioned.get(0).getPoints(0).getValue().getDoubleValue());
+        assertEquals(Map.of("zone", "us-b"), partitioned.get(1).getResource().getLabelsMap());
+    }
+
+    @Test
+    void unknownGroupByFieldRejected() {
+        write(gaugePoint(METRIC, Map.of(), 1.0, NOW.minusSeconds(30)));
+        Aggregation bad = aligned(Aggregation.Aligner.ALIGN_SUM, 60).toBuilder()
+                .setCrossSeriesReducer(Aggregation.Reducer.REDUCE_SUM)
+                .addGroupByFields("bogus.field")
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> list(typeFilter(), interval(NOW.minusSeconds(3600), NOW), bad));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    // ── Pagination ───────────────────────────────────────────────────────────
+
+    @Test
+    void listMetricDescriptorsPaginates() {
+        for (int i = 1; i <= 3; i++) {
+            service.createMetricDescriptor(PROJECT, descriptor("custom.googleapis.com/m" + i).build());
+        }
+
+        PageToken.Page<MetricDescriptor> first = service.listMetricDescriptors(PROJECT, null, 2, null);
+        assertEquals(2, first.items().size());
+        assertNotNull(first.nextPageToken());
+
+        PageToken.Page<MetricDescriptor> second =
+                service.listMetricDescriptors(PROJECT, null, 2, first.nextPageToken());
+        assertEquals(1, second.items().size());
+        assertNull(second.nextPageToken());
+    }
+
+    @Test
+    void listTimeSeriesFullViewPaginatesByPoints() {
+        for (String id : List.of("a", "b")) {
+            for (int minute = 3; minute >= 1; minute--) {
+                write(gaugePoint(METRIC, Map.of("id", id), minute, NOW.minusSeconds(minute * 60L)));
+            }
+        }
+
+        PageToken.Page<TimeSeries> first = service.listTimeSeries(PROJECT, typeFilter(),
+                interval(NOW.minusSeconds(3600), NOW), Aggregation.getDefaultInstance(), "FULL", 4, null);
+        assertEquals(4, first.items().stream().mapToInt(TimeSeries::getPointsCount).sum());
+        assertEquals(2, first.items().size());
+        assertNotNull(first.nextPageToken());
+
+        PageToken.Page<TimeSeries> second = service.listTimeSeries(PROJECT, typeFilter(),
+                interval(NOW.minusSeconds(3600), NOW), Aggregation.getDefaultInstance(), "FULL", 4,
+                first.nextPageToken());
+        assertEquals(2, second.items().stream().mapToInt(TimeSeries::getPointsCount).sum());
+        assertEquals(1, second.items().size());
+        assertNull(second.nextPageToken());
+    }
+
+    @Test
+    void listTimeSeriesHeadersViewPaginatesBySeries() {
+        write(gaugePoint(METRIC, Map.of("id", "a"), 1.0, NOW.minusSeconds(60)));
+        write(gaugePoint(METRIC, Map.of("id", "b"), 2.0, NOW.minusSeconds(60)));
+
+        PageToken.Page<TimeSeries> first = service.listTimeSeries(PROJECT, typeFilter(),
+                interval(NOW.minusSeconds(3600), NOW), Aggregation.getDefaultInstance(), "HEADERS", 1, null);
+        assertEquals(1, first.items().size());
+        assertEquals(0, first.items().get(0).getPointsCount());
+        assertNotNull(first.nextPageToken());
+
+        PageToken.Page<TimeSeries> second = service.listTimeSeries(PROJECT, typeFilter(),
+                interval(NOW.minusSeconds(3600), NOW), Aggregation.getDefaultInstance(), "HEADERS", 1,
+                first.nextPageToken());
+        assertEquals(1, second.items().size());
+        assertNull(second.nextPageToken());
+    }
+
+    @Test
+    void listMonitoredResourceDescriptorsPaginates() {
+        PageToken.Page<MonitoredResourceDescriptor> first =
+                service.listMonitoredResourceDescriptors(PROJECT, 1, null);
+        assertEquals(1, first.items().size());
+        assertEquals("global", first.items().get(0).getType());
+        assertNotNull(first.nextPageToken());
+
+        PageToken.Page<MonitoredResourceDescriptor> second =
+                service.listMonitoredResourceDescriptors(PROJECT, 1, first.nextPageToken());
+        assertEquals("gce_instance", second.items().get(0).getType());
+        assertNull(second.nextPageToken());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void write(TimeSeries series) {
+        service.createTimeSeries(PROJECT, List.of(series));
+    }
+
+    private PageToken.Page<TimeSeries> list(String filter, TimeInterval interval) {
+        return list(filter, interval, Aggregation.getDefaultInstance());
+    }
+
+    private PageToken.Page<TimeSeries> list(String filter, TimeInterval interval, Aggregation aggregation) {
+        return service.listTimeSeries(PROJECT, filter, interval, aggregation, "FULL", 0, null);
+    }
+
+    private static String typeFilter() {
+        return "metric.type = \"" + METRIC + "\"";
+    }
+
+    private static MetricDescriptor.Builder descriptor(String type) {
+        return MetricDescriptor.newBuilder()
+                .setType(type)
+                .setMetricKind(MetricDescriptor.MetricKind.GAUGE)
+                .setValueType(MetricDescriptor.ValueType.DOUBLE);
+    }
+
+    private static TimeSeries gaugePoint(String type, Map<String, String> metricLabels,
+                                         double value, Instant end) {
+        return gaugePoint(type, metricLabels, Map.of(), value, end);
+    }
+
+    private static TimeSeries gaugePoint(String type, Map<String, String> metricLabels,
+                                         Map<String, String> resourceLabels, double value, Instant end) {
+        return TimeSeries.newBuilder()
+                .setMetric(Metric.newBuilder().setType(type).putAllLabels(metricLabels))
+                .setResource(MonitoredResource.newBuilder().setType("global").putAllLabels(resourceLabels))
+                .addPoints(Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setEndTime(ts(end)))
+                        .setValue(TypedValue.newBuilder().setDoubleValue(value)))
+                .build();
+    }
+
+    private static TimeSeries intGaugePoint(String type, long value, Instant end) {
+        return TimeSeries.newBuilder()
+                .setMetric(Metric.newBuilder().setType(type))
+                .setResource(MonitoredResource.newBuilder().setType("global"))
+                .addPoints(Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setEndTime(ts(end)))
+                        .setValue(TypedValue.newBuilder().setInt64Value(value)))
+                .build();
+    }
+
+    private static TimeSeries cumulativePoint(String type, double value, Instant start, Instant end) {
+        return TimeSeries.newBuilder()
+                .setMetric(Metric.newBuilder().setType(type))
+                .setResource(MonitoredResource.newBuilder().setType("global"))
+                .setMetricKind(MetricDescriptor.MetricKind.CUMULATIVE)
+                .addPoints(Point.newBuilder()
+                        .setInterval(TimeInterval.newBuilder().setStartTime(ts(start)).setEndTime(ts(end)))
+                        .setValue(TypedValue.newBuilder().setDoubleValue(value)))
+                .build();
+    }
+
+    private static Aggregation aligned(Aggregation.Aligner aligner, long periodSeconds) {
+        return Aggregation.newBuilder()
+                .setPerSeriesAligner(aligner)
+                .setAlignmentPeriod(Duration.newBuilder().setSeconds(periodSeconds))
+                .build();
+    }
+
+    private static TimeInterval interval(Instant start, Instant end) {
+        return TimeInterval.newBuilder().setStartTime(ts(start)).setEndTime(ts(end)).build();
+    }
+
+    private static Timestamp ts(Instant instant) {
+        return Timestamp.newBuilder()
+                .setSeconds(instant.getEpochSecond())
+                .setNanos(instant.getNano())
+                .build();
+    }
+
+    private static Instant toInstant(Timestamp ts) {
+        return Instant.ofEpochSecond(ts.getSeconds(), ts.getNanos());
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Cloud Monitoring parity gaps tracked in #45:

- `ListTimeSeries` now supports the practical aggregation subset — per-series alignment and cross-series reduction via a new `TimeSeriesAggregator` — plus pagination
- `CreateTimeSeries` enforces real GCP validation rules (metric kind / value-type consistency, label validation, end-time ordering)
- Extended time-series filter grammar support
- Fixes for service gating and point-sequence edge cases

Closes #45

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Behavior grounded in the `google/monitoring/v3` protos plus the cloud.google.com aggregation/filter semantics documentation mirrored under `local/google/docs/`. Verified through Java SDK (`MetricServiceClient`) additions in `sdk-test-java/MonitoringTest` and REST integration tests covering both protocol paths (gRPC and `/v3` REST JSON).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)