### PR TITLE
feat(bigquery): implement BigQuery Phase 1 REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Cloud Monitoring | ✅ | ❌ |
 | Service Usage | ✅ | ❌ |
 | Identity Platform / Firebase Auth | ✅ | ❌ |
+| BigQuery (Phase 1) | ✅ | ❌ |
 | Native binary | ✅ | ❌ |
 
 ## Architecture Overview
@@ -161,7 +162,7 @@ flowchart LR
         end
 
         subgraph REST ["REST services"]
-            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions\nCloud SQL\nGKE"]
+            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions\nCloud SQL\nGKE\nBigQuery"]
         end
 
         subgraph Docker ["Docker-backed"]
@@ -192,6 +193,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Serverless control planes | Cloud Run, Cloud Functions |
 | Task scheduling | Cloud Tasks, Cloud Scheduler |
 | Databases | Cloud SQL for PostgreSQL |
+| Analytics | BigQuery (Phase 1) |
 | Observability | Cloud Logging, Cloud Monitoring |
 
 <details>
@@ -217,6 +219,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Cloud Monitoring** | gRPC + REST JSON | Metric descriptors (create/get/list/delete), monitored resource descriptors, time series write (`CreateTimeSeries` with GCP validation rules) and read (`ListTimeSeries` with alignment/reduction subset and pagination) |
 | **Service Usage** | REST JSON | Enable/disable/list a project's services (`serviceusage.googleapis.com` v1) with done LROs; accept-and-succeed state store for Terraform `google_project_service`, Pulumi, and `gcloud services`; includes a minimal Cloud Resource Manager v1 `projects.get` for provider project lookups |
 | **Firebase Auth (Identity Platform)** | REST JSON | Identity Toolkit v1 wire-compatible with the official Auth emulator: email/password, anonymous and custom-token sign-in, unsigned emulator JWTs `firebase-admin` verifies, token refresh + revocation, admin user CRUD/list via `FIREBASE_AUTH_EMULATOR_HOST` |
+| **BigQuery (Phase 1)** | REST JSON | Datasets and tables CRUD with schema normalization, schema-validated `tabledata.insertAll`/`tabledata.list`, query jobs (`jobs.query`, `jobs.insert`, `getQueryResults`) over a SQL subset (`SELECT *`/columns/`COUNT(*)`, `WHERE =`, `LIMIT`) |
 
 </details>
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-run</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -188,6 +188,21 @@ public final class TestFixtures {
         return FunctionServiceClient.create(settings);
     }
 
+    /**
+     * Creates a BigQuery client pointing at the emulator. The java-bigquery SDK has no
+     * emulator env-var support; setHost() routes the Apiary client to the emulator, which
+     * serves under /bigquery/v2/.
+     */
+    public static com.google.cloud.bigquery.BigQuery bigQueryClient() {
+        return com.google.cloud.bigquery.BigQueryOptions.newBuilder()
+                .setHost(endpoint())
+                .setLocation("US")
+                .setProjectId(projectId())
+                .setCredentials(NoCredentials.getInstance())
+                .build()
+                .getService();
+    }
+
     public static SQLAdmin sqlAdminClient() {
         return new SQLAdmin.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance(), request -> {
         })

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/BigQueryTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/BigQueryTest.java
@@ -1,0 +1,220 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TableResult;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Validates the Phase 1 BigQuery REST surface against the real {@code google-cloud-bigquery}
+ * SDK: dataset/table metadata, {@code insertAll}, the {@code jobs.query} fast path, the
+ * {@code jobs.insert} + {@code Job.waitFor()} + {@code Job.getQueryResults()} path (which
+ * reads rows from the job's destination table), and error surfaces. The SDK targets the
+ * emulator via {@code setHost} (see {@link TestFixtures#bigQueryClient()}).
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class BigQueryTest {
+
+    private static final String PROJECT_ID = TestFixtures.projectId();
+    private static final String DATASET = TestFixtures.uniqueName("ds").replace("-", "_");
+    private static final String TABLE = "people";
+
+    private static BigQuery bigquery;
+
+    @BeforeAll
+    static void setUp() {
+        bigquery = TestFixtures.bigQueryClient();
+    }
+
+    @Test
+    @Order(1)
+    void createDataset() {
+        com.google.cloud.bigquery.Dataset dataset =
+                bigquery.create(DatasetInfo.newBuilder(DATASET).setLocation("US").build());
+        assertThat(dataset.getDatasetId().getDataset()).isEqualTo(DATASET);
+    }
+
+    @Test
+    @Order(2)
+    void duplicateDatasetSurfacesDuplicateReason() {
+        assertThatThrownBy(() -> bigquery.create(DatasetInfo.newBuilder(DATASET).build()))
+                .isInstanceOfSatisfying(BigQueryException.class, e -> {
+                    assertThat(e.getCode()).isEqualTo(409);
+                    assertThat(e.getError().getReason()).isEqualTo("duplicate");
+                });
+    }
+
+    @Test
+    @Order(3)
+    void createTableWithTypedSchema() {
+        Schema schema = Schema.of(
+                Field.of("name", StandardSQLTypeName.STRING),
+                Field.of("age", StandardSQLTypeName.INT64),
+                Field.of("score", StandardSQLTypeName.FLOAT64),
+                Field.of("active", StandardSQLTypeName.BOOL),
+                Field.newBuilder("tags", StandardSQLTypeName.STRING)
+                        .setMode(Field.Mode.REPEATED).build());
+        com.google.cloud.bigquery.Table table = bigquery.create(TableInfo.newBuilder(
+                TableId.of(DATASET, TABLE), StandardTableDefinition.of(schema)).build());
+        assertThat(table.getTableId().getTable()).isEqualTo(TABLE);
+
+        Schema fetched = bigquery.getTable(TableId.of(DATASET, TABLE))
+                .getDefinition().getSchema();
+        assertThat(fetched.getFields().get("tags").getMode()).isEqualTo(Field.Mode.REPEATED);
+    }
+
+    @Test
+    @Order(4)
+    void insertAllRowsAndPerRowErrors() {
+        InsertAllResponse ok = bigquery.insertAll(InsertAllRequest.newBuilder(TableId.of(DATASET, TABLE))
+                .addRow(Map.of("name", "alice", "age", 30, "score", 9.5, "active", true,
+                        "tags", List.of("admin", "dev")))
+                .addRow(Map.of("name", "bob", "age", 25, "score", 7.0, "active", false,
+                        "tags", List.of()))
+                .build());
+        assertThat(ok.hasErrors()).isFalse();
+
+        InsertAllResponse bad = bigquery.insertAll(InsertAllRequest.newBuilder(TableId.of(DATASET, TABLE))
+                .addRow(Map.of("name", "x", "bogus", 1))
+                .build());
+        assertThat(bad.hasErrors()).isTrue();
+        assertThat(bad.getInsertErrors().get(0L).get(0).getReason()).isEqualTo("invalid");
+    }
+
+    @Test
+    @Order(5)
+    void selectStarReturnsTypedValues() throws InterruptedException {
+        String sql = "SELECT * FROM `" + PROJECT_ID + "." + DATASET + "." + TABLE + "`";
+        TableResult result = bigquery.query(QueryJobConfiguration.newBuilder(sql).build());
+        assertThat(result.getTotalRows()).isEqualTo(2);
+
+        FieldValueList alice = null;
+        for (FieldValueList row : result.iterateAll()) {
+            if ("alice".equals(row.get("name").getStringValue())) {
+                alice = row;
+            }
+        }
+        assertThat(alice).isNotNull();
+        assertThat(alice.get("age").getLongValue()).isEqualTo(30L);
+        assertThat(alice.get("score").getDoubleValue()).isEqualTo(9.5);
+        assertThat(alice.get("active").getBooleanValue()).isTrue();
+        assertThat(alice.get("tags").getRepeatedValue().stream()
+                .map(FieldValue::getStringValue).toList())
+                .containsExactly("admin", "dev");
+    }
+
+    @Test
+    @Order(6)
+    void whereAndCountQueries() throws InterruptedException {
+        TableResult filtered = bigquery.query(QueryJobConfiguration.newBuilder(
+                "SELECT name FROM `" + PROJECT_ID + "." + DATASET + "." + TABLE + "` WHERE age = 30")
+                .build());
+        List<String> names = new ArrayList<>();
+        filtered.iterateAll().forEach(row -> names.add(row.get("name").getStringValue()));
+        assertThat(names).containsExactly("alice");
+
+        TableResult count = bigquery.query(QueryJobConfiguration.newBuilder(
+                "SELECT COUNT(*) FROM `" + PROJECT_ID + "." + DATASET + "." + TABLE + "`").build());
+        assertThat(count.iterateAll().iterator().next().get(0).getLongValue()).isEqualTo(2L);
+    }
+
+    @Test
+    @Order(7)
+    void jobInsertWaitForAndQueryResults() throws InterruptedException {
+        // Exercises jobs.insert + polling + tabledata.list on the job's destination table.
+        String sql = "SELECT name, age FROM `" + PROJECT_ID + "." + DATASET + "." + TABLE
+                + "` WHERE active = TRUE";
+        Job job = bigquery.create(JobInfo.of(QueryJobConfiguration.newBuilder(sql).build()));
+        job = job.waitFor();
+
+        assertThat(job.getStatus().getError()).isNull();
+        TableResult result = job.getQueryResults();
+        assertThat(result.getTotalRows()).isEqualTo(1);
+        FieldValueList row = result.iterateAll().iterator().next();
+        assertThat(row.get("name").getStringValue()).isEqualTo("alice");
+        assertThat(row.get("age").getLongValue()).isEqualTo(30L);
+    }
+
+    @Test
+    @Order(8)
+    void invalidSqlViaFastPathThrowsInvalidQuery() {
+        String sql = "SELECT name FROM `" + PROJECT_ID + "." + DATASET + "." + TABLE + "` GROUP BY name";
+        assertThatThrownBy(() -> bigquery.query(QueryJobConfiguration.newBuilder(sql).build()))
+                .isInstanceOfSatisfying(BigQueryException.class, e -> {
+                    assertThat(e.getCode()).isEqualTo(400);
+                    assertThat(e.getError().getReason()).isEqualTo("invalidQuery");
+                });
+    }
+
+    @Test
+    @Order(9)
+    void invalidSqlViaJobReportsErrorInStatus() {
+        String sql = "SELECT name FROM `" + PROJECT_ID + "." + DATASET + "." + TABLE + "` ORDER BY name";
+        Job job = bigquery.create(JobInfo.of(QueryJobConfiguration.newBuilder(sql).build()));
+
+        // jobs.insert succeeds; the SQL failure lives in the job status (jobs.get)...
+        Job fetched = bigquery.getJob(job.getJobId());
+        assertThat(fetched.getStatus().getState().toString()).isEqualTo("DONE");
+        assertThat(fetched.getStatus().getError()).isNotNull();
+        assertThat(fetched.getStatus().getError().getReason()).isEqualTo("invalidQuery");
+
+        // ...and waitFor() throws because getQueryResults returns HTTP 400 for failed jobs.
+        assertThatThrownBy(job::waitFor)
+                .isInstanceOfSatisfying(BigQueryException.class,
+                        e -> assertThat(e.getError().getReason()).isEqualTo("invalidQuery"));
+    }
+
+    @Test
+    @Order(10)
+    void listTableDataPaginates() {
+        TableResult page = bigquery.listTableData(TableId.of(DATASET, TABLE),
+                BigQuery.TableDataListOption.pageSize(1));
+        assertThat(page.getValues()).hasSize(1);
+
+        List<FieldValueList> all = new ArrayList<>();
+        page.iterateAll().forEach(all::add);
+        assertThat(all).hasSize(2);
+    }
+
+    @Test
+    @Order(11)
+    void missingResourcesReturnNull() {
+        assertThat(bigquery.getDataset("missing_dataset_xyz")).isNull();
+        assertThat(bigquery.getTable(TableId.of(DATASET, "missing_table_xyz"))).isNull();
+    }
+
+    @Test
+    @Order(12)
+    void deleteDataset() {
+        boolean deleted = bigquery.delete(DatasetId.of(PROJECT_ID, DATASET),
+                BigQuery.DatasetDeleteOption.deleteContents());
+        assertThat(deleted).isTrue();
+        assertThat(bigquery.delete(DatasetId.of(PROJECT_ID, DATASET))).isFalse();
+    }
+}

--- a/docs/services/bigquery.md
+++ b/docs/services/bigquery.md
@@ -1,0 +1,104 @@
+# BigQuery (Phase 1)
+
+floci-gcp emulates the BigQuery v2 REST API (the surface the `google-cloud-bigquery` SDK and
+the Discovery document define) for **metadata, streaming inserts, and a limited SQL subset**:
+datasets, tables with schemas, `tabledata.insertAll`, `tabledata.list`, and query jobs. A real
+GoogleSQL engine (Phase 2) and the Storage Read/Write gRPC API (Phase 3) are out of scope.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_BIGQUERY_ENABLED` | `true` | Enable/disable BigQuery |
+
+## Endpoint
+
+BigQuery has **no `*_EMULATOR_HOST` convention in the Java SDK** — point the client at floci-gcp
+with `setHost` and disable credentials:
+
+```java
+BigQuery bigquery = BigQueryOptions.newBuilder()
+    .setHost("http://localhost:4588")
+    .setProjectId("floci-local")
+    .setCredentials(NoCredentials.getInstance())
+    .build().getService();
+```
+
+REST paths live under `/bigquery/v2/projects/{project}/...`.
+
+## Scope
+
+- **Datasets**: insert, get, list, patch/update, delete (`deleteContents` honored; deleting a
+  non-empty dataset without it → 400 `resourceInUse`). Duplicate create → 409 `duplicate`.
+- **Tables**: insert, get, list, patch/update, delete. Schemas accept standard or legacy type
+  names and are normalized to legacy names (`INT64`→`INTEGER`, `FLOAT64`→`FLOAT`, `BOOL`→`BOOLEAN`,
+  `STRUCT`→`RECORD`) with `NULLABLE` as the default mode, matching SDK round-trips.
+- **tabledata.insertAll**: schema-validated per row — HTTP 200 always, failures reported via
+  `insertErrors` (unknown fields honor `ignoreUnknownValues`; `skipInvalidRows=false` inserts
+  nothing and marks valid rows `stopped`; missing `REQUIRED` fields and uncoercible values are
+  rejected with reason `invalid`).
+- **tabledata.list**: `{f:[{v:"..."}]}` row encoding (scalars as strings, `REPEATED` as arrays of
+  `{v}`, `RECORD` as nested `{f:[...]}`), `maxResults`/`pageToken`/`startIndex` paging.
+  `maxResults=0` returns zero rows (the SDK's `Job.waitFor()` contract); a `pageToken` wins over
+  `startIndex` (the SDK sends both when auto-paging).
+- **Jobs / queries**: `jobs.query` (fast path, always answers `jobComplete=true` synchronously),
+  `jobs.insert` (QUERY only), `jobs.get`, `jobs.list`, `jobs.cancel`, `jobs.delete`,
+  `getQueryResults`. Query results are materialized into a hidden anonymous table
+  (`_floci_anon.anon_<jobId>`) referenced as the job's `configuration.query.destinationTable`,
+  which is how the SDK's `Job.getQueryResults()` reads rows.
+
+## Supported SQL
+
+```
+query     := SELECT selection FROM table_ref [WHERE predicate {AND predicate}] [LIMIT int] [;]
+selection := * | COUNT ( * ) | column {, column}
+table_ref := [project .] dataset . table | table        (backtick-quoted forms accepted)
+predicate := column = literal
+literal   := 'string' | "string" | integer | float | TRUE | FALSE
+```
+
+- An unqualified `table` requires the request's `defaultDataset`.
+- Typed equality per column: `INTEGER`/`FLOAT`/`BOOLEAN`/`STRING`; comparing with a mismatched
+  literal type → 400 `invalidQuery` ("No matching signature for operator =").
+- `COUNT(*)` returns a single `INTEGER` column named `f0_` and respects `WHERE`.
+- **Anything else** (JOIN, GROUP BY, ORDER BY, OR, `!=`, `<`, functions, aliases, subqueries,
+  DML/DDL, `= NULL`) fails fast with 400 and reason `invalidQuery` naming the construct — never
+  silent divergence.
+- Invalid SQL via `jobs.query` → HTTP 400; via `jobs.insert` → HTTP 200 `DONE` job carrying
+  `status.errorResult` (and `getQueryResults` on that job → HTTP 400), matching real job semantics.
+
+## Type support
+
+| Legacy type | Accepted `insertAll` values | Wire encoding |
+|---|---|---|
+| `STRING` | string, number, boolean | as-is |
+| `INTEGER` (`INT64`) | integral number, decimal string | decimal string |
+| `FLOAT` (`FLOAT64`) | number, decimal string | decimal string |
+| `BOOLEAN` (`BOOL`) | boolean, `"true"`/`"false"` | `"true"`/`"false"` |
+| `RECORD` (`STRUCT`) | object (validated against nested fields) | `{f:[...]}` |
+| any + `REPEATED` mode | array of the base type | array of `{v}` |
+| other (`TIMESTAMP`, `DATE`, ...) | stored/echoed textually | as-is |
+
+## Deviations from real BigQuery
+
+- No `insertId` de-duplication (real BigQuery is best-effort anyway).
+- Jobs always complete synchronously (`jobComplete=true`, state `DONE`) — no PENDING/RUNNING phase.
+- `useLegacySql` is ignored; the SQL subset above is the only dialect.
+- `WHERE` on `TIMESTAMP`/`RECORD`/`REPEATED` columns is not supported.
+- Cross-project table references are rejected.
+- Anonymous result tables persist until `jobs.delete`; they are hidden from dataset listings.
+- `dryRun` is not special-cased; Storage Read/Write API (gRPC) is not implemented (Phase 3).
+
+## Quick smoke (curl)
+
+```bash
+B=http://localhost:4588/bigquery/v2/projects/demo
+curl -sX POST $B/datasets -H 'Content-Type: application/json' \
+  -d '{"datasetReference":{"datasetId":"ds1"}}'
+curl -sX POST $B/datasets/ds1/tables -H 'Content-Type: application/json' \
+  -d '{"tableReference":{"tableId":"t1"},"schema":{"fields":[{"name":"name","type":"STRING"},{"name":"age","type":"INT64"}]}}'
+curl -sX POST $B/datasets/ds1/tables/t1/insertAll -H 'Content-Type: application/json' \
+  -d '{"rows":[{"json":{"name":"ana","age":30}}]}'
+curl -sX POST $B/queries -H 'Content-Type: application/json' \
+  -d '{"query":"SELECT name FROM ds1.t1 WHERE age = 30"}'
+```

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -24,6 +24,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud Monitoring](cloud-monitoring.md) | gRPC + REST JSON | `google.monitoring.v3.MetricService`, `/v3/projects/{project}` |
 | [Service Usage](service-usage.md) | REST JSON | `/v1/projects/{project}/services` (+ minimal Resource Manager `/v1/projects/{projectId}`) |
 | [Firebase Auth](firebase-auth.md) | REST JSON | `/identitytoolkit.googleapis.com/v1/accounts:*`, `/securetoken.googleapis.com/v1/token` |
+| [BigQuery (Phase 1)](bigquery.md) | REST JSON | `/bigquery/v2/projects/{project}` |
 
 ## Single-Port Design
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,4 +87,5 @@ nav:
     - Cloud Monitoring: services/cloud-monitoring.md
     - Service Usage: services/service-usage.md
     - Firebase Auth: services/firebase-auth.md
+    - BigQuery: services/bigquery.md
   - Contributing: contributing.md

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -112,6 +112,8 @@ public interface EmulatorConfig {
         ResourceManagerServiceConfig resourcemanager();
 
         FirebaseAuthServiceConfig firebaseauth();
+
+        BigQueryServiceConfig bigquery();
     }
 
     interface ServiceUsageServiceConfig {
@@ -120,6 +122,11 @@ public interface EmulatorConfig {
     }
 
     interface FirebaseAuthServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface BigQueryServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/floci/gcp/core/common/GcpException.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpException.java
@@ -11,12 +11,19 @@ public class GcpException extends RuntimeException {
     private final int httpStatus;
     private final String gcpStatus;
     private final Status.Code grpcCode;
+    private final String reason;
 
     private GcpException(int httpStatus, String gcpStatus, Status.Code grpcCode, String message) {
+        this(httpStatus, gcpStatus, grpcCode, message, null);
+    }
+
+    private GcpException(int httpStatus, String gcpStatus, Status.Code grpcCode, String message,
+                         String reason) {
         super(message);
         this.httpStatus = httpStatus;
         this.gcpStatus = gcpStatus;
         this.grpcCode = grpcCode;
+        this.reason = reason;
     }
 
     public int getHttpStatus() {
@@ -29,6 +36,15 @@ public class GcpException extends RuntimeException {
 
     public Status.Code getGrpcCode() {
         return grpcCode;
+    }
+
+    /** Legacy Google JSON API {@code errors[].reason} override; null derives it from the status. */
+    public String getReason() {
+        return reason;
+    }
+
+    public GcpException withReason(String reason) {
+        return new GcpException(httpStatus, gcpStatus, grpcCode, getMessage(), reason);
     }
 
     public static GcpException notFound(String message) {

--- a/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
@@ -23,10 +23,12 @@ public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
 
     @Override
     public Response toResponse(GcpException ex) {
+        String reason = ex.getReason() != null ? ex.getReason() : reasonFor(ex.getGcpStatus());
         return Response.status(ex.getHttpStatus())
                 .type(MediaType.APPLICATION_JSON)
-                .entity(new ErrorWrapper(
-                        ErrorDetail.of(ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus())))
+                .entity(new ErrorWrapper(new ErrorDetail(
+                        ex.getHttpStatus(), ex.getMessage(), ex.getGcpStatus(),
+                        List.of(new ErrorItem(ex.getMessage(), "global", reason)))))
                 .build();
     }
 

--- a/src/main/java/io/floci/gcp/services/bigquery/BigQueryController.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/BigQueryController.java
@@ -1,0 +1,452 @@
+package io.floci.gcp.services.bigquery;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.services.bigquery.model.Dataset;
+import io.floci.gcp.services.bigquery.model.ErrorProto;
+import io.floci.gcp.services.bigquery.model.Job;
+import io.floci.gcp.services.bigquery.model.JobReference;
+import io.floci.gcp.services.bigquery.model.JobStatus;
+import io.floci.gcp.services.bigquery.model.QueryResponse;
+import io.floci.gcp.services.bigquery.model.StoredJob;
+import io.floci.gcp.services.bigquery.model.Table;
+import io.floci.gcp.services.bigquery.model.TableRow;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * BigQuery REST (Discovery) control plane, served under {@code /bigquery/v2/projects}.
+ * Mirrors the GCS REST controller pattern: thin methods delegating to {@link BigQueryService}.
+ */
+@ApplicationScoped
+@Path("/bigquery/v2/projects")
+@Produces(MediaType.APPLICATION_JSON)
+public class BigQueryController {
+
+    private final BigQueryService service;
+
+    @Inject
+    public BigQueryController(BigQueryService service) {
+        this.service = service;
+    }
+
+    // ── Datasets ─────────────────────────────────────────────────────────────────
+
+    @POST
+    @Path("/{projectId}/datasets")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response insertDataset(@PathParam("projectId") String projectId, Dataset body) {
+        return Response.ok(service.createDataset(projectId, body != null ? body : new Dataset())).build();
+    }
+
+    @GET
+    @Path("/{projectId}/datasets")
+    public Response listDatasets(@PathParam("projectId") String projectId,
+            @QueryParam("maxResults") @DefaultValue("0") int maxResults,
+            @QueryParam("pageToken") String pageToken) {
+        List<Dataset> all = service.listDatasets(projectId);
+        PageToken.Page<Dataset> page = PageToken.paginate(all, maxResults, pageToken);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("kind", "bigquery#datasetList");
+        if (!page.items().isEmpty()) {
+            resp.put("datasets", page.items());
+        }
+        if (page.nextPageToken() != null) {
+            resp.put("nextPageToken", page.nextPageToken());
+        }
+        return Response.ok(resp).build();
+    }
+
+    @GET
+    @Path("/{projectId}/datasets/{datasetId}")
+    public Response getDataset(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId) {
+        return Response.ok(service.getDataset(projectId, datasetId)).build();
+    }
+
+    @PATCH
+    @Path("/{projectId}/datasets/{datasetId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response patchDataset(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, Dataset body) {
+        return Response.ok(service.patchDataset(projectId, datasetId, body != null ? body : new Dataset())).build();
+    }
+
+    @PUT
+    @Path("/{projectId}/datasets/{datasetId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateDataset(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, Dataset body) {
+        return Response.ok(service.patchDataset(projectId, datasetId, body != null ? body : new Dataset())).build();
+    }
+
+    @POST
+    @Path("/{projectId}/datasets/{datasetId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response postDatasetMethodOverride(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId,
+            @HeaderParam("X-HTTP-Method-Override") String methodOverride, Dataset body) {
+        if ("PATCH".equalsIgnoreCase(methodOverride)) {
+            return Response.ok(service.patchDataset(projectId, datasetId, body != null ? body : new Dataset())).build();
+        }
+        throw GcpException.invalidArgument("unsupported method override: " + methodOverride);
+    }
+
+    @DELETE
+    @Path("/{projectId}/datasets/{datasetId}")
+    public Response deleteDataset(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId,
+            @QueryParam("deleteContents") @DefaultValue("false") boolean deleteContents) {
+        service.deleteDataset(projectId, datasetId, deleteContents);
+        return Response.noContent().build();
+    }
+
+    // ── Tables ───────────────────────────────────────────────────────────────────
+
+    @POST
+    @Path("/{projectId}/datasets/{datasetId}/tables")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response insertTable(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, Table body) {
+        return Response.ok(service.createTable(projectId, datasetId, body != null ? body : new Table())).build();
+    }
+
+    @GET
+    @Path("/{projectId}/datasets/{datasetId}/tables")
+    public Response listTables(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId,
+            @QueryParam("maxResults") @DefaultValue("0") int maxResults,
+            @QueryParam("pageToken") String pageToken) {
+        List<Table> all = service.listTables(projectId, datasetId);
+        PageToken.Page<Table> page = PageToken.paginate(all, maxResults, pageToken);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("kind", "bigquery#tableList");
+        if (!page.items().isEmpty()) {
+            resp.put("tables", page.items());
+        }
+        resp.put("totalItems", all.size());
+        if (page.nextPageToken() != null) {
+            resp.put("nextPageToken", page.nextPageToken());
+        }
+        return Response.ok(resp).build();
+    }
+
+    @GET
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}")
+    public Response getTable(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId) {
+        return Response.ok(service.getTable(projectId, datasetId, tableId)).build();
+    }
+
+    @PATCH
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response patchTable(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId, Table body) {
+        return Response.ok(service.patchTable(projectId, datasetId, tableId, body != null ? body : new Table())).build();
+    }
+
+    @PUT
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateTable(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId, Table body) {
+        return Response.ok(service.patchTable(projectId, datasetId, tableId, body != null ? body : new Table())).build();
+    }
+
+    @POST
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response postTableMethodOverride(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId,
+            @HeaderParam("X-HTTP-Method-Override") String methodOverride, Table body) {
+        if ("PATCH".equalsIgnoreCase(methodOverride)) {
+            return Response.ok(service.patchTable(projectId, datasetId, tableId, body != null ? body : new Table())).build();
+        }
+        throw GcpException.invalidArgument("unsupported method override: " + methodOverride);
+    }
+
+    @DELETE
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}")
+    public Response deleteTable(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId) {
+        service.deleteTable(projectId, datasetId, tableId);
+        return Response.noContent().build();
+    }
+
+    // ── Table data ───────────────────────────────────────────────────────────────
+
+    @POST
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}/insertAll")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response insertAll(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId,
+            Map<String, Object> body) {
+        boolean skipInvalidRows = boolValue(body, "skipInvalidRows");
+        boolean ignoreUnknownValues = boolValue(body, "ignoreUnknownValues");
+        List<Map<String, Object>> insertErrors = service.insertAll(projectId, datasetId, tableId,
+                extractInsertRows(body), skipInvalidRows, ignoreUnknownValues);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("kind", "bigquery#tableDataInsertAllResponse");
+        if (!insertErrors.isEmpty()) {
+            resp.put("insertErrors", insertErrors);
+        }
+        return Response.ok(resp).build();
+    }
+
+    @GET
+    @Path("/{projectId}/datasets/{datasetId}/tables/{tableId}/data")
+    public Response listTableData(@PathParam("projectId") String projectId,
+            @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId,
+            @QueryParam("maxResults") Long maxResults,
+            @QueryParam("pageToken") String pageToken,
+            @QueryParam("startIndex") Long startIndex) {
+        BigQueryService.TableData data = service.listTableData(projectId, datasetId, tableId);
+        PageToken.Page<TableRow> page = pageRows(data.rows(), maxResults, pageToken, startIndex);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("kind", "bigquery#tableDataList");
+        resp.put("totalRows", String.valueOf(data.rows().size()));
+        if (!page.items().isEmpty()) {
+            resp.put("rows", page.items());
+        }
+        if (page.nextPageToken() != null) {
+            resp.put("pageToken", page.nextPageToken());
+        }
+        return Response.ok(resp).build();
+    }
+
+    // ── Queries / Jobs ─────────────────────────────────────────────────────────────
+
+    @POST
+    @Path("/{projectId}/queries")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response query(@PathParam("projectId") String projectId, Map<String, Object> body) {
+        String sql = body != null ? (String) body.get("query") : null;
+        String location = body != null ? (String) body.get("location") : null;
+        Map<String, Object> defaultDataset = body != null ? asMap(body.get("defaultDataset")) : null;
+        String defaultDatasetId = defaultDataset != null ? (String) defaultDataset.get("datasetId") : null;
+
+        StoredJob job = service.query(projectId, location, null, sql, defaultDatasetId);
+        Long maxResults = body != null && body.get("maxResults") instanceof Number n ? n.longValue() : null;
+        QueryResponse resp = buildQueryResponse(job, maxResults, null, null);
+        resp.setKind("bigquery#queryResponse");
+        return Response.ok(resp).build();
+    }
+
+    @GET
+    @Path("/{projectId}/queries/{jobId}")
+    public Response getQueryResults(@PathParam("projectId") String projectId,
+            @PathParam("jobId") String jobId,
+            @QueryParam("maxResults") Long maxResults,
+            @QueryParam("pageToken") String pageToken,
+            @QueryParam("startIndex") Long startIndex) {
+        StoredJob job = service.getJob(projectId, jobId);
+        QueryResponse resp = buildQueryResponse(job, maxResults, pageToken, startIndex);
+        resp.setKind("bigquery#getQueryResultsResponse");
+        return Response.ok(resp).build();
+    }
+
+    @POST
+    @Path("/{projectId}/jobs")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response insertJob(@PathParam("projectId") String projectId, Job body) {
+        Map<String, Object> configuration = body != null ? body.getConfiguration() : null;
+        Map<String, Object> queryConfig = configuration != null ? asMap(configuration.get("query")) : null;
+        if (queryConfig == null || queryConfig.get("query") == null) {
+            throw GcpException.invalidArgument(
+                    "Only QUERY jobs are supported in the Phase 1 BigQuery emulator");
+        }
+        String location = body.getJobReference() != null ? body.getJobReference().getLocation() : null;
+        String jobId = body.getJobReference() != null ? body.getJobReference().getJobId() : null;
+        String sql = (String) queryConfig.get("query");
+        Map<String, Object> defaultDataset = asMap(queryConfig.get("defaultDataset"));
+        String defaultDatasetId = defaultDataset != null ? (String) defaultDataset.get("datasetId") : null;
+
+        StoredJob job;
+        try {
+            job = service.query(projectId, location, jobId, sql, defaultDatasetId);
+        } catch (GcpException e) {
+            if (e.getHttpStatus() == 409) {
+                throw e;
+            }
+            // jobs.insert reports SQL failures inside the job status, not as an HTTP error.
+            job = service.failedJob(projectId, location, jobId, sql, e);
+        }
+        return Response.ok(buildJob(job)).build();
+    }
+
+    @GET
+    @Path("/{projectId}/jobs/{jobId}")
+    public Response getJob(@PathParam("projectId") String projectId, @PathParam("jobId") String jobId) {
+        return Response.ok(buildJob(service.getJob(projectId, jobId))).build();
+    }
+
+    @GET
+    @Path("/{projectId}/jobs")
+    public Response listJobs(@PathParam("projectId") String projectId,
+            @QueryParam("maxResults") @DefaultValue("0") int maxResults,
+            @QueryParam("pageToken") String pageToken) {
+        List<StoredJob> all = service.listJobs(projectId);
+        PageToken.Page<StoredJob> page = PageToken.paginate(all, maxResults, pageToken);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("kind", "bigquery#jobList");
+        if (!page.items().isEmpty()) {
+            resp.put("jobs", page.items().stream().map(BigQueryController::buildJob).toList());
+        }
+        if (page.nextPageToken() != null) {
+            resp.put("nextPageToken", page.nextPageToken());
+        }
+        return Response.ok(resp).build();
+    }
+
+    @POST
+    @Path("/{projectId}/jobs/{jobId}/cancel")
+    public Response cancelJob(@PathParam("projectId") String projectId, @PathParam("jobId") String jobId) {
+        // Jobs complete synchronously, so cancel just echoes the (already DONE) job.
+        StoredJob job = service.getJob(projectId, jobId);
+        return Response.ok(Map.of(
+                "kind", "bigquery#jobCancelResponse",
+                "job", buildJob(job))).build();
+    }
+
+    @DELETE
+    @Path("/{projectId}/jobs/{jobId}/delete")
+    public Response deleteJob(@PathParam("projectId") String projectId, @PathParam("jobId") String jobId) {
+        service.deleteJob(projectId, jobId);
+        return Response.noContent().build();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private QueryResponse buildQueryResponse(StoredJob job, Long maxResults, String pageToken,
+            Long startIndex) {
+        QueryResponse resp = new QueryResponse();
+        resp.setJobReference(new JobReference(job.getProjectId(), job.getJobId(), job.getLocation()));
+        resp.setJobComplete(true);
+        resp.setCacheHit(false);
+        resp.setTotalBytesProcessed("0");
+
+        BigQueryService.TableData data = service.queryResults(job.getProjectId(), job);
+        resp.setSchema(data.schema());
+        resp.setTotalRows(String.valueOf(data.rows().size()));
+        PageToken.Page<TableRow> page = pageRows(data.rows(), maxResults, pageToken, startIndex);
+        if (!page.items().isEmpty()) {
+            resp.setRows(page.items());
+        }
+        resp.setPageToken(page.nextPageToken());
+        return resp;
+    }
+
+    private static Job buildJob(StoredJob sj) {
+        Job job = new Job();
+        job.setId(sj.getProjectId() + ":" + sj.getLocation() + "." + sj.getJobId());
+        job.setJobReference(new JobReference(sj.getProjectId(), sj.getJobId(), sj.getLocation()));
+
+        Map<String, Object> queryConfig = new LinkedHashMap<>();
+        queryConfig.put("query", sj.getQuery());
+        queryConfig.put("useLegacySql", false);
+        if (sj.getDestinationTableId() != null) {
+            queryConfig.put("destinationTable", Map.of(
+                    "projectId", sj.getProjectId(),
+                    "datasetId", sj.getDestinationDatasetId(),
+                    "tableId", sj.getDestinationTableId()));
+        }
+        Map<String, Object> configuration = new LinkedHashMap<>();
+        configuration.put("jobType", "QUERY");
+        configuration.put("query", queryConfig);
+        job.setConfiguration(configuration);
+
+        JobStatus status = new JobStatus();
+        status.setState(sj.getState());
+        if (sj.failed()) {
+            ErrorProto error = new ErrorProto(sj.getErrorReason(), "query", sj.getErrorMessage());
+            status.setErrorResult(error);
+            status.setErrors(List.of(error));
+        }
+        job.setStatus(status);
+
+        if (sj.getCreationTime() != null) {
+            Map<String, Object> statistics = new LinkedHashMap<>();
+            statistics.put("creationTime", sj.getCreationTime());
+            statistics.put("startTime", sj.getCreationTime());
+            statistics.put("endTime", sj.getCreationTime());
+            statistics.put("query", Map.of("totalBytesProcessed", "0", "statementType", "SELECT"));
+            job.setStatistics(statistics);
+        }
+        return job;
+    }
+
+    /**
+     * Row paging for tabledata.list / query results: {@code maxResults} is nullable —
+     * {@code 0} means zero rows (the SDK's {@code Job.waitFor} sends 0), absent means all.
+     * A non-empty {@code pageToken} wins over {@code startIndex}: the SDK's auto-paging
+     * sends the token together with a default {@code startIndex=0}.
+     */
+    private static PageToken.Page<TableRow> pageRows(List<TableRow> all, Long maxResults,
+            String pageToken, Long startIndex) {
+        if (maxResults != null && maxResults == 0) {
+            return new PageToken.Page<>(List.of(), null);
+        }
+        int offset = pageToken != null && !pageToken.isBlank()
+                ? PageToken.decode(pageToken)
+                : startIndex != null ? (int) Math.min(startIndex, Integer.MAX_VALUE) : 0;
+        if (offset < 0 || offset >= all.size()) {
+            return new PageToken.Page<>(List.of(), null);
+        }
+        int size = maxResults != null && maxResults > 0
+                ? (int) Math.min(maxResults, Integer.MAX_VALUE) : all.size();
+        int end = Math.min(offset + size, all.size());
+        List<TableRow> items = List.copyOf(all.subList(offset, end));
+        String next = end < all.size() ? PageToken.encode(end) : null;
+        return new PageToken.Page<>(items, next);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<BigQueryService.InsertRow> extractInsertRows(Map<String, Object> body) {
+        List<BigQueryService.InsertRow> result = new ArrayList<>();
+        if (body == null) {
+            return result;
+        }
+        Object rows = body.get("rows");
+        if (!(rows instanceof List<?> list)) {
+            return result;
+        }
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i) instanceof Map<?, ?> rowMap) {
+                Object json = ((Map<String, Object>) rowMap).get("json");
+                if (json instanceof Map) {
+                    result.add(new BigQueryService.InsertRow(i, (Map<String, Object>) json));
+                }
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object o) {
+        return o instanceof Map ? (Map<String, Object>) o : null;
+    }
+
+    private static boolean boolValue(Map<String, Object> body, String key) {
+        return body != null && Boolean.TRUE.equals(body.get(key));
+    }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/BigQueryController.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/BigQueryController.java
@@ -342,6 +342,12 @@ public class BigQueryController {
         QueryResponse resp = new QueryResponse();
         resp.setJobReference(new JobReference(job.getProjectId(), job.getJobId(), job.getLocation()));
         resp.setJobComplete(true);
+        if (job.failed()) {
+            // Failed jobs surface as a completed 200 response with embedded errors; the
+            // Java SDK's Job.getQueryResults() then reads the failure from job status.
+            resp.setErrors(List.of(new ErrorProto(job.getErrorReason(), null, job.getErrorMessage())));
+            return resp;
+        }
         resp.setCacheHit(false);
         resp.setTotalBytesProcessed("0");
 

--- a/src/main/java/io/floci/gcp/services/bigquery/BigQueryController.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/BigQueryController.java
@@ -96,7 +96,7 @@ public class BigQueryController {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response updateDataset(@PathParam("projectId") String projectId,
             @PathParam("datasetId") String datasetId, Dataset body) {
-        return Response.ok(service.patchDataset(projectId, datasetId, body != null ? body : new Dataset())).build();
+        return Response.ok(service.updateDataset(projectId, datasetId, body != null ? body : new Dataset())).build();
     }
 
     @POST
@@ -170,7 +170,7 @@ public class BigQueryController {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response updateTable(@PathParam("projectId") String projectId,
             @PathParam("datasetId") String datasetId, @PathParam("tableId") String tableId, Table body) {
-        return Response.ok(service.patchTable(projectId, datasetId, tableId, body != null ? body : new Table())).build();
+        return Response.ok(service.updateTable(projectId, datasetId, tableId, body != null ? body : new Table())).build();
     }
 
     @POST
@@ -431,12 +431,14 @@ public class BigQueryController {
             return result;
         }
         for (int i = 0; i < list.size(); i++) {
-            if (list.get(i) instanceof Map<?, ?> rowMap) {
-                Object json = ((Map<String, Object>) rowMap).get("json");
-                if (json instanceof Map) {
-                    result.add(new BigQueryService.InsertRow(i, (Map<String, Object>) json));
-                }
+            Object json = list.get(i) instanceof Map<?, ?> rowMap
+                    ? ((Map<String, Object>) rowMap).get("json") : null;
+            if (!(json instanceof Map)) {
+                throw GcpException.invalidArgument(
+                        "Insert entry at index " + i + " is missing the required json row payload")
+                        .withReason("invalid");
             }
+            result.add(new BigQueryService.InsertRow(i, (Map<String, Object>) json));
         }
         return result;
     }

--- a/src/main/java/io/floci/gcp/services/bigquery/BigQueryService.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/BigQueryService.java
@@ -1,0 +1,416 @@
+package io.floci.gcp.services.bigquery;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.bigquery.model.Dataset;
+import io.floci.gcp.services.bigquery.model.DatasetReference;
+import io.floci.gcp.services.bigquery.model.ErrorProto;
+import io.floci.gcp.services.bigquery.model.StoredJob;
+import io.floci.gcp.services.bigquery.model.StoredTableData;
+import io.floci.gcp.services.bigquery.model.Table;
+import io.floci.gcp.services.bigquery.model.TableReference;
+import io.floci.gcp.services.bigquery.model.TableRow;
+import io.floci.gcp.services.bigquery.model.TableSchema;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * BigQuery Phase 1: datasets/tables metadata, streaming inserts ({@code insertAll}),
+ * row reads, and a trivial {@code SELECT *} / {@code COUNT(*)} query path. Storage is
+ * project-namespaced via {@link StorageFactory#create}.
+ */
+@ApplicationScoped
+public class BigQueryService {
+
+    private static final Logger LOG = Logger.getLogger(BigQueryService.class);
+
+    private final StorageBackend<String, Dataset> datasetStore;
+    private final StorageBackend<String, Table> tableStore;
+    private final StorageBackend<String, StoredTableData> dataStore;
+    private final StorageBackend<String, StoredJob> jobStore;
+
+    private final ServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+
+    @Inject
+    public BigQueryService(ServiceRegistry serviceRegistry, EmulatorConfig config,
+            StorageFactory storageFactory) {
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+        this.datasetStore = storageFactory.create("bigquery-datasets", "bigquery-datasets.json",
+                new TypeReference<Map<String, Dataset>>() {});
+        this.tableStore = storageFactory.create("bigquery-tables", "bigquery-tables.json",
+                new TypeReference<Map<String, Table>>() {});
+        this.dataStore = storageFactory.create("bigquery-tabledata", "bigquery-tabledata.json",
+                new TypeReference<Map<String, StoredTableData>>() {});
+        this.jobStore = storageFactory.create("bigquery-jobs", "bigquery-jobs.json",
+                new TypeReference<Map<String, StoredJob>>() {});
+    }
+
+    BigQueryService(StorageBackend<String, Dataset> datasetStore,
+            StorageBackend<String, Table> tableStore,
+            StorageBackend<String, StoredTableData> dataStore,
+            StorageBackend<String, StoredJob> jobStore) {
+        this.datasetStore = datasetStore;
+        this.tableStore = tableStore;
+        this.dataStore = dataStore;
+        this.jobStore = jobStore;
+        this.serviceRegistry = null;
+        this.config = null;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        serviceRegistry.register(ServiceDescriptor.builder("bigquery")
+                .enabled(config.services().bigquery().enabled())
+                .storageKey("bigquery")
+                .protocol(ServiceProtocol.REST)
+                .resourceClasses(BigQueryController.class)
+                .build());
+    }
+
+    // ── Datasets ─────────────────────────────────────────────────────────────────
+
+    public Dataset createDataset(String projectId, Dataset body) {
+        String datasetId = body.getDatasetReference() != null
+                ? body.getDatasetReference().getDatasetId() : null;
+        if (datasetId == null || datasetId.isBlank()) {
+            throw GcpException.invalidArgument("datasetReference.datasetId is required");
+        }
+        if (datasetStore.get(datasetId).isPresent()) {
+            throw GcpException.alreadyExists("Already Exists: Dataset " + projectId + ":" + datasetId)
+                    .withReason("duplicate");
+        }
+        String now = nowMillis();
+        body.setDatasetReference(new DatasetReference(projectId, datasetId));
+        body.setId(projectId + ":" + datasetId);
+        body.setEtag(etag());
+        body.setCreationTime(now);
+        body.setLastModifiedTime(now);
+        datasetStore.put(datasetId, body);
+        LOG.debugf("createDataset project=%s dataset=%s", projectId, datasetId);
+        return body;
+    }
+
+    public Dataset getDataset(String projectId, String datasetId) {
+        return datasetStore.get(datasetId)
+                .orElseThrow(() -> GcpException.notFound("Not found: Dataset " + projectId + ":" + datasetId));
+    }
+
+    public List<Dataset> listDatasets(String projectId) {
+        return datasetStore.scan(k -> true);
+    }
+
+    public Dataset patchDataset(String projectId, String datasetId, Dataset patch) {
+        Dataset existing = getDataset(projectId, datasetId);
+        if (patch.getFriendlyName() != null) {
+            existing.setFriendlyName(patch.getFriendlyName());
+        }
+        if (patch.getDescription() != null) {
+            existing.setDescription(patch.getDescription());
+        }
+        if (patch.getLabels() != null) {
+            existing.setLabels(patch.getLabels());
+        }
+        existing.setLastModifiedTime(nowMillis());
+        existing.setEtag(etag());
+        datasetStore.put(datasetId, existing);
+        return existing;
+    }
+
+    public void deleteDataset(String projectId, String datasetId, boolean deleteContents) {
+        getDataset(projectId, datasetId);
+        List<Table> tables = listTables(projectId, datasetId);
+        if (!tables.isEmpty() && !deleteContents) {
+            throw GcpException.invalidArgument(
+                    "Dataset " + projectId + ":" + datasetId + " is still in use")
+                    .withReason("resourceInUse");
+        }
+        for (Table t : tables) {
+            String tableId = t.getTableReference().getTableId();
+            tableStore.delete(tableKey(datasetId, tableId));
+            dataStore.delete(tableKey(datasetId, tableId));
+        }
+        datasetStore.delete(datasetId);
+        LOG.debugf("deleteDataset project=%s dataset=%s deleteContents=%s", projectId, datasetId, deleteContents);
+    }
+
+    // ── Tables ───────────────────────────────────────────────────────────────────
+
+    public Table createTable(String projectId, String datasetId, Table body) {
+        getDataset(projectId, datasetId);
+        String tableId = body.getTableReference() != null
+                ? body.getTableReference().getTableId() : null;
+        if (tableId == null || tableId.isBlank()) {
+            throw GcpException.invalidArgument("tableReference.tableId is required");
+        }
+        String key = tableKey(datasetId, tableId);
+        if (tableStore.get(key).isPresent()) {
+            throw GcpException.alreadyExists(
+                    "Already Exists: Table " + projectId + ":" + datasetId + "." + tableId)
+                    .withReason("duplicate");
+        }
+        String now = nowMillis();
+        body.setSchema(RowCodec.normalizeSchema(body.getSchema()));
+        body.setTableReference(new TableReference(projectId, datasetId, tableId));
+        body.setId(projectId + ":" + datasetId + "." + tableId);
+        body.setType(body.getType() != null ? body.getType() : "TABLE");
+        body.setEtag(etag());
+        body.setCreationTime(now);
+        body.setLastModifiedTime(now);
+        body.setNumRows("0");
+        tableStore.put(key, body);
+        LOG.debugf("createTable project=%s dataset=%s table=%s", projectId, datasetId, tableId);
+        return body;
+    }
+
+    public Table getTable(String projectId, String datasetId, String tableId) {
+        return tableStore.get(tableKey(datasetId, tableId))
+                .orElseThrow(() -> GcpException.notFound(
+                        "Not found: Table " + projectId + ":" + datasetId + "." + tableId));
+    }
+
+    public List<Table> listTables(String projectId, String datasetId) {
+        String prefix = datasetId + "/";
+        return tableStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public Table patchTable(String projectId, String datasetId, String tableId, Table patch) {
+        Table existing = getTable(projectId, datasetId, tableId);
+        if (patch.getFriendlyName() != null) {
+            existing.setFriendlyName(patch.getFriendlyName());
+        }
+        if (patch.getDescription() != null) {
+            existing.setDescription(patch.getDescription());
+        }
+        if (patch.getSchema() != null) {
+            existing.setSchema(RowCodec.normalizeSchema(patch.getSchema()));
+        }
+        if (patch.getLabels() != null) {
+            existing.setLabels(patch.getLabels());
+        }
+        existing.setLastModifiedTime(nowMillis());
+        existing.setEtag(etag());
+        tableStore.put(tableKey(datasetId, tableId), existing);
+        return existing;
+    }
+
+    public void deleteTable(String projectId, String datasetId, String tableId) {
+        getTable(projectId, datasetId, tableId);
+        tableStore.delete(tableKey(datasetId, tableId));
+        dataStore.delete(tableKey(datasetId, tableId));
+        LOG.debugf("deleteTable project=%s dataset=%s table=%s", projectId, datasetId, tableId);
+    }
+
+    // ── Table data ───────────────────────────────────────────────────────────────
+
+    /** One {@code insertAll} row: the JSON payload plus its request index. */
+    public record InsertRow(int index, Map<String, Object> json) {}
+
+    /**
+     * Validates and appends rows from {@code insertAll}. Returns the per-row insert
+     * errors (empty = all accepted); the HTTP response is 200 either way.
+     */
+    public List<Map<String, Object>> insertAll(String projectId, String datasetId, String tableId,
+            List<InsertRow> rows, boolean skipInvalidRows, boolean ignoreUnknownValues) {
+        Table table = getTable(projectId, datasetId, tableId);
+        String key = tableKey(datasetId, tableId);
+
+        List<Map<String, Object>> insertErrors = new ArrayList<>();
+        List<Map<String, Object>> accepted = new ArrayList<>();
+        List<Integer> acceptedIndexes = new ArrayList<>();
+        for (InsertRow row : rows) {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            List<ErrorProto> rowErrors = RowCodec.normalizeRow(
+                    table.getSchema(), row.json(), ignoreUnknownValues, normalized);
+            if (rowErrors.isEmpty()) {
+                accepted.add(normalized);
+                acceptedIndexes.add(row.index());
+            } else {
+                insertErrors.add(Map.of("index", row.index(), "errors", rowErrors));
+            }
+        }
+
+        if (!insertErrors.isEmpty() && !skipInvalidRows) {
+            // Real BigQuery inserts nothing and marks the valid rows as "stopped".
+            for (Integer index : acceptedIndexes) {
+                insertErrors.add(Map.of("index", index,
+                        "errors", List.of(new ErrorProto("stopped", null, null))));
+            }
+            return insertErrors;
+        }
+
+        if (!accepted.isEmpty()) {
+            StoredTableData data = dataStore.get(key).orElseGet(StoredTableData::new);
+            data.getRows().addAll(accepted);
+            dataStore.put(key, data);
+            table.setNumRows(String.valueOf(data.getRows().size()));
+            table.setLastModifiedTime(nowMillis());
+            tableStore.put(key, table);
+        }
+        LOG.debugf("insertAll project=%s dataset=%s table=%s accepted=%d rejected=%d",
+                projectId, datasetId, tableId, accepted.size(), insertErrors.size());
+        return insertErrors;
+    }
+
+    /** Encoded rows plus totals for {@code tabledata.list}. */
+    public record TableData(TableSchema schema, List<TableRow> rows) {}
+
+    public TableData listTableData(String projectId, String datasetId, String tableId) {
+        Table table = getTable(projectId, datasetId, tableId);
+        StoredTableData data = dataStore.get(tableKey(datasetId, tableId)).orElseGet(StoredTableData::new);
+        return new TableData(table.getSchema(), RowCodec.encodeRows(table.getSchema(), data.getRows()));
+    }
+
+    // ── Query ────────────────────────────────────────────────────────────────────
+
+    /** Hidden dataset holding materialized query results; never listed, has no dataset record. */
+    static final String ANON_DATASET = "_floci_anon";
+
+    /**
+     * Parses and executes the SQL subset, materializing results into a hidden anonymous
+     * table referenced as the job's {@code configuration.query.destinationTable} (the SDK's
+     * {@code Job.getQueryResults()} reads rows from there via {@code tabledata.list}).
+     * SQL errors propagate as {@link GcpException} — {@code jobs.query} maps them to HTTP
+     * errors while {@code jobs.insert} converts them into a DONE job with an error status.
+     */
+    public StoredJob query(String projectId, String location, String jobId,
+            String sql, String defaultDatasetId) {
+        QueryEngine.ParsedQuery parsed = QueryEngine.parse(sql);
+
+        QueryEngine.TableRef ref = parsed.table();
+        if (ref.projectId() != null && !ref.projectId().equals(projectId)) {
+            throw QueryEngine.invalidQuery(
+                    "Cross-project queries are not supported by the Phase 1 emulator: "
+                            + ref.projectId() + "." + ref.datasetId() + "." + ref.tableId());
+        }
+        String datasetId = ref.datasetId() != null ? ref.datasetId() : defaultDatasetId;
+        if (datasetId == null || datasetId.isBlank()) {
+            throw QueryEngine.invalidQuery("Table name \"" + ref.tableId()
+                    + "\" missing dataset while no default dataset is set in the request.");
+        }
+
+        Table table = getTable(projectId, datasetId, ref.tableId());
+        StoredTableData data = dataStore.get(tableKey(datasetId, ref.tableId()))
+                .orElseGet(StoredTableData::new);
+
+        QueryEngine.Result result = QueryEngine.evaluate(parsed, table.getSchema(), data.getRows());
+
+        StoredJob job = new StoredJob();
+        job.setJobId(jobId != null && !jobId.isBlank()
+                ? jobId : "job_" + UUID.randomUUID().toString().replace("-", ""));
+        if (jobStore.get(job.getJobId()).isPresent()) {
+            throw GcpException.alreadyExists("Already Exists: Job " + projectId + ":" + job.getJobId())
+                    .withReason("duplicate");
+        }
+        job.setProjectId(projectId);
+        job.setLocation(location != null && !location.isBlank() ? location : "US");
+        job.setQuery(sql);
+        job.setState("DONE");
+        job.setCreationTime(nowMillis());
+        job.setTotalRows(result.rows().size());
+        job.setDestinationDatasetId(ANON_DATASET);
+        job.setDestinationTableId("anon_" + job.getJobId());
+
+        materializeResult(projectId, job, result);
+        jobStore.put(job.getJobId(), job);
+        return job;
+    }
+
+    /** Persists a failed query job (used by {@code jobs.insert}, which must not throw). */
+    public StoredJob failedJob(String projectId, String location, String jobId,
+            String sql, GcpException cause) {
+        StoredJob job = new StoredJob();
+        job.setJobId(jobId != null && !jobId.isBlank()
+                ? jobId : "job_" + UUID.randomUUID().toString().replace("-", ""));
+        job.setProjectId(projectId);
+        job.setLocation(location != null && !location.isBlank() ? location : "US");
+        job.setQuery(sql);
+        job.setState("DONE");
+        job.setCreationTime(nowMillis());
+        job.setErrorReason(cause.getReason() != null ? cause.getReason() : "invalidQuery");
+        job.setErrorMessage(cause.getMessage());
+        jobStore.put(job.getJobId(), job);
+        return job;
+    }
+
+    private void materializeResult(String projectId, StoredJob job, QueryEngine.Result result) {
+        String key = tableKey(job.getDestinationDatasetId(), job.getDestinationTableId());
+        Table anon = new Table();
+        anon.setTableReference(new TableReference(projectId,
+                job.getDestinationDatasetId(), job.getDestinationTableId()));
+        anon.setId(projectId + ":" + job.getDestinationDatasetId() + "." + job.getDestinationTableId());
+        anon.setType("TABLE");
+        anon.setSchema(result.schema());
+        anon.setCreationTime(job.getCreationTime());
+        anon.setLastModifiedTime(job.getCreationTime());
+        anon.setNumRows(String.valueOf(result.rows().size()));
+        tableStore.put(key, anon);
+
+        StoredTableData rows = new StoredTableData();
+        rows.setRows(new ArrayList<>(result.rows()));
+        dataStore.put(key, rows);
+    }
+
+    public StoredJob getJob(String projectId, String jobId) {
+        return jobStore.get(jobId)
+                .orElseThrow(() -> GcpException.notFound("Not found: Job " + projectId + ":" + jobId));
+    }
+
+    public List<StoredJob> listJobs(String projectId) {
+        return jobStore.scan(k -> true).stream()
+                .sorted((a, b) -> nullSafe(b.getCreationTime()).compareTo(nullSafe(a.getCreationTime())))
+                .toList();
+    }
+
+    public void deleteJob(String projectId, String jobId) {
+        StoredJob job = getJob(projectId, jobId);
+        if (job.getDestinationTableId() != null) {
+            String key = tableKey(job.getDestinationDatasetId(), job.getDestinationTableId());
+            tableStore.delete(key);
+            dataStore.delete(key);
+        }
+        jobStore.delete(jobId);
+    }
+
+    /** Encoded result rows for {@code getQueryResults}, read from the job's anonymous table. */
+    public TableData queryResults(String projectId, StoredJob job) {
+        if (job.failed()) {
+            throw GcpException.invalidArgument(job.getErrorMessage()).withReason(job.getErrorReason());
+        }
+        return listTableData(projectId, job.getDestinationDatasetId(), job.getDestinationTableId());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private static String nullSafe(String value) {
+        return value != null ? value : "";
+    }
+
+    private static String tableKey(String datasetId, String tableId) {
+        return datasetId + "/" + tableId;
+    }
+
+    private static String nowMillis() {
+        return String.valueOf(Instant.now().toEpochMilli());
+    }
+
+    private static String etag() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/BigQueryService.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/BigQueryService.java
@@ -133,6 +133,18 @@ public class BigQueryService {
         return existing;
     }
 
+    /** datasets.update (PUT): full replacement — mutable fields absent from the body are cleared. */
+    public Dataset updateDataset(String projectId, String datasetId, Dataset update) {
+        Dataset existing = getDataset(projectId, datasetId);
+        existing.setFriendlyName(update.getFriendlyName());
+        existing.setDescription(update.getDescription());
+        existing.setLabels(update.getLabels());
+        existing.setLastModifiedTime(nowMillis());
+        existing.setEtag(etag());
+        datasetStore.put(datasetId, existing);
+        return existing;
+    }
+
     public void deleteDataset(String projectId, String datasetId, boolean deleteContents) {
         getDataset(projectId, datasetId);
         List<Table> tables = listTables(projectId, datasetId);
@@ -204,6 +216,19 @@ public class BigQueryService {
         if (patch.getLabels() != null) {
             existing.setLabels(patch.getLabels());
         }
+        existing.setLastModifiedTime(nowMillis());
+        existing.setEtag(etag());
+        tableStore.put(tableKey(datasetId, tableId), existing);
+        return existing;
+    }
+
+    /** tables.update (PUT): full replacement — mutable fields absent from the body are cleared. */
+    public Table updateTable(String projectId, String datasetId, String tableId, Table update) {
+        Table existing = getTable(projectId, datasetId, tableId);
+        existing.setFriendlyName(update.getFriendlyName());
+        existing.setDescription(update.getDescription());
+        existing.setSchema(update.getSchema() != null ? RowCodec.normalizeSchema(update.getSchema()) : null);
+        existing.setLabels(update.getLabels());
         existing.setLastModifiedTime(nowMillis());
         existing.setEtag(etag());
         tableStore.put(tableKey(datasetId, tableId), existing);

--- a/src/main/java/io/floci/gcp/services/bigquery/BigQueryService.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/BigQueryService.java
@@ -316,6 +316,9 @@ public class BigQueryService {
      */
     public StoredJob query(String projectId, String location, String jobId,
             String sql, String defaultDatasetId) {
+        // Reserve the ID before any parsing/lookup so a duplicate explicit jobId always
+        // 409s — even when the query would otherwise fail — matching failedJob's path.
+        String resolvedJobId = reserveJobId(projectId, jobId);
         QueryEngine.ParsedQuery parsed = QueryEngine.parse(sql);
 
         QueryEngine.TableRef ref = parsed.table();
@@ -337,12 +340,7 @@ public class BigQueryService {
         QueryEngine.Result result = QueryEngine.evaluate(parsed, table.getSchema(), data.getRows());
 
         StoredJob job = new StoredJob();
-        job.setJobId(jobId != null && !jobId.isBlank()
-                ? jobId : "job_" + UUID.randomUUID().toString().replace("-", ""));
-        if (jobStore.get(job.getJobId()).isPresent()) {
-            throw GcpException.alreadyExists("Already Exists: Job " + projectId + ":" + job.getJobId())
-                    .withReason("duplicate");
-        }
+        job.setJobId(resolvedJobId);
         job.setProjectId(projectId);
         job.setLocation(location != null && !location.isBlank() ? location : "US");
         job.setQuery(sql);
@@ -357,12 +355,12 @@ public class BigQueryService {
         return job;
     }
 
-    /** Persists a failed query job (used by {@code jobs.insert}, which must not throw). */
+    /** Persists a failed query job (used by {@code jobs.insert}, which must not throw for SQL errors). */
     public StoredJob failedJob(String projectId, String location, String jobId,
             String sql, GcpException cause) {
+        String resolvedJobId = reserveJobId(projectId, jobId);
         StoredJob job = new StoredJob();
-        job.setJobId(jobId != null && !jobId.isBlank()
-                ? jobId : "job_" + UUID.randomUUID().toString().replace("-", ""));
+        job.setJobId(resolvedJobId);
         job.setProjectId(projectId);
         job.setLocation(location != null && !location.isBlank() ? location : "US");
         job.setQuery(sql);
@@ -372,6 +370,18 @@ public class BigQueryService {
         job.setErrorMessage(cause.getMessage());
         jobStore.put(job.getJobId(), job);
         return job;
+    }
+
+    /** Resolves a job ID (generating one when blank) and rejects an already-used explicit ID with 409. */
+    private String reserveJobId(String projectId, String jobId) {
+        if (jobId == null || jobId.isBlank()) {
+            return "job_" + UUID.randomUUID().toString().replace("-", "");
+        }
+        if (jobStore.get(jobId).isPresent()) {
+            throw GcpException.alreadyExists("Already Exists: Job " + projectId + ":" + jobId)
+                    .withReason("duplicate");
+        }
+        return jobId;
     }
 
     private void materializeResult(String projectId, StoredJob job, QueryEngine.Result result) {

--- a/src/main/java/io/floci/gcp/services/bigquery/QueryEngine.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/QueryEngine.java
@@ -125,7 +125,9 @@ final class QueryEngine {
             countField.setMode("NULLABLE");
             Map<String, Object> countRow = new LinkedHashMap<>();
             countRow.put("f0_", (long) filtered.size());
-            return new Result(new TableSchema(List.of(countField)), List.of(countRow));
+            List<Map<String, Object>> countRows = query.limit() != null && query.limit() < 1
+                    ? List.of() : List.of(countRow);
+            return new Result(new TableSchema(List.of(countField)), countRows);
         }
 
         if (query.limit() != null && filtered.size() > query.limit()) {

--- a/src/main/java/io/floci/gcp/services/bigquery/QueryEngine.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/QueryEngine.java
@@ -1,0 +1,409 @@
+package io.floci.gcp.services.bigquery;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.services.bigquery.model.TableFieldSchema;
+import io.floci.gcp.services.bigquery.model.TableSchema;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hand-rolled parser/evaluator for the Phase 1 SQL subset:
+ * <pre>SELECT *|col[, col...]|COUNT(*) FROM [project.]dataset.table
+ *     [WHERE col = literal [AND ...]] [LIMIT n]</pre>
+ * Anything else surfaces as {@code INVALID_ARGUMENT} with reason {@code invalidQuery} —
+ * never silent divergence. A real GoogleSQL engine is Phase 2.
+ */
+final class QueryEngine {
+
+    private static final String GRAMMAR_HINT =
+            "The Phase 1 BigQuery emulator supports: SELECT *|columns|COUNT(*) FROM table "
+                    + "[WHERE column = literal [AND ...]] [LIMIT n]";
+
+    enum Kind { STAR, COUNT_STAR, COLUMNS }
+
+    record TableRef(String projectId, String datasetId, String tableId) {}
+
+    record Condition(String column, Object literal) {}
+
+    record ParsedQuery(Kind kind, List<String> columns, TableRef table,
+                       List<Condition> conditions, Integer limit) {}
+
+    record Result(TableSchema schema, List<Map<String, Object>> rows) {}
+
+    private QueryEngine() {}
+
+    // ── Parsing ──────────────────────────────────────────────────────────────
+
+    static ParsedQuery parse(String sql) {
+        if (sql == null || sql.isBlank()) {
+            throw invalidQuery("No query supplied");
+        }
+        Tokenizer tokens = new Tokenizer(sql);
+
+        tokens.expectKeyword("SELECT");
+
+        Kind kind;
+        List<String> columns = new ArrayList<>();
+        if (tokens.consumeSymbol('*')) {
+            kind = Kind.STAR;
+        } else if (tokens.consumeKeyword("COUNT")) {
+            tokens.expectSymbol('(');
+            tokens.expectSymbol('*');
+            tokens.expectSymbol(')');
+            kind = Kind.COUNT_STAR;
+        } else {
+            kind = Kind.COLUMNS;
+            columns.add(tokens.expectIdentifier("column name"));
+            while (tokens.consumeSymbol(',')) {
+                columns.add(tokens.expectIdentifier("column name"));
+            }
+        }
+
+        tokens.expectKeyword("FROM");
+        TableRef table = parseTableRef(tokens);
+
+        List<Condition> conditions = new ArrayList<>();
+        if (tokens.consumeKeyword("WHERE")) {
+            conditions.add(parseCondition(tokens));
+            while (tokens.consumeKeyword("AND")) {
+                conditions.add(parseCondition(tokens));
+            }
+        }
+
+        Integer limit = null;
+        if (tokens.consumeKeyword("LIMIT")) {
+            limit = tokens.expectIntegerLiteral();
+        }
+
+        tokens.consumeSymbol(';');
+        if (!tokens.atEnd()) {
+            throw invalidQuery("Unsupported SQL near \"" + tokens.remainder() + "\". " + GRAMMAR_HINT);
+        }
+        return new ParsedQuery(kind, columns, table, conditions, limit);
+    }
+
+    private static TableRef parseTableRef(Tokenizer tokens) {
+        List<String> parts = new ArrayList<>(tokens.expectTableRefPart());
+        while (tokens.consumeSymbol('.')) {
+            parts.addAll(tokens.expectTableRefPart());
+        }
+        return switch (parts.size()) {
+            case 1 -> new TableRef(null, null, parts.get(0));
+            case 2 -> new TableRef(null, parts.get(0), parts.get(1));
+            case 3 -> new TableRef(parts.get(0), parts.get(1), parts.get(2));
+            default -> throw invalidQuery("Invalid table reference: " + String.join(".", parts));
+        };
+    }
+
+    private static Condition parseCondition(Tokenizer tokens) {
+        String column = tokens.expectIdentifier("column name");
+        tokens.expectSymbol('=');
+        Object literal = tokens.expectLiteral();
+        return new Condition(column, literal);
+    }
+
+    // ── Evaluation ───────────────────────────────────────────────────────────
+
+    static Result evaluate(ParsedQuery query, TableSchema schema, List<Map<String, Object>> storedRows) {
+        List<TableFieldSchema> fields = schema != null && schema.getFields() != null
+                ? schema.getFields() : List.of();
+
+        List<Map<String, Object>> filtered = new ArrayList<>();
+        for (Map<String, Object> row : storedRows) {
+            if (matches(row, query.conditions(), fields)) {
+                filtered.add(row);
+            }
+        }
+
+        if (query.kind() == Kind.COUNT_STAR) {
+            TableFieldSchema countField = new TableFieldSchema();
+            countField.setName("f0_");
+            countField.setType("INTEGER");
+            countField.setMode("NULLABLE");
+            Map<String, Object> countRow = new LinkedHashMap<>();
+            countRow.put("f0_", (long) filtered.size());
+            return new Result(new TableSchema(List.of(countField)), List.of(countRow));
+        }
+
+        if (query.limit() != null && filtered.size() > query.limit()) {
+            filtered = filtered.subList(0, query.limit());
+        }
+
+        if (query.kind() == Kind.STAR) {
+            return new Result(new TableSchema(fields), filtered);
+        }
+
+        List<TableFieldSchema> projected = new ArrayList<>();
+        for (String column : query.columns()) {
+            projected.add(resolveColumn(column, fields));
+        }
+        List<Map<String, Object>> projectedRows = new ArrayList<>(filtered.size());
+        for (Map<String, Object> row : filtered) {
+            Map<String, Object> out = new LinkedHashMap<>();
+            for (TableFieldSchema field : projected) {
+                out.put(field.getName(), row.get(field.getName()));
+            }
+            projectedRows.add(out);
+        }
+        return new Result(new TableSchema(projected), projectedRows);
+    }
+
+    private static boolean matches(Map<String, Object> row, List<Condition> conditions,
+                                   List<TableFieldSchema> fields) {
+        for (Condition condition : conditions) {
+            TableFieldSchema field = resolveColumn(condition.column(), fields);
+            if ("REPEATED".equals(field.getMode()) || "RECORD".equals(field.getType())) {
+                throw invalidQuery("Filtering on " + field.getMode() + "/" + field.getType()
+                        + " column " + field.getName() + " is not supported. " + GRAMMAR_HINT);
+            }
+            Object stored = row.get(field.getName());
+            if (stored == null || !compare(field, stored, condition.literal())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean compare(TableFieldSchema field, Object stored, Object literal) {
+        switch (field.getType()) {
+            case "INTEGER" -> {
+                if (!(literal instanceof Long l)) {
+                    throw typeMismatch(field, literal);
+                }
+                return stored instanceof Number n && n.longValue() == l;
+            }
+            case "FLOAT" -> {
+                double target;
+                if (literal instanceof Long l) {
+                    target = l;
+                } else if (literal instanceof Double d) {
+                    target = d;
+                } else {
+                    throw typeMismatch(field, literal);
+                }
+                return stored instanceof Number n && n.doubleValue() == target;
+            }
+            case "BOOLEAN" -> {
+                if (!(literal instanceof Boolean b)) {
+                    throw typeMismatch(field, literal);
+                }
+                return stored instanceof Boolean s && s == b;
+            }
+            default -> {
+                if (!(literal instanceof String s)) {
+                    throw typeMismatch(field, literal);
+                }
+                return String.valueOf(stored).equals(s);
+            }
+        }
+    }
+
+    private static TableFieldSchema resolveColumn(String name, List<TableFieldSchema> fields) {
+        return fields.stream()
+                .filter(f -> f.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> invalidQuery("Unrecognized name: " + name));
+    }
+
+    private static GcpException typeMismatch(TableFieldSchema field, Object literal) {
+        String literalType = switch (literal) {
+            case Long ignored -> "INT64";
+            case Double ignored -> "FLOAT64";
+            case Boolean ignored -> "BOOL";
+            default -> "STRING";
+        };
+        return invalidQuery("No matching signature for operator = for argument types: "
+                + field.getType() + ", " + literalType);
+    }
+
+    static GcpException invalidQuery(String message) {
+        return GcpException.invalidArgument(message).withReason("invalidQuery");
+    }
+
+    // ── Tokenizer ────────────────────────────────────────────────────────────
+
+    private static final class Tokenizer {
+
+        private final String sql;
+        private int pos;
+
+        Tokenizer(String sql) {
+            this.sql = sql;
+        }
+
+        boolean atEnd() {
+            skipWhitespace();
+            return pos >= sql.length();
+        }
+
+        String remainder() {
+            return sql.substring(pos).trim();
+        }
+
+        void expectKeyword(String keyword) {
+            if (!consumeKeyword(keyword)) {
+                throw invalidQuery("Expected " + keyword + " near \"" + remainder() + "\". " + GRAMMAR_HINT);
+            }
+        }
+
+        boolean consumeKeyword(String keyword) {
+            skipWhitespace();
+            int end = pos + keyword.length();
+            if (end > sql.length() || !sql.substring(pos, end).equalsIgnoreCase(keyword)) {
+                return false;
+            }
+            if (end < sql.length() && isIdentifierChar(sql.charAt(end))) {
+                return false;
+            }
+            pos = end;
+            return true;
+        }
+
+        void expectSymbol(char symbol) {
+            if (!consumeSymbol(symbol)) {
+                throw invalidQuery("Expected '" + symbol + "' near \"" + remainder() + "\". " + GRAMMAR_HINT);
+            }
+        }
+
+        boolean consumeSymbol(char symbol) {
+            skipWhitespace();
+            if (pos < sql.length() && sql.charAt(pos) == symbol) {
+                pos++;
+                return true;
+            }
+            return false;
+        }
+
+        String expectIdentifier(String what) {
+            skipWhitespace();
+            int start = pos;
+            while (pos < sql.length() && isIdentifierChar(sql.charAt(pos))) {
+                pos++;
+            }
+            if (pos == start) {
+                throw invalidQuery("Expected " + what + " near \"" + remainder() + "\". " + GRAMMAR_HINT);
+            }
+            String identifier = sql.substring(start, pos);
+            if (isReserved(identifier)) {
+                throw invalidQuery("Unsupported SQL construct: " + identifier.toUpperCase() + ". " + GRAMMAR_HINT);
+            }
+            return identifier;
+        }
+
+        /** One table-ref part: a backtick-quoted path (may contain dots) or a plain identifier. */
+        List<String> expectTableRefPart() {
+            skipWhitespace();
+            if (pos < sql.length() && sql.charAt(pos) == '`') {
+                int close = sql.indexOf('`', pos + 1);
+                if (close < 0) {
+                    throw invalidQuery("Unterminated backtick identifier. " + GRAMMAR_HINT);
+                }
+                String quoted = sql.substring(pos + 1, close);
+                pos = close + 1;
+                return List.of(quoted.split("\\."));
+            }
+            return List.of(expectIdentifier("table name"));
+        }
+
+        Object expectLiteral() {
+            skipWhitespace();
+            if (pos >= sql.length()) {
+                throw invalidQuery("Expected a literal value. " + GRAMMAR_HINT);
+            }
+            char c = sql.charAt(pos);
+            if (c == '\'' || c == '"') {
+                return stringLiteral(c);
+            }
+            if (c == '-' || Character.isDigit(c)) {
+                return numberLiteral();
+            }
+            if (consumeKeyword("TRUE")) {
+                return Boolean.TRUE;
+            }
+            if (consumeKeyword("FALSE")) {
+                return Boolean.FALSE;
+            }
+            if (consumeKeyword("NULL")) {
+                throw invalidQuery("Comparisons with NULL are not supported (use of '= NULL'). " + GRAMMAR_HINT);
+            }
+            throw invalidQuery("Expected a literal value near \"" + remainder() + "\". " + GRAMMAR_HINT);
+        }
+
+        int expectIntegerLiteral() {
+            Object literal = expectLiteral();
+            if (literal instanceof Long l && l >= 0 && l <= Integer.MAX_VALUE) {
+                return l.intValue();
+            }
+            throw invalidQuery("LIMIT requires a non-negative integer literal. " + GRAMMAR_HINT);
+        }
+
+        private String stringLiteral(char quote) {
+            StringBuilder value = new StringBuilder();
+            pos++;
+            while (pos < sql.length()) {
+                char c = sql.charAt(pos);
+                if (c == '\\' && pos + 1 < sql.length()) {
+                    value.append(sql.charAt(pos + 1));
+                    pos += 2;
+                    continue;
+                }
+                if (c == quote) {
+                    pos++;
+                    return value.toString();
+                }
+                value.append(c);
+                pos++;
+            }
+            throw invalidQuery("Unterminated string literal. " + GRAMMAR_HINT);
+        }
+
+        private Object numberLiteral() {
+            int start = pos;
+            if (sql.charAt(pos) == '-') {
+                pos++;
+            }
+            boolean isFloat = false;
+            while (pos < sql.length()) {
+                char c = sql.charAt(pos);
+                if (Character.isDigit(c)) {
+                    pos++;
+                } else if (c == '.' || c == 'e' || c == 'E'
+                        || ((c == '-' || c == '+') && pos > start
+                            && (sql.charAt(pos - 1) == 'e' || sql.charAt(pos - 1) == 'E'))) {
+                    isFloat = true;
+                    pos++;
+                } else {
+                    break;
+                }
+            }
+            String text = sql.substring(start, pos);
+            try {
+                return isFloat ? (Object) Double.parseDouble(text) : (Object) Long.parseLong(text);
+            } catch (NumberFormatException e) {
+                throw invalidQuery("Invalid numeric literal: " + text + ". " + GRAMMAR_HINT);
+            }
+        }
+
+        private void skipWhitespace() {
+            while (pos < sql.length() && Character.isWhitespace(sql.charAt(pos))) {
+                pos++;
+            }
+        }
+
+        private static boolean isIdentifierChar(char c) {
+            return Character.isLetterOrDigit(c) || c == '_';
+        }
+
+        private static boolean isReserved(String identifier) {
+            return switch (identifier.toUpperCase()) {
+                case "SELECT", "FROM", "WHERE", "AND", "OR", "JOIN", "GROUP", "ORDER", "BY",
+                     "HAVING", "UNION", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP",
+                     "AS", "DISTINCT", "LIMIT" -> true;
+                default -> false;
+            };
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/RowCodec.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/RowCodec.java
@@ -93,7 +93,7 @@ final class RowCodec {
                 continue;
             }
             try {
-                out.put(field.getName(), coerce(field, raw));
+                out.put(field.getName(), coerce(field, raw, ignoreUnknownValues));
             } catch (IllegalArgumentException e) {
                 errors.add(error("invalid", field.getName(), e.getMessage()));
             }
@@ -111,7 +111,7 @@ final class RowCodec {
                 .findFirst().orElse(null);
     }
 
-    private static Object coerce(TableFieldSchema field, Object raw) {
+    private static Object coerce(TableFieldSchema field, Object raw, boolean ignoreUnknownValues) {
         if ("REPEATED".equals(field.getMode())) {
             if (!(raw instanceof List<?> list)) {
                 throw new IllegalArgumentException(
@@ -119,15 +119,15 @@ final class RowCodec {
             }
             List<Object> coerced = new ArrayList<>(list.size());
             for (Object element : list) {
-                coerced.add(coerceScalar(field, element));
+                coerced.add(coerceScalar(field, element, ignoreUnknownValues));
             }
             return coerced;
         }
-        return coerceScalar(field, raw);
+        return coerceScalar(field, raw, ignoreUnknownValues);
     }
 
     @SuppressWarnings("unchecked")
-    private static Object coerceScalar(TableFieldSchema field, Object raw) {
+    private static Object coerceScalar(TableFieldSchema field, Object raw, boolean ignoreUnknownValues) {
         String type = field.getType();
         switch (type) {
             case "INTEGER" -> {
@@ -171,7 +171,7 @@ final class RowCodec {
                     TableSchema subSchema = new TableSchema(field.getFields() != null
                             ? field.getFields() : List.of());
                     List<ErrorProto> nestedErrors =
-                            normalizeRow(subSchema, (Map<String, Object>) map, true, nested);
+                            normalizeRow(subSchema, (Map<String, Object>) map, ignoreUnknownValues, nested);
                     if (!nestedErrors.isEmpty()) {
                         throw new IllegalArgumentException(nestedErrors.get(0).getMessage());
                     }

--- a/src/main/java/io/floci/gcp/services/bigquery/RowCodec.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/RowCodec.java
@@ -1,0 +1,250 @@
+package io.floci.gcp.services.bigquery;
+
+import io.floci.gcp.services.bigquery.model.ErrorProto;
+import io.floci.gcp.services.bigquery.model.TableCell;
+import io.floci.gcp.services.bigquery.model.TableFieldSchema;
+import io.floci.gcp.services.bigquery.model.TableRow;
+import io.floci.gcp.services.bigquery.model.TableSchema;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Schema-aware conversion between {@code insertAll} JSON rows, the normalized stored
+ * representation, and BigQuery's {@code {f:[{v:...}]}} wire encoding. Scalar cell values
+ * are always strings on the wire; REPEATED cells are arrays of {@code {v:...}} and RECORD
+ * cells nest {@code {f:[...]}} (the exact contract of the SDK's {@code FieldValue.fromPb}).
+ */
+final class RowCodec {
+
+    private RowCodec() {}
+
+    /** Standard SQL → legacy type-name mapping; the SDK round-trips legacy names. */
+    static String legacyType(String type) {
+        if (type == null) {
+            return "STRING";
+        }
+        return switch (type.toUpperCase()) {
+            case "INT64" -> "INTEGER";
+            case "FLOAT64" -> "FLOAT";
+            case "BOOL" -> "BOOLEAN";
+            case "STRUCT" -> "RECORD";
+            default -> type.toUpperCase();
+        };
+    }
+
+    static TableSchema normalizeSchema(TableSchema schema) {
+        if (schema == null || schema.getFields() == null) {
+            return schema;
+        }
+        return new TableSchema(normalizeFields(schema.getFields()));
+    }
+
+    private static List<TableFieldSchema> normalizeFields(List<TableFieldSchema> fields) {
+        List<TableFieldSchema> normalized = new ArrayList<>(fields.size());
+        for (TableFieldSchema field : fields) {
+            TableFieldSchema copy = new TableFieldSchema();
+            copy.setName(field.getName());
+            copy.setType(legacyType(field.getType()));
+            copy.setMode(field.getMode() != null && !field.getMode().isBlank()
+                    ? field.getMode().toUpperCase() : "NULLABLE");
+            copy.setDescription(field.getDescription());
+            if (field.getFields() != null) {
+                copy.setFields(normalizeFields(field.getFields()));
+            }
+            normalized.add(copy);
+        }
+        return normalized;
+    }
+
+    /**
+     * Validates and coerces one {@code insertAll} JSON object against the schema.
+     * Returns the per-row errors (empty = accepted); the normalized row is written to
+     * {@code out} keyed by canonical field names.
+     */
+    static List<ErrorProto> normalizeRow(TableSchema schema, Map<String, Object> json,
+                                         boolean ignoreUnknownValues, Map<String, Object> out) {
+        List<ErrorProto> errors = new ArrayList<>();
+        List<TableFieldSchema> fields = schema != null && schema.getFields() != null
+                ? schema.getFields() : List.of();
+
+        Map<String, TableFieldSchema> byLowerName = new LinkedHashMap<>();
+        fields.forEach(f -> byLowerName.put(f.getName().toLowerCase(), f));
+
+        if (!ignoreUnknownValues) {
+            for (String key : json.keySet()) {
+                if (!byLowerName.containsKey(key.toLowerCase())) {
+                    errors.add(error("invalid", key, "no such field: " + key + "."));
+                }
+            }
+        }
+
+        for (TableFieldSchema field : fields) {
+            Object raw = valueFor(json, field.getName());
+            if (raw == null) {
+                if ("REQUIRED".equals(field.getMode())) {
+                    errors.add(error("invalid", field.getName(),
+                            "Missing required field: " + field.getName() + "."));
+                } else {
+                    out.put(field.getName(), null);
+                }
+                continue;
+            }
+            try {
+                out.put(field.getName(), coerce(field, raw));
+            } catch (IllegalArgumentException e) {
+                errors.add(error("invalid", field.getName(), e.getMessage()));
+            }
+        }
+        return errors;
+    }
+
+    private static Object valueFor(Map<String, Object> json, String fieldName) {
+        if (json.containsKey(fieldName)) {
+            return json.get(fieldName);
+        }
+        return json.entrySet().stream()
+                .filter(e -> e.getKey().equalsIgnoreCase(fieldName))
+                .map(Map.Entry::getValue)
+                .findFirst().orElse(null);
+    }
+
+    private static Object coerce(TableFieldSchema field, Object raw) {
+        if ("REPEATED".equals(field.getMode())) {
+            if (!(raw instanceof List<?> list)) {
+                throw new IllegalArgumentException(
+                        "Repeated field " + field.getName() + " requires an array value.");
+            }
+            List<Object> coerced = new ArrayList<>(list.size());
+            for (Object element : list) {
+                coerced.add(coerceScalar(field, element));
+            }
+            return coerced;
+        }
+        return coerceScalar(field, raw);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object coerceScalar(TableFieldSchema field, Object raw) {
+        String type = field.getType();
+        switch (type) {
+            case "INTEGER" -> {
+                if (raw instanceof Number n && n.doubleValue() == Math.floor(n.doubleValue())) {
+                    return n.longValue();
+                }
+                if (raw instanceof String s) {
+                    try {
+                        return Long.parseLong(s.trim());
+                    } catch (NumberFormatException ignored) {
+                        // falls through to the error below
+                    }
+                }
+                throw new IllegalArgumentException("Cannot convert value to integer (bad value): " + raw);
+            }
+            case "FLOAT" -> {
+                if (raw instanceof Number n) {
+                    return n.doubleValue();
+                }
+                if (raw instanceof String s) {
+                    try {
+                        return Double.parseDouble(s.trim());
+                    } catch (NumberFormatException ignored) {
+                        // falls through to the error below
+                    }
+                }
+                throw new IllegalArgumentException("Cannot convert value to double (bad value): " + raw);
+            }
+            case "BOOLEAN" -> {
+                if (raw instanceof Boolean b) {
+                    return b;
+                }
+                if (raw instanceof String s && ("true".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s))) {
+                    return Boolean.parseBoolean(s);
+                }
+                throw new IllegalArgumentException("Cannot convert value to boolean (bad value): " + raw);
+            }
+            case "RECORD" -> {
+                if (raw instanceof Map<?, ?> map) {
+                    Map<String, Object> nested = new LinkedHashMap<>();
+                    TableSchema subSchema = new TableSchema(field.getFields() != null
+                            ? field.getFields() : List.of());
+                    List<ErrorProto> nestedErrors =
+                            normalizeRow(subSchema, (Map<String, Object>) map, true, nested);
+                    if (!nestedErrors.isEmpty()) {
+                        throw new IllegalArgumentException(nestedErrors.get(0).getMessage());
+                    }
+                    return nested;
+                }
+                throw new IllegalArgumentException("Record field " + field.getName() + " requires an object value.");
+            }
+            default -> {
+                // STRING, TIMESTAMP, DATE, TIME, DATETIME, NUMERIC, BYTES... stored textually
+                if (raw instanceof String || raw instanceof Number || raw instanceof Boolean) {
+                    return String.valueOf(raw);
+                }
+                throw new IllegalArgumentException(
+                        "Cannot convert value to " + type + " (bad value): " + raw);
+            }
+        }
+    }
+
+    static List<TableRow> encodeRows(TableSchema schema, List<Map<String, Object>> rows) {
+        List<TableRow> encoded = new ArrayList<>(rows.size());
+        for (Map<String, Object> row : rows) {
+            encoded.add(encodeRow(schema, row));
+        }
+        return encoded;
+    }
+
+    static TableRow encodeRow(TableSchema schema, Map<String, Object> row) {
+        List<TableFieldSchema> fields = schema != null && schema.getFields() != null
+                ? schema.getFields() : List.of();
+        List<TableCell> cells = new ArrayList<>(fields.size());
+        for (TableFieldSchema field : fields) {
+            cells.add(new TableCell(encodeValue(field, row.get(field.getName()))));
+        }
+        return new TableRow(cells);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object encodeValue(TableFieldSchema field, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if ("REPEATED".equals(field.getMode()) && value instanceof List<?> list) {
+            List<Map<String, Object>> wrapped = new ArrayList<>(list.size());
+            for (Object element : list) {
+                Map<String, Object> cell = new LinkedHashMap<>();
+                cell.put("v", encodeScalar(field, element));
+                wrapped.add(cell);
+            }
+            return wrapped;
+        }
+        return encodeScalar(field, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object encodeScalar(TableFieldSchema field, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if ("RECORD".equals(field.getType()) && value instanceof Map<?, ?> map) {
+            TableSchema subSchema = new TableSchema(field.getFields() != null ? field.getFields() : List.of());
+            return Map.of("f", encodeRow(subSchema, (Map<String, Object>) map).getF());
+        }
+        if (value instanceof Boolean b) {
+            return b ? "true" : "false";
+        }
+        return String.valueOf(value);
+    }
+
+    private static ErrorProto error(String reason, String location, String message) {
+        ErrorProto error = new ErrorProto();
+        error.setReason(reason);
+        error.setLocation(location);
+        error.setMessage(message);
+        return error;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/Dataset.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/Dataset.java
@@ -1,0 +1,56 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.Map;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Dataset {
+
+    private String kind = "bigquery#dataset";
+    private String id;
+    private String etag;
+    private String selfLink;
+    private DatasetReference datasetReference;
+    private String friendlyName;
+    private String description;
+    private String location;
+    private Map<String, String> labels;
+    private String creationTime;
+    private String lastModifiedTime;
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getEtag() { return etag; }
+    public void setEtag(String etag) { this.etag = etag; }
+
+    public String getSelfLink() { return selfLink; }
+    public void setSelfLink(String selfLink) { this.selfLink = selfLink; }
+
+    public DatasetReference getDatasetReference() { return datasetReference; }
+    public void setDatasetReference(DatasetReference datasetReference) { this.datasetReference = datasetReference; }
+
+    public String getFriendlyName() { return friendlyName; }
+    public void setFriendlyName(String friendlyName) { this.friendlyName = friendlyName; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+
+    public Map<String, String> getLabels() { return labels; }
+    public void setLabels(Map<String, String> labels) { this.labels = labels; }
+
+    public String getCreationTime() { return creationTime; }
+    public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
+
+    public String getLastModifiedTime() { return lastModifiedTime; }
+    public void setLastModifiedTime(String lastModifiedTime) { this.lastModifiedTime = lastModifiedTime; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/DatasetReference.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/DatasetReference.java
@@ -1,0 +1,25 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DatasetReference {
+
+    private String projectId;
+    private String datasetId;
+
+    public DatasetReference() {}
+
+    public DatasetReference(String projectId, String datasetId) {
+        this.projectId = projectId;
+        this.datasetId = datasetId;
+    }
+
+    public String getProjectId() { return projectId; }
+    public void setProjectId(String projectId) { this.projectId = projectId; }
+
+    public String getDatasetId() { return datasetId; }
+    public void setDatasetId(String datasetId) { this.datasetId = datasetId; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/ErrorProto.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/ErrorProto.java
@@ -1,0 +1,34 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorProto {
+
+    private String reason;
+    private String location;
+    private String debugInfo;
+    private String message;
+
+    public ErrorProto() {}
+
+    public ErrorProto(String reason, String location, String message) {
+        this.reason = reason;
+        this.location = location;
+        this.message = message;
+    }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+
+    public String getDebugInfo() { return debugInfo; }
+    public void setDebugInfo(String debugInfo) { this.debugInfo = debugInfo; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/Job.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/Job.java
@@ -1,0 +1,44 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.Map;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Job {
+
+    private String kind = "bigquery#job";
+    private String id;
+    private String etag;
+    private String selfLink;
+    private JobReference jobReference;
+    private Map<String, Object> configuration;
+    private JobStatus status;
+    private Map<String, Object> statistics;
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getEtag() { return etag; }
+    public void setEtag(String etag) { this.etag = etag; }
+
+    public String getSelfLink() { return selfLink; }
+    public void setSelfLink(String selfLink) { this.selfLink = selfLink; }
+
+    public JobReference getJobReference() { return jobReference; }
+    public void setJobReference(JobReference jobReference) { this.jobReference = jobReference; }
+
+    public Map<String, Object> getConfiguration() { return configuration; }
+    public void setConfiguration(Map<String, Object> configuration) { this.configuration = configuration; }
+
+    public JobStatus getStatus() { return status; }
+    public void setStatus(JobStatus status) { this.status = status; }
+
+    public Map<String, Object> getStatistics() { return statistics; }
+    public void setStatistics(Map<String, Object> statistics) { this.statistics = statistics; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/JobReference.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/JobReference.java
@@ -1,0 +1,30 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JobReference {
+
+    private String projectId;
+    private String jobId;
+    private String location;
+
+    public JobReference() {}
+
+    public JobReference(String projectId, String jobId, String location) {
+        this.projectId = projectId;
+        this.jobId = jobId;
+        this.location = location;
+    }
+
+    public String getProjectId() { return projectId; }
+    public void setProjectId(String projectId) { this.projectId = projectId; }
+
+    public String getJobId() { return jobId; }
+    public void setJobId(String jobId) { this.jobId = jobId; }
+
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/JobStatus.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/JobStatus.java
@@ -1,0 +1,25 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JobStatus {
+
+    /** One of PENDING, RUNNING, DONE. */
+    private String state;
+    private ErrorProto errorResult;
+    private List<ErrorProto> errors;
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public ErrorProto getErrorResult() { return errorResult; }
+    public void setErrorResult(ErrorProto errorResult) { this.errorResult = errorResult; }
+
+    public List<ErrorProto> getErrors() { return errors; }
+    public void setErrors(List<ErrorProto> errors) { this.errors = errors; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/QueryResponse.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/QueryResponse.java
@@ -1,0 +1,53 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/** Response shape for {@code jobs.query} (POST /queries) and {@code getQueryResults}. */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class QueryResponse {
+
+    private String kind = "bigquery#queryResponse";
+    private JobReference jobReference;
+    private Boolean jobComplete;
+    private TableSchema schema;
+    private List<TableRow> rows;
+    private String totalRows;
+    private String pageToken;
+    private Boolean cacheHit;
+    private String totalBytesProcessed;
+    private List<ErrorProto> errors;
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public JobReference getJobReference() { return jobReference; }
+    public void setJobReference(JobReference jobReference) { this.jobReference = jobReference; }
+
+    public Boolean getJobComplete() { return jobComplete; }
+    public void setJobComplete(Boolean jobComplete) { this.jobComplete = jobComplete; }
+
+    public TableSchema getSchema() { return schema; }
+    public void setSchema(TableSchema schema) { this.schema = schema; }
+
+    public List<TableRow> getRows() { return rows; }
+    public void setRows(List<TableRow> rows) { this.rows = rows; }
+
+    public String getTotalRows() { return totalRows; }
+    public void setTotalRows(String totalRows) { this.totalRows = totalRows; }
+
+    public String getPageToken() { return pageToken; }
+    public void setPageToken(String pageToken) { this.pageToken = pageToken; }
+
+    public Boolean getCacheHit() { return cacheHit; }
+    public void setCacheHit(Boolean cacheHit) { this.cacheHit = cacheHit; }
+
+    public String getTotalBytesProcessed() { return totalBytesProcessed; }
+    public void setTotalBytesProcessed(String totalBytesProcessed) { this.totalBytesProcessed = totalBytesProcessed; }
+
+    public List<ErrorProto> getErrors() { return errors; }
+    public void setErrors(List<ErrorProto> errors) { this.errors = errors; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/StoredJob.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/StoredJob.java
@@ -1,0 +1,66 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Internal persisted representation of a query job, keyed by {@code jobId}. Result rows
+ * are materialized into a hidden anonymous table ({@code destinationDatasetId} /
+ * {@code destinationTableId}) so {@code getQueryResults} and the SDK's
+ * {@code Job.getQueryResults()} (which reads {@code tabledata.list} on the job's
+ * destination table) share one row store.
+ */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoredJob {
+
+    private String jobId;
+    private String projectId;
+    private String location;
+    private String query;
+    /** PENDING, RUNNING, or DONE. */
+    private String state;
+    private String destinationDatasetId;
+    private String destinationTableId;
+    private long totalRows;
+    private String creationTime;
+    private String errorReason;
+    private String errorMessage;
+
+    public String getJobId() { return jobId; }
+    public void setJobId(String jobId) { this.jobId = jobId; }
+
+    public String getProjectId() { return projectId; }
+    public void setProjectId(String projectId) { this.projectId = projectId; }
+
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+
+    public String getQuery() { return query; }
+    public void setQuery(String query) { this.query = query; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getDestinationDatasetId() { return destinationDatasetId; }
+    public void setDestinationDatasetId(String destinationDatasetId) { this.destinationDatasetId = destinationDatasetId; }
+
+    public String getDestinationTableId() { return destinationTableId; }
+    public void setDestinationTableId(String destinationTableId) { this.destinationTableId = destinationTableId; }
+
+    public long getTotalRows() { return totalRows; }
+    public void setTotalRows(long totalRows) { this.totalRows = totalRows; }
+
+    public String getCreationTime() { return creationTime; }
+    public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
+
+    public String getErrorReason() { return errorReason; }
+    public void setErrorReason(String errorReason) { this.errorReason = errorReason; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    public boolean failed() {
+        return errorReason != null;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/StoredTableData.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/StoredTableData.java
@@ -1,0 +1,24 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Internal store of rows ingested via {@code tabledata.insertAll}, keyed by
+ * {@code datasetId/tableId}. Each row is the raw {@code json} object (column → value)
+ * from the insert request; conversion to the wire {@code {f:[{v}]}} shape happens at
+ * read time against the table schema.
+ */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoredTableData {
+
+    private List<Map<String, Object>> rows = new ArrayList<>();
+
+    public List<Map<String, Object>> getRows() { return rows; }
+    public void setRows(List<Map<String, Object>> rows) { this.rows = rows; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/Table.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/Table.java
@@ -1,0 +1,68 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.Map;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Table {
+
+    private String kind = "bigquery#table";
+    private String id;
+    private String etag;
+    private String selfLink;
+    private TableReference tableReference;
+    private String friendlyName;
+    private String description;
+    private String type = "TABLE";
+    private TableSchema schema;
+    private Map<String, String> labels;
+    private String numRows;
+    private String numBytes;
+    private String creationTime;
+    private String lastModifiedTime;
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getEtag() { return etag; }
+    public void setEtag(String etag) { this.etag = etag; }
+
+    public String getSelfLink() { return selfLink; }
+    public void setSelfLink(String selfLink) { this.selfLink = selfLink; }
+
+    public TableReference getTableReference() { return tableReference; }
+    public void setTableReference(TableReference tableReference) { this.tableReference = tableReference; }
+
+    public String getFriendlyName() { return friendlyName; }
+    public void setFriendlyName(String friendlyName) { this.friendlyName = friendlyName; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public TableSchema getSchema() { return schema; }
+    public void setSchema(TableSchema schema) { this.schema = schema; }
+
+    public Map<String, String> getLabels() { return labels; }
+    public void setLabels(Map<String, String> labels) { this.labels = labels; }
+
+    public String getNumRows() { return numRows; }
+    public void setNumRows(String numRows) { this.numRows = numRows; }
+
+    public String getNumBytes() { return numBytes; }
+    public void setNumBytes(String numBytes) { this.numBytes = numBytes; }
+
+    public String getCreationTime() { return creationTime; }
+    public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
+
+    public String getLastModifiedTime() { return lastModifiedTime; }
+    public void setLastModifiedTime(String lastModifiedTime) { this.lastModifiedTime = lastModifiedTime; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/TableCell.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/TableCell.java
@@ -1,0 +1,25 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A single cell in a {@link TableRow}. The {@code v} value is a scalar (rendered as a
+ * string on the wire), a nested {@code {f:[...]}} for RECORD types, or an array for
+ * REPEATED fields.
+ */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TableCell {
+
+    private Object v;
+
+    public TableCell() {}
+
+    public TableCell(Object v) {
+        this.v = v;
+    }
+
+    public Object getV() { return v; }
+    public void setV(Object v) { this.v = v; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/TableFieldSchema.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/TableFieldSchema.java
@@ -1,0 +1,32 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TableFieldSchema {
+
+    private String name;
+    private String type;
+    private String mode;
+    private String description;
+    private List<TableFieldSchema> fields;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getMode() { return mode; }
+    public void setMode(String mode) { this.mode = mode; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public List<TableFieldSchema> getFields() { return fields; }
+    public void setFields(List<TableFieldSchema> fields) { this.fields = fields; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/TableReference.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/TableReference.java
@@ -1,0 +1,30 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TableReference {
+
+    private String projectId;
+    private String datasetId;
+    private String tableId;
+
+    public TableReference() {}
+
+    public TableReference(String projectId, String datasetId, String tableId) {
+        this.projectId = projectId;
+        this.datasetId = datasetId;
+        this.tableId = tableId;
+    }
+
+    public String getProjectId() { return projectId; }
+    public void setProjectId(String projectId) { this.projectId = projectId; }
+
+    public String getDatasetId() { return datasetId; }
+    public void setDatasetId(String datasetId) { this.datasetId = datasetId; }
+
+    public String getTableId() { return tableId; }
+    public void setTableId(String tableId) { this.tableId = tableId; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/TableRow.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/TableRow.java
@@ -1,0 +1,23 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/** A row in BigQuery's tabledata/query wire format: {@code {f:[{v:value}]}}. */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TableRow {
+
+    private List<TableCell> f;
+
+    public TableRow() {}
+
+    public TableRow(List<TableCell> f) {
+        this.f = f;
+    }
+
+    public List<TableCell> getF() { return f; }
+    public void setF(List<TableCell> f) { this.f = f; }
+}

--- a/src/main/java/io/floci/gcp/services/bigquery/model/TableSchema.java
+++ b/src/main/java/io/floci/gcp/services/bigquery/model/TableSchema.java
@@ -1,0 +1,22 @@
+package io.floci.gcp.services.bigquery.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TableSchema {
+
+    private List<TableFieldSchema> fields;
+
+    public TableSchema() {}
+
+    public TableSchema(List<TableFieldSchema> fields) {
+        this.fields = fields;
+    }
+
+    public List<TableFieldSchema> getFields() { return fields; }
+    public void setFields(List<TableFieldSchema> fields) { this.fields = fields; }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,8 @@ floci-gcp:
       tick-interval-seconds: 10
     eventarc:
       enabled: true
+    bigquery:
+      enabled: true
     gke:
       enabled: true
       mock: false

--- a/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
+++ b/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
@@ -49,6 +49,36 @@ class GcpExceptionMapperTest {
     }
 
     @Test
+    void explicitReasonOverridesDerivedReason() {
+        GcpException ex = GcpException.invalidArgument("bad sql").withReason("invalidQuery");
+        var response = new GcpExceptionMapper().toResponse(ex);
+        var wrapper = (GcpExceptionMapper.ErrorWrapper) response.getEntity();
+
+        assertEquals(400, wrapper.error().code());
+        assertEquals("INVALID_ARGUMENT", wrapper.error().status());
+        assertEquals("invalidQuery", wrapper.error().errors().get(0).reason());
+    }
+
+    @Test
+    void mapperDerivesReasonWhenNoneSet() {
+        GcpException ex = GcpException.alreadyExists("exists");
+        var response = new GcpExceptionMapper().toResponse(ex);
+        var wrapper = (GcpExceptionMapper.ErrorWrapper) response.getEntity();
+
+        assertEquals("alreadyExists", wrapper.error().errors().get(0).reason());
+        assertNull(ex.getReason());
+    }
+
+    @Test
+    void withReasonPreservesStatusAndMessage() {
+        GcpException ex = GcpException.alreadyExists("Already Exists: Dataset p:d").withReason("duplicate");
+        assertEquals(409, ex.getHttpStatus());
+        assertEquals("ALREADY_EXISTS", ex.getGcpStatus());
+        assertEquals("Already Exists: Dataset p:d", ex.getMessage());
+        assertEquals("duplicate", ex.getReason());
+    }
+
+    @Test
     void reasonIsDerivedFromStatus() {
         assertEquals("alreadyExists",
                 GcpExceptionMapper.ErrorDetail.of(409, "x", "ALREADY_EXISTS").errors().get(0).reason());

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryDisabledRestIntegrationTest.java
@@ -1,0 +1,33 @@
+package io.floci.gcp.services.bigquery;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(BigQueryDisabledRestIntegrationTest.DisabledBigQueryProfile.class)
+class BigQueryDisabledRestIntegrationTest {
+
+    @Test
+    void disabledBigQueryRestServiceReturnsUnavailableWrapper() {
+        given()
+                .when().get("/bigquery/v2/projects/bq-disabled/datasets")
+                .then()
+                .statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"))
+                .body("error.message", equalTo("Service bigquery is not enabled."));
+    }
+
+    public static class DisabledBigQueryProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.bigquery.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryRestIntegrationTest.java
@@ -188,6 +188,23 @@ class BigQueryRestIntegrationTest {
                 .statusCode(200)
                 .body("status.state", equalTo("DONE"))
                 .body("status.errorResult.reason", equalTo("invalidQuery"));
+
+        // getQueryResults on the failed job → HTTP 200, jobComplete with embedded errors
+        String failedJobId = given()
+                .contentType("application/json")
+                .body("""
+                        {"configuration": {"query": {"query": "SELECT name FROM ds1.t1 ORDER BY name"}}}
+                        """)
+                .when().post(BASE + "/jobs")
+                .then()
+                .statusCode(200)
+                .extract().path("jobReference.jobId");
+        given()
+                .when().get(BASE + "/queries/" + failedJobId)
+                .then()
+                .statusCode(200)
+                .body("jobComplete", equalTo(true))
+                .body("errors[0].reason", equalTo("invalidQuery"));
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryRestIntegrationTest.java
@@ -1,0 +1,247 @@
+package io.floci.gcp.services.bigquery;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class BigQueryRestIntegrationTest {
+
+    private static final String PROJECT = "bq-rest-it";
+    private static final String BASE = "/bigquery/v2/projects/" + PROJECT;
+
+    private static String queryJobId;
+
+    @Test
+    @Order(1)
+    void createDatasetAndTableWireShapes() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"datasetReference": {"datasetId": "ds1"}, "friendlyName": "DS One"}
+                        """)
+                .when().post(BASE + "/datasets")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#dataset"))
+                .body("id", equalTo(PROJECT + ":ds1"))
+                .body("datasetReference.projectId", equalTo(PROJECT));
+
+        // Duplicate → 409 with legacy reason "duplicate"
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"datasetReference": {"datasetId": "ds1"}}
+                        """)
+                .when().post(BASE + "/datasets")
+                .then()
+                .statusCode(409)
+                .body("error.errors[0].reason", equalTo("duplicate"));
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"tableReference": {"tableId": "t1"},
+                         "schema": {"fields": [
+                            {"name": "name", "type": "STRING"},
+                            {"name": "age", "type": "INT64"},
+                            {"name": "tags", "type": "STRING", "mode": "REPEATED"}]}}
+                        """)
+                .when().post(BASE + "/datasets/ds1/tables")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#table"))
+                .body("id", equalTo(PROJECT + ":ds1.t1"))
+                .body("type", equalTo("TABLE"))
+                .body("schema.fields[1].type", equalTo("INTEGER"))
+                .body("schema.fields[0].mode", equalTo("NULLABLE"));
+    }
+
+    @Test
+    @Order(2)
+    void insertAllValidRowsAndPerRowErrors() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"rows": [
+                            {"json": {"name": "ana", "age": 30, "tags": ["a", "b"]}},
+                            {"json": {"name": "bo", "age": 25, "tags": []}}]}
+                        """)
+                .when().post(BASE + "/datasets/ds1/tables/t1/insertAll")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#tableDataInsertAllResponse"))
+                .body("insertErrors", nullValue());
+
+        // Unknown field without ignoreUnknownValues → HTTP 200 + per-row error
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"rows": [{"json": {"name": "x", "bogus": 1}}]}
+                        """)
+                .when().post(BASE + "/datasets/ds1/tables/t1/insertAll")
+                .then()
+                .statusCode(200)
+                .body("insertErrors", hasSize(1))
+                .body("insertErrors[0].index", equalTo(0))
+                .body("insertErrors[0].errors[0].reason", equalTo("invalid"));
+    }
+
+    @Test
+    @Order(3)
+    void tableDataListEncodesRowsAndPages() {
+        given()
+                .queryParam("maxResults", 1)
+                .when().get(BASE + "/datasets/ds1/tables/t1/data")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#tableDataList"))
+                .body("totalRows", equalTo("2"))
+                .body("rows", hasSize(1))
+                .body("rows[0].f[0].v", equalTo("ana"))
+                .body("rows[0].f[1].v", equalTo("30"))
+                .body("rows[0].f[2].v[0].v", equalTo("a"))
+                .body("pageToken", notNullValue());
+
+        // maxResults=0 must return zero rows (Job.waitFor contract)
+        given()
+                .queryParam("maxResults", 0)
+                .when().get(BASE + "/datasets/ds1/tables/t1/data")
+                .then()
+                .statusCode(200)
+                .body("totalRows", equalTo("2"))
+                .body("rows", nullValue());
+    }
+
+    @Test
+    @Order(4)
+    void queryFastPathReturnsCompleteResponse() {
+        queryJobId = given()
+                .contentType("application/json")
+                .body("""
+                        {"query": "SELECT name FROM ds1.t1 WHERE age = 30", "useLegacySql": false}
+                        """)
+                .when().post(BASE + "/queries")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#queryResponse"))
+                .body("jobComplete", equalTo(true))
+                .body("schema.fields", hasSize(1))
+                .body("totalRows", equalTo("1"))
+                .body("rows[0].f[0].v", equalTo("ana"))
+                .body("jobReference.projectId", equalTo(PROJECT))
+                .extract().path("jobReference.jobId");
+    }
+
+    @Test
+    @Order(5)
+    void getQueryResultsAndJobCarryDestinationTable() {
+        given()
+                .when().get(BASE + "/queries/" + queryJobId)
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#getQueryResultsResponse"))
+                .body("jobComplete", equalTo(true))
+                .body("totalRows", equalTo("1"));
+
+        given()
+                .when().get(BASE + "/jobs/" + queryJobId)
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#job"))
+                .body("status.state", equalTo("DONE"))
+                .body("configuration.query.destinationTable.datasetId", equalTo("_floci_anon"))
+                .body("statistics.creationTime", notNullValue());
+    }
+
+    @Test
+    @Order(6)
+    void invalidSqlPathsDiffer() {
+        // jobs.query → HTTP 400 invalidQuery
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"query": "SELECT name FROM ds1.t1 GROUP BY name"}
+                        """)
+                .when().post(BASE + "/queries")
+                .then()
+                .statusCode(400)
+                .body("error.errors[0].reason", equalTo("invalidQuery"));
+
+        // jobs.insert → HTTP 200 DONE job with errorResult
+        given()
+                .contentType("application/json")
+                .body("""
+                        {"configuration": {"query": {"query": "SELECT name FROM ds1.t1 ORDER BY name"}}}
+                        """)
+                .when().post(BASE + "/jobs")
+                .then()
+                .statusCode(200)
+                .body("status.state", equalTo("DONE"))
+                .body("status.errorResult.reason", equalTo("invalidQuery"));
+    }
+
+    @Test
+    @Order(7)
+    void jobLifecycleCancelAndDelete() {
+        String jobId = given()
+                .contentType("application/json")
+                .body("""
+                        {"configuration": {"query": {"query": "SELECT COUNT(*) FROM ds1.t1"}}}
+                        """)
+                .when().post(BASE + "/jobs")
+                .then()
+                .statusCode(200)
+                .body("status.state", equalTo("DONE"))
+                .extract().path("jobReference.jobId");
+
+        given()
+                .when().post(BASE + "/jobs/" + jobId + "/cancel")
+                .then()
+                .statusCode(200)
+                .body("kind", equalTo("bigquery#jobCancelResponse"))
+                .body("job.jobReference.jobId", equalTo(jobId));
+
+        given()
+                .when().delete(BASE + "/jobs/" + jobId + "/delete")
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get(BASE + "/jobs/" + jobId)
+                .then()
+                .statusCode(404)
+                .body("error.errors[0].reason", equalTo("notFound"));
+    }
+
+    @Test
+    @Order(8)
+    void deleteSemantics() {
+        given()
+                .when().delete(BASE + "/datasets/ds1")
+                .then()
+                .statusCode(400)
+                .body("error.errors[0].reason", equalTo("resourceInUse"));
+
+        given()
+                .queryParam("deleteContents", true)
+                .when().delete(BASE + "/datasets/ds1")
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get(BASE + "/datasets/ds1")
+                .then()
+                .statusCode(404)
+                .body("error.errors[0].reason", equalTo("notFound"));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
@@ -1,0 +1,378 @@
+package io.floci.gcp.services.bigquery;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.bigquery.model.Dataset;
+import io.floci.gcp.services.bigquery.model.DatasetReference;
+import io.floci.gcp.services.bigquery.model.ErrorProto;
+import io.floci.gcp.services.bigquery.model.StoredJob;
+import io.floci.gcp.services.bigquery.model.Table;
+import io.floci.gcp.services.bigquery.model.TableFieldSchema;
+import io.floci.gcp.services.bigquery.model.TableReference;
+import io.floci.gcp.services.bigquery.model.TableRow;
+import io.floci.gcp.services.bigquery.model.TableSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BigQueryServiceTest {
+
+    private static final String PROJECT = "p1";
+    private static final String DATASET = "ds1";
+    private static final String TABLE = "t1";
+
+    private BigQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BigQueryService(new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>());
+    }
+
+    // ── Datasets ──
+
+    @Test
+    void createDatasetSetsReferenceAndTimestamps() {
+        Dataset created = service.createDataset(PROJECT, newDataset(DATASET));
+        assertEquals(PROJECT, created.getDatasetReference().getProjectId());
+        assertEquals(DATASET, created.getDatasetReference().getDatasetId());
+        assertEquals(PROJECT + ":" + DATASET, created.getId());
+        assertNotNull(created.getCreationTime());
+        assertNotNull(created.getEtag());
+    }
+
+    @Test
+    void createDatasetDuplicateThrowsDuplicateReason() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createDataset(PROJECT, newDataset(DATASET)));
+        assertEquals("ALREADY_EXISTS", ex.getGcpStatus());
+        assertEquals("duplicate", ex.getReason());
+    }
+
+    @Test
+    void getDatasetMissingThrowsNotFound() {
+        GcpException ex = assertThrows(GcpException.class, () -> service.getDataset(PROJECT, "nope"));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void listDatasetsReturnsCreated() {
+        service.createDataset(PROJECT, newDataset("a"));
+        service.createDataset(PROJECT, newDataset("b"));
+        assertEquals(2, service.listDatasets(PROJECT).size());
+    }
+
+    @Test
+    void deleteNonEmptyDatasetRequiresDeleteContents() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        service.createTable(PROJECT, DATASET, newTable(DATASET, TABLE));
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.deleteDataset(PROJECT, DATASET, false));
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("resourceInUse", ex.getReason());
+        service.deleteDataset(PROJECT, DATASET, true);
+        assertThrows(GcpException.class, () -> service.getDataset(PROJECT, DATASET));
+    }
+
+    // ── Tables ──
+
+    @Test
+    void createTableRequiresExistingDataset() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createTable(PROJECT, "missing", newTable("missing", TABLE)));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void createTableSetsDefaultsAndNormalizesSchema() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        Table body = new Table();
+        body.setTableReference(new TableReference(null, DATASET, TABLE));
+        body.setSchema(new TableSchema(List.of(
+                field("name", "STRING", null),
+                field("age", "INT64", null),
+                field("score", "FLOAT64", "required"),
+                field("active", "BOOL", null),
+                field("tags", "STRING", "REPEATED"))));
+
+        Table created = service.createTable(PROJECT, DATASET, body);
+        assertEquals("TABLE", created.getType());
+        assertEquals("0", created.getNumRows());
+        assertEquals(PROJECT + ":" + DATASET + "." + TABLE, created.getId());
+
+        List<TableFieldSchema> fields = created.getSchema().getFields();
+        assertEquals("STRING", fields.get(0).getType());
+        assertEquals("NULLABLE", fields.get(0).getMode());
+        assertEquals("INTEGER", fields.get(1).getType());
+        assertEquals("FLOAT", fields.get(2).getType());
+        assertEquals("REQUIRED", fields.get(2).getMode());
+        assertEquals("BOOLEAN", fields.get(3).getType());
+        assertEquals("REPEATED", fields.get(4).getMode());
+    }
+
+    @Test
+    void createTableDuplicateThrowsDuplicateReason() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        service.createTable(PROJECT, DATASET, newTable(DATASET, TABLE));
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.createTable(PROJECT, DATASET, newTable(DATASET, TABLE)));
+        assertEquals("duplicate", ex.getReason());
+    }
+
+    // ── insertAll ──
+
+    @Test
+    void insertAllCoercesAndListsRowsInWireShape() {
+        seedTable();
+        List<Map<String, Object>> errors = insertRows(
+                Map.of("name", "alice", "age", 30),
+                Map.of("name", "bob", "age", "25"));
+        assertTrue(errors.isEmpty());
+
+        assertEquals("2", service.getTable(PROJECT, DATASET, TABLE).getNumRows());
+
+        BigQueryService.TableData data = service.listTableData(PROJECT, DATASET, TABLE);
+        assertEquals(2, data.rows().size());
+        // Cells follow schema order (name, age), scalars rendered as strings.
+        assertEquals("alice", data.rows().get(0).getF().get(0).getV());
+        assertEquals("30", data.rows().get(0).getF().get(1).getV());
+        assertEquals("25", data.rows().get(1).getF().get(1).getV());
+    }
+
+    @Test
+    void insertAllRejectsUnknownFieldUnlessIgnored() {
+        seedTable();
+        List<Map<String, Object>> errors = service.insertAll(PROJECT, DATASET, TABLE,
+                List.of(new BigQueryService.InsertRow(0, Map.of("name", "x", "bogus", 1))),
+                false, false);
+        assertEquals(1, errors.size());
+        assertEquals(0, errors.get(0).get("index"));
+        assertEquals(0, service.listTableData(PROJECT, DATASET, TABLE).rows().size());
+
+        List<Map<String, Object>> ignored = service.insertAll(PROJECT, DATASET, TABLE,
+                List.of(new BigQueryService.InsertRow(0, Map.of("name", "x", "bogus", 1))),
+                false, true);
+        assertTrue(ignored.isEmpty());
+        assertEquals(1, service.listTableData(PROJECT, DATASET, TABLE).rows().size());
+    }
+
+    @Test
+    void insertAllWithoutSkipStopsValidRows() {
+        seedTable();
+        List<Map<String, Object>> errors = service.insertAll(PROJECT, DATASET, TABLE,
+                List.of(new BigQueryService.InsertRow(0, Map.of("name", "ok", "age", 1)),
+                        new BigQueryService.InsertRow(1, Map.of("name", "bad", "age", "not-a-number"))),
+                false, false);
+
+        assertEquals(2, errors.size());
+        assertEquals(0, service.listTableData(PROJECT, DATASET, TABLE).rows().size());
+        Map<Object, Object> byIndex = new java.util.HashMap<>();
+        errors.forEach(e -> byIndex.put(e.get("index"), e.get("errors")));
+        @SuppressWarnings("unchecked")
+        List<ErrorProto> stoppedErrors = (List<ErrorProto>) byIndex.get(0);
+        assertEquals("stopped", stoppedErrors.get(0).getReason());
+    }
+
+    @Test
+    void insertAllWithSkipInsertsValidRowsOnly() {
+        seedTable();
+        List<Map<String, Object>> errors = service.insertAll(PROJECT, DATASET, TABLE,
+                List.of(new BigQueryService.InsertRow(0, Map.of("name", "ok", "age", 1)),
+                        new BigQueryService.InsertRow(1, Map.of("name", "bad", "age", "nope"))),
+                true, false);
+
+        assertEquals(1, errors.size());
+        assertEquals(1, errors.get(0).get("index"));
+        assertEquals(1, service.listTableData(PROJECT, DATASET, TABLE).rows().size());
+    }
+
+    @Test
+    void insertAllEnforcesRequiredFields() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        Table table = new Table();
+        table.setTableReference(new TableReference(null, DATASET, TABLE));
+        table.setSchema(new TableSchema(List.of(field("name", "STRING", "REQUIRED"))));
+        service.createTable(PROJECT, DATASET, table);
+
+        List<Map<String, Object>> errors = service.insertAll(PROJECT, DATASET, TABLE,
+                List.of(new BigQueryService.InsertRow(0, Map.of())), false, false);
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    void repeatedAndNullCellsUseWireEncoding() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        Table table = new Table();
+        table.setTableReference(new TableReference(null, DATASET, TABLE));
+        table.setSchema(new TableSchema(List.of(
+                field("name", "STRING", null),
+                field("tags", "STRING", "REPEATED"))));
+        service.createTable(PROJECT, DATASET, table);
+
+        insertRows(Map.of("name", "a", "tags", List.of("x", "y")));
+        insertRows(Map.of("tags", List.of()));
+
+        List<TableRow> rows = service.listTableData(PROJECT, DATASET, TABLE).rows();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> repeated = (List<Map<String, Object>>) rows.get(0).getF().get(1).getV();
+        assertEquals(2, repeated.size());
+        assertEquals("x", repeated.get(0).get("v"));
+        assertNull(rows.get(1).getF().get(0).getV());
+    }
+
+    // ── Query + jobs ──
+
+    @Test
+    void selectStarMaterializesAnonymousDestinationTable() {
+        seedTwoRows();
+        StoredJob job = service.query(PROJECT, "US", null, "SELECT * FROM ds1.t1", null);
+
+        assertEquals("DONE", job.getState());
+        assertEquals(2, job.getTotalRows());
+        assertEquals(BigQueryService.ANON_DATASET, job.getDestinationDatasetId());
+
+        BigQueryService.TableData results = service.queryResults(PROJECT, job);
+        assertEquals(2, results.rows().size());
+        assertEquals(2, results.schema().getFields().size());
+
+        // The SDK reads the same rows via tabledata.list on the destination table.
+        BigQueryService.TableData viaTableData = service.listTableData(PROJECT,
+                job.getDestinationDatasetId(), job.getDestinationTableId());
+        assertEquals(2, viaTableData.rows().size());
+    }
+
+    @Test
+    void whereProjectionAndLimitAreApplied() {
+        seedTwoRows();
+        StoredJob job = service.query(PROJECT, "US", null,
+                "SELECT name FROM ds1.t1 WHERE age = 30", null);
+        BigQueryService.TableData results = service.queryResults(PROJECT, job);
+
+        assertEquals(1, results.schema().getFields().size());
+        assertEquals("name", results.schema().getFields().get(0).getName());
+        assertEquals(1, results.rows().size());
+        assertEquals("alice", results.rows().get(0).getF().get(0).getV());
+
+        StoredJob limited = service.query(PROJECT, "US", null, "SELECT * FROM ds1.t1 LIMIT 1", null);
+        assertEquals(1, service.queryResults(PROJECT, limited).rows().size());
+    }
+
+    @Test
+    void countStarReturnsSingleIntegerRow() {
+        seedTwoRows();
+        StoredJob job = service.query(PROJECT, "US", null, "SELECT COUNT(*) FROM ds1.t1", null);
+        BigQueryService.TableData results = service.queryResults(PROJECT, job);
+        assertEquals("INTEGER", results.schema().getFields().get(0).getType());
+        assertEquals("2", results.rows().get(0).getF().get(0).getV());
+    }
+
+    @Test
+    void defaultDatasetResolvesUnqualifiedTable() {
+        seedTwoRows();
+        StoredJob job = service.query(PROJECT, "US", null, "SELECT COUNT(*) FROM t1", DATASET);
+        assertEquals("DONE", job.getState());
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.query(PROJECT, "US", null, "SELECT COUNT(*) FROM t1", null));
+        assertEquals("invalidQuery", ex.getReason());
+    }
+
+    @Test
+    void unsupportedSqlThrowsInvalidQueryReason() {
+        seedTwoRows();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.query(PROJECT, "US", null, "SELECT * FROM ds1.t1 GROUP BY name", null));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertEquals("invalidQuery", ex.getReason());
+    }
+
+    @Test
+    void missingTableThrowsNotFound() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.query(PROJECT, "US", null, "SELECT * FROM ds1.missing", null));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void failedJobIsPersistedAndQueryResultsRethrow() {
+        StoredJob job = service.failedJob(PROJECT, "US", null, "SELECT bogus",
+                QueryEngine.invalidQuery("Unrecognized name: bogus"));
+
+        StoredJob fetched = service.getJob(PROJECT, job.getJobId());
+        assertTrue(fetched.failed());
+        assertEquals("DONE", fetched.getState());
+
+        GcpException ex = assertThrows(GcpException.class, () -> service.queryResults(PROJECT, fetched));
+        assertEquals("invalidQuery", ex.getReason());
+    }
+
+    @Test
+    void deleteJobRemovesAnonymousTable() {
+        seedTwoRows();
+        StoredJob job = service.query(PROJECT, "US", null, "SELECT * FROM ds1.t1", null);
+        String anonDataset = job.getDestinationDatasetId();
+        String anonTable = job.getDestinationTableId();
+
+        service.deleteJob(PROJECT, job.getJobId());
+        assertThrows(GcpException.class, () -> service.getJob(PROJECT, job.getJobId()));
+        assertThrows(GcpException.class, () -> service.getTable(PROJECT, anonDataset, anonTable));
+    }
+
+    @Test
+    void anonymousDatasetNeverAppearsInListings() {
+        seedTwoRows();
+        service.query(PROJECT, "US", null, "SELECT * FROM ds1.t1", null);
+        assertTrue(service.listDatasets(PROJECT).stream()
+                .noneMatch(d -> BigQueryService.ANON_DATASET.equals(d.getDatasetReference().getDatasetId())));
+    }
+
+    // ── Helpers ──
+
+    private Dataset newDataset(String datasetId) {
+        Dataset d = new Dataset();
+        d.setDatasetReference(new DatasetReference(null, datasetId));
+        return d;
+    }
+
+    private Table newTable(String datasetId, String tableId) {
+        Table t = new Table();
+        t.setTableReference(new TableReference(null, datasetId, tableId));
+        t.setSchema(new TableSchema(List.of(
+                field("name", "STRING", null),
+                field("age", "INTEGER", null))));
+        return t;
+    }
+
+    private static TableFieldSchema field(String name, String type, String mode) {
+        TableFieldSchema f = new TableFieldSchema();
+        f.setName(name);
+        f.setType(type);
+        f.setMode(mode);
+        return f;
+    }
+
+    private void seedTable() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        service.createTable(PROJECT, DATASET, newTable(DATASET, TABLE));
+    }
+
+    private void seedTwoRows() {
+        seedTable();
+        insertRows(Map.of("name", "alice", "age", 30), Map.of("name", "bob", "age", 25));
+    }
+
+    @SafeVarargs
+    private List<Map<String, Object>> insertRows(Map<String, Object>... jsons) {
+        List<BigQueryService.InsertRow> rows = new java.util.ArrayList<>();
+        for (int i = 0; i < jsons.length; i++) {
+            rows.add(new BigQueryService.InsertRow(i, jsons[i]));
+        }
+        return service.insertAll(PROJECT, DATASET, TABLE, rows, false, false);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
@@ -336,6 +336,24 @@ class BigQueryServiceTest {
     }
 
     @Test
+    void duplicateExplicitJobIdConflictsEvenWhenQueryFails() {
+        seedTwoRows();
+        // First insert with an explicit ID against a missing table → stored as a failed job.
+        GcpException missing = assertThrows(GcpException.class,
+                () -> service.query(PROJECT, "US", "dup-job", "SELECT * FROM ds1.nope", null));
+        StoredJob failed = service.failedJob(PROJECT, "US", "dup-job", "SELECT * FROM ds1.nope", missing);
+        assertTrue(failed.failed());
+
+        // Re-submitting the same explicit ID must 409, not silently overwrite.
+        GcpException viaQuery = assertThrows(GcpException.class,
+                () -> service.query(PROJECT, "US", "dup-job", "SELECT * FROM ds1.t1", null));
+        assertEquals(409, viaQuery.getHttpStatus());
+        GcpException viaFailed = assertThrows(GcpException.class,
+                () -> service.failedJob(PROJECT, "US", "dup-job", "SELECT * FROM ds1.nope", missing));
+        assertEquals(409, viaFailed.getHttpStatus());
+    }
+
+    @Test
     void unsupportedSqlThrowsInvalidQueryReason() {
         seedTwoRows();
         GcpException ex = assertThrows(GcpException.class,

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
@@ -55,6 +55,35 @@ class BigQueryServiceTest {
     }
 
     @Test
+    void updateDatasetReplacesEntireResource() {
+        Dataset created = newDataset(DATASET);
+        created.setDescription("to be cleared");
+        created.setFriendlyName("old name");
+        service.createDataset(PROJECT, created);
+
+        Dataset replacement = new Dataset();
+        replacement.setFriendlyName("new name");
+        Dataset updated = service.updateDataset(PROJECT, DATASET, replacement);
+
+        assertEquals("new name", updated.getFriendlyName());
+        assertNull(updated.getDescription());
+    }
+
+    @Test
+    void patchDatasetPreservesOmittedFields() {
+        Dataset created = newDataset(DATASET);
+        created.setDescription("kept");
+        service.createDataset(PROJECT, created);
+
+        Dataset patch = new Dataset();
+        patch.setFriendlyName("patched");
+        Dataset patched = service.patchDataset(PROJECT, DATASET, patch);
+
+        assertEquals("patched", patched.getFriendlyName());
+        assertEquals("kept", patched.getDescription());
+    }
+
+    @Test
     void getDatasetMissingThrowsNotFound() {
         GcpException ex = assertThrows(GcpException.class, () -> service.getDataset(PROJECT, "nope"));
         assertEquals("NOT_FOUND", ex.getGcpStatus());

--- a/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/BigQueryServiceTest.java
@@ -153,6 +153,30 @@ class BigQueryServiceTest {
         assertEquals("duplicate", ex.getReason());
     }
 
+    @Test
+    void insertAllRejectsUnknownNestedFieldWhenNotIgnoringUnknownValues() {
+        service.createDataset(PROJECT, newDataset(DATASET));
+        TableFieldSchema sub = new TableFieldSchema();
+        sub.setName("city");
+        sub.setType("STRING");
+        TableFieldSchema address = new TableFieldSchema();
+        address.setName("address");
+        address.setType("RECORD");
+        address.setFields(java.util.List.of(sub));
+        Table table = new Table();
+        table.setTableReference(new TableReference(PROJECT, DATASET, TABLE));
+        table.setSchema(new TableSchema(java.util.List.of(address)));
+        service.createTable(PROJECT, DATASET, table);
+
+        var rows = java.util.List.of(new BigQueryService.InsertRow(0,
+                java.util.Map.of("address", java.util.Map.of("city", "SD", "zip", "00000"))));
+        var strictErrors = service.insertAll(PROJECT, DATASET, TABLE, rows, false, false);
+        assertEquals(1, strictErrors.size());
+
+        var lenientErrors = service.insertAll(PROJECT, DATASET, TABLE, rows, false, true);
+        assertEquals(0, lenientErrors.size());
+    }
+
     // ── insertAll ──
 
     @Test

--- a/src/test/java/io/floci/gcp/services/bigquery/QueryEngineTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/QueryEngineTest.java
@@ -144,6 +144,12 @@ class QueryEngineTest {
     }
 
     @Test
+    void countStarRespectsLimitZero() {
+        QueryEngine.Result result = evaluate("SELECT COUNT(*) FROM t LIMIT 0");
+        assertEquals(0, result.rows().size());
+    }
+
+    @Test
     void nullStoredValuesNeverMatch() {
         List<Map<String, Object>> rows = List.of(row(null, null, null, null, null));
         QueryEngine.ParsedQuery query = QueryEngine.parse("SELECT * FROM t WHERE age = 1");

--- a/src/test/java/io/floci/gcp/services/bigquery/QueryEngineTest.java
+++ b/src/test/java/io/floci/gcp/services/bigquery/QueryEngineTest.java
@@ -1,0 +1,177 @@
+package io.floci.gcp.services.bigquery;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.services.bigquery.model.TableFieldSchema;
+import io.floci.gcp.services.bigquery.model.TableSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryEngineTest {
+
+    private static final TableSchema SCHEMA = new TableSchema(List.of(
+            field("name", "STRING", "NULLABLE"),
+            field("age", "INTEGER", "NULLABLE"),
+            field("score", "FLOAT", "NULLABLE"),
+            field("active", "BOOLEAN", "NULLABLE"),
+            field("tags", "STRING", "REPEATED")));
+
+    private static final List<Map<String, Object>> ROWS = List.of(
+            row("alice", 30L, 9.5, true, List.of("a")),
+            row("bob", 25L, 7.0, false, List.of()),
+            row("carol", 30L, 8.25, true, List.of("b", "c")));
+
+    // ── Parsing: supported grammar ──
+
+    @Test
+    void parsesSelectStarWithTableRefVariants() {
+        assertEquals(new QueryEngine.TableRef(null, null, "t"),
+                QueryEngine.parse("SELECT * FROM t").table());
+        assertEquals(new QueryEngine.TableRef(null, "d", "t"),
+                QueryEngine.parse("select * from d.t;").table());
+        assertEquals(new QueryEngine.TableRef("p", "d", "t"),
+                QueryEngine.parse("SELECT * FROM p.d.t").table());
+        assertEquals(new QueryEngine.TableRef("p", "d", "t"),
+                QueryEngine.parse("SELECT * FROM `p.d.t`").table());
+        assertEquals(new QueryEngine.TableRef("p", "d", "t"),
+                QueryEngine.parse("SELECT * FROM `p`.`d`.`t`").table());
+    }
+
+    @Test
+    void parsesColumnsCountWhereAndLimit() {
+        QueryEngine.ParsedQuery columns = QueryEngine.parse("SELECT name, age FROM d.t");
+        assertEquals(QueryEngine.Kind.COLUMNS, columns.kind());
+        assertEquals(List.of("name", "age"), columns.columns());
+
+        QueryEngine.ParsedQuery count = QueryEngine.parse("SELECT COUNT(*) FROM d.t");
+        assertEquals(QueryEngine.Kind.COUNT_STAR, count.kind());
+
+        QueryEngine.ParsedQuery filtered = QueryEngine.parse(
+                "SELECT * FROM d.t WHERE name = 'alice' AND age = 30 AND active = TRUE LIMIT 5");
+        assertEquals(3, filtered.conditions().size());
+        assertEquals("alice", filtered.conditions().get(0).literal());
+        assertEquals(30L, filtered.conditions().get(1).literal());
+        assertEquals(Boolean.TRUE, filtered.conditions().get(2).literal());
+        assertEquals(5, filtered.limit());
+    }
+
+    @Test
+    void parsesLiteralShapes() {
+        assertEquals(-3L, QueryEngine.parse("SELECT * FROM t WHERE a = -3").conditions().get(0).literal());
+        assertEquals(2.5, QueryEngine.parse("SELECT * FROM t WHERE a = 2.5").conditions().get(0).literal());
+        assertEquals("it's", QueryEngine.parse("SELECT * FROM t WHERE a = 'it\\'s'").conditions().get(0).literal());
+        assertEquals("x", QueryEngine.parse("SELECT * FROM t WHERE a = \"x\"").conditions().get(0).literal());
+    }
+
+    // ── Parsing: rejections with invalidQuery ──
+
+    @Test
+    void rejectsUnsupportedConstructs() {
+        for (String sql : List.of(
+                "SELECT * FROM a JOIN b ON a.id = b.id",
+                "SELECT * FROM t GROUP BY name",
+                "SELECT * FROM t ORDER BY name",
+                "SELECT * FROM t WHERE a = 1 OR b = 2",
+                "SELECT * FROM t WHERE a != 1",
+                "SELECT * FROM t WHERE a < 1",
+                "SELECT MAX(age) FROM t",
+                "SELECT name AS n FROM t",
+                "SELECT * FROM (SELECT * FROM t)",
+                "SELECT * FROM t WHERE a = NULL",
+                "INSERT INTO t VALUES (1)",
+                "DELETE FROM t",
+                "")) {
+            GcpException ex = assertThrows(GcpException.class, () -> QueryEngine.parse(sql), sql);
+            assertEquals("INVALID_ARGUMENT", ex.getGcpStatus(), sql);
+            if (!sql.isEmpty()) {
+                assertEquals("invalidQuery", ex.getReason(), sql);
+            }
+        }
+    }
+
+    // ── Evaluation ──
+
+    @Test
+    void evaluatesTypedEqualityAcrossTypes() {
+        assertEquals(2, evaluate("SELECT * FROM t WHERE age = 30").rows().size());
+        assertEquals(1, evaluate("SELECT * FROM t WHERE score = 7.0").rows().size());
+        assertEquals(2, evaluate("SELECT * FROM t WHERE active = TRUE").rows().size());
+        assertEquals(1, evaluate("SELECT * FROM t WHERE name = 'bob'").rows().size());
+        assertEquals(1, evaluate("SELECT * FROM t WHERE age = 30 AND name = 'carol'").rows().size());
+        assertEquals(0, evaluate("SELECT * FROM t WHERE age = 99").rows().size());
+    }
+
+    @Test
+    void integerColumnAcceptsIntegerLiteralOnly() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> evaluate("SELECT * FROM t WHERE age = 'thirty'"));
+        assertEquals("invalidQuery", ex.getReason());
+        assertTrue(ex.getMessage().contains("No matching signature"));
+    }
+
+    @Test
+    void unknownColumnRejected() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> evaluate("SELECT bogus FROM t"));
+        assertTrue(ex.getMessage().contains("Unrecognized name: bogus"));
+    }
+
+    @Test
+    void filteringOnRepeatedColumnRejected() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> evaluate("SELECT * FROM t WHERE tags = 'a'"));
+        assertEquals("invalidQuery", ex.getReason());
+    }
+
+    @Test
+    void projectionIsCaseInsensitiveAndOrdered() {
+        QueryEngine.Result result = evaluate("SELECT AGE, Name FROM t LIMIT 2");
+        assertEquals(List.of("age", "name"),
+                result.schema().getFields().stream().map(TableFieldSchema::getName).toList());
+        assertEquals(2, result.rows().size());
+        assertEquals(30L, result.rows().get(0).get("age"));
+    }
+
+    @Test
+    void countStarCountsFilteredRows() {
+        QueryEngine.Result result = evaluate("SELECT COUNT(*) FROM t WHERE active = TRUE");
+        assertEquals("f0_", result.schema().getFields().get(0).getName());
+        assertEquals(2L, result.rows().get(0).get("f0_"));
+    }
+
+    @Test
+    void nullStoredValuesNeverMatch() {
+        List<Map<String, Object>> rows = List.of(row(null, null, null, null, null));
+        QueryEngine.ParsedQuery query = QueryEngine.parse("SELECT * FROM t WHERE age = 1");
+        assertEquals(0, QueryEngine.evaluate(query, SCHEMA, rows).rows().size());
+    }
+
+    // ── Helpers ──
+
+    private static QueryEngine.Result evaluate(String sql) {
+        return QueryEngine.evaluate(QueryEngine.parse(sql), SCHEMA, ROWS);
+    }
+
+    private static TableFieldSchema field(String name, String type, String mode) {
+        TableFieldSchema f = new TableFieldSchema();
+        f.setName(name);
+        f.setType(type);
+        f.setMode(mode);
+        return f;
+    }
+
+    private static Map<String, Object> row(String name, Long age, Double score, Boolean active,
+                                           List<String> tags) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("name", name);
+        row.put("age", age);
+        row.put("score", score);
+        row.put("active", active);
+        row.put("tags", tags);
+        return row;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -42,6 +42,8 @@ floci-gcp:
       tick-interval-seconds: 1
     eventarc:
       enabled: true
+    bigquery:
+      enabled: true
     gke:
       enabled: true
       mock: true


### PR DESCRIPTION
## Summary

Phase 1 of BigQuery (#40): the v2 REST surface —

- Dataset and table CRUD with schema normalization
- Schema-validated `tabledata.insertAll` + `tabledata.list` via a `RowCodec`
- Query jobs (`jobs.query`, `jobs.insert`, `jobs.get`, `getQueryResults`) over a practical SQL subset (`SELECT *`/columns/`COUNT(*)`, `WHERE` equality, `LIMIT`, projection)
- BigQuery reason-coded `ErrorProto` errors and anonymous destination tables

The Storage gRPC API and broader SQL support remain tracked in #40 for later phases.

Refs #40

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Grounded in the BigQuery v2 discovery document (`local/google/discovery/bigquery-v2.json`) — the v2 API is discovery-based, there is no proto for this surface. Verified with the Java SDK (`google-cloud-bigquery`) in `sdk-test-java/BigQueryTest`, plus unit and REST integration coverage (`BigQueryServiceTest`, `QueryEngineTest`, `BigQueryRestIntegrationTest`). Wire-format details — row `f`/`v` encoding, reason-coded errors, job state transitions — match the discovery schemas.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)