### PR TITLE
feat(gcs): enforce downscoped token access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Both gRPC and REST are served on port **4588** via ALPN negotiation:
 
 ### Auth bypass
 
-GCP SDKs skip credential checks when `*_EMULATOR_HOST` environment variables are set. floci-gcp does not validate credentials; it accepts all requests unconditionally.
+GCP SDKs skip credential checks when `*_EMULATOR_HOST` environment variables are set. floci-gcp does not cryptographically validate credentials: requests with no credential, external credentials, and emulator-issued OAuth or impersonated tokens are accepted. The exception is an emulator-issued downscoped token, whose GCS requests are evaluated against its Credential Access Boundary (CAB).
 
 ### Project ID as multi-tenancy key
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export FIREBASE_AUTH_EMULATOR_HOST=localhost:4588
 export GOOGLE_CLOUD_PROJECT=floci-local
 ```
 
-All GCP services are available at `http://localhost:4588`. Credentials are not validated.
+All GCP services are available at `http://localhost:4588`. Credentials are not cryptographically validated. The exception is a Floci-issued downscoped token, whose GCS requests are evaluated against its Credential Access Boundary (CAB).
 
 <details>
 <summary>Using Docker directly?</summary>

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -2,6 +2,7 @@ package io.floci.gcp.test;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
@@ -65,6 +66,15 @@ public final class TestFixtures {
                 .build()
                 .getService();
     }
+
+	public static Storage storageClient(Credentials credentials) {
+		return StorageOptions.newBuilder()
+				.setHost(endpoint())
+				.setProjectId(projectId())
+				.setCredentials(credentials)
+				.build()
+				.getService();
+	}
 
     /**
      * Creates a Firestore client pointing at the emulator.

--- a/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/io/floci/gcp/test/TestFixtures.java
@@ -3,6 +3,7 @@ package io.floci.gcp.test;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
@@ -34,6 +35,10 @@ import com.google.api.services.sqladmin.SQLAdmin;
 
 import java.io.IOException;
 import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.List;
 import java.util.UUID;
 
 public final class TestFixtures {
@@ -51,6 +56,20 @@ public final class TestFixtures {
 
     public static String uniqueName(String prefix) {
         return prefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    public static ServiceAccountCredentials serviceAccountCredentials() throws GeneralSecurityException {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        return ServiceAccountCredentials.newBuilder()
+                .setClientId("123456789")
+                .setClientEmail("storage-test@test-project.iam.gserviceaccount.com")
+                .setPrivateKey(keyPair.getPrivate())
+                .setPrivateKeyId("test-key")
+                .setScopes(List.of("https://www.googleapis.com/auth/cloud-platform"))
+                .setTokenServerUri(URI.create(endpoint() + "/token"))
+                .build();
     }
 
     /**

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsDownscopedTokenTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsDownscopedTokenTest.java
@@ -1,0 +1,134 @@
+package io.floci.gcp.test;
+
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.CredentialAccessBoundary;
+import com.google.auth.oauth2.DownscopedCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GcsDownscopedTokenTest {
+
+	@Test
+	void storageClientEnforcesDownscopedTokenPrefix() throws Exception {
+		String bucket = TestFixtures.uniqueName("downscoped-bucket");
+		try (Storage setup = TestFixtures.storageClient()) {
+			setup.create(BucketInfo.of(bucket));
+		}
+
+		AccessToken accessToken = downscopedAccessToken(bucket);
+		try (Storage scoped = TestFixtures.storageClient(OAuth2Credentials.create(accessToken))) {
+			BlobId allowed = BlobId.of(bucket, "allowed/file.txt");
+			scoped.create(BlobInfo.newBuilder(allowed).build(), "allowed".getBytes(StandardCharsets.UTF_8));
+
+			assertThat(new String(scoped.readAllBytes(allowed), StandardCharsets.UTF_8)).isEqualTo("allowed");
+			assertThat(scoped.list(bucket, Storage.BlobListOption.prefix("allowed/")).iterateAll())
+					.extracting(blob -> blob.getName())
+					.contains("allowed/file.txt");
+
+				assertThatThrownBy(() -> scoped.create(
+						BlobInfo.newBuilder(BlobId.of(bucket, "allowed_sibling/file.txt")).build(),
+						"denied".getBytes(StandardCharsets.UTF_8)))
+						.isInstanceOfSatisfying(StorageException.class,
+								exception -> assertThat(exception.getCode()).isEqualTo(403));
+				assertThatThrownBy(() -> scoped.readAllBytes(BlobId.of(bucket, "allowed_sibling/file.txt")))
+						.isInstanceOfSatisfying(StorageException.class,
+								exception -> assertThat(exception.getCode()).isEqualTo(403));
+				assertThatThrownBy(() -> scoped.list(bucket, Storage.BlobListOption.prefix("allowed_sibling/"))
+						.iterateAll().iterator().hasNext())
+						.isInstanceOfSatisfying(StorageException.class,
+								exception -> assertThat(exception.getCode()).isEqualTo(403));
+
+			assertThat(scoped.delete(allowed)).isTrue();
+		}
+	}
+
+	@Test
+	void storageClientAllowsWholeBucketRuleWithoutListPrefix() throws Exception {
+		String bucket = TestFixtures.uniqueName("downscoped-whole-bucket");
+		BlobId first = BlobId.of(bucket, "first.txt");
+		BlobId second = BlobId.of(bucket, "nested/second.txt");
+		try (Storage setup = TestFixtures.storageClient()) {
+			setup.create(BucketInfo.of(bucket));
+			setup.create(BlobInfo.newBuilder(first).build(), "first".getBytes(StandardCharsets.UTF_8));
+			setup.create(BlobInfo.newBuilder(second).build(), "second".getBytes(StandardCharsets.UTF_8));
+		}
+
+		CredentialAccessBoundary cab = CredentialAccessBoundary.newBuilder()
+				.addRule(CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+						.setAvailableResource("//storage.googleapis.com/projects/_/buckets/" + bucket)
+						.setAvailablePermissions(List.of("inRole:roles/storage.objectViewer"))
+						.build())
+				.build();
+		try (Storage scoped = TestFixtures.storageClient(
+				OAuth2Credentials.create(exchangeAccessToken(cab)))) {
+			assertThat(scoped.list(bucket).iterateAll())
+					.extracting(blob -> blob.getName())
+					.containsExactlyInAnyOrder("first.txt", "nested/second.txt");
+			assertThat(new String(scoped.readAllBytes(second), StandardCharsets.UTF_8)).isEqualTo("second");
+		}
+	}
+
+	private static AccessToken downscopedAccessToken(String bucket) throws Exception {
+		CredentialAccessBoundary cab = CredentialAccessBoundary.newBuilder()
+				.addRule(CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+						.setAvailableResource("//storage.googleapis.com/projects/_/buckets/" + bucket)
+						.setAvailablePermissions(List.of(
+								"inRole:roles/storage.legacyObjectReader",
+								"inRole:roles/storage.objectViewer",
+								"inRole:roles/storage.legacyBucketWriter"))
+						.setAvailabilityCondition(
+								CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
+										.setExpression("resource.name.startsWith("
+												+ "'projects/_/buckets/" + bucket + "/objects/allowed/')"
+												+ " || api.getAttribute("
+												+ "'storage.googleapis.com/objectListPrefix', '').startsWith("
+												+ "'allowed/')")
+										.build())
+						.build())
+				.build();
+
+		return exchangeAccessToken(cab);
+	}
+
+	private static AccessToken exchangeAccessToken(CredentialAccessBoundary cab) throws Exception {
+		GoogleCredentials sourceCredentials = GoogleCredentials.create(new AccessToken(
+				"source-token",
+				Date.from(Instant.now().plusSeconds(3600))));
+		DownscopedCredentials credentials = DownscopedCredentials.newBuilder()
+				.setSourceCredential(sourceCredentials)
+				.setCredentialAccessBoundary(cab)
+				.setHttpTransportFactory(stsTransportFactory())
+				.build();
+		return credentials.refreshAccessToken();
+	}
+
+	private static HttpTransportFactory stsTransportFactory() {
+		return () -> new NetHttpTransport.Builder()
+				.setConnectionFactory(url -> {
+					if ("sts.googleapis.com".equals(url.getHost())) {
+						URL rewritten = new URL(TestFixtures.endpoint() + url.getFile());
+						return (HttpURLConnection) rewritten.openConnection();
+					}
+					return (HttpURLConnection) url.openConnection();
+				})
+				.build();
+	}
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsServiceAccountAuthenticationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsServiceAccountAuthenticationTest.java
@@ -1,15 +1,9 @@
 package io.floci.gcp.test;
 
-import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.junit.jupiter.api.Test;
-
-import java.net.URI;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,18 +11,7 @@ class GcsServiceAccountAuthenticationTest {
 
     @Test
     void serviceAccountCredentialsAuthenticateStorageRequests() throws Exception {
-        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-        generator.initialize(2048);
-        KeyPair keyPair = generator.generateKeyPair();
-
-        ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
-                .setClientId("123456789")
-                .setClientEmail("storage-test@test-project.iam.gserviceaccount.com")
-                .setPrivateKey(keyPair.getPrivate())
-                .setPrivateKeyId("test-key")
-                .setScopes(List.of("https://www.googleapis.com/auth/cloud-platform"))
-                .setTokenServerUri(URI.create(TestFixtures.endpoint() + "/token"))
-                .build();
+        var credentials = TestFixtures.serviceAccountCredentials();
 
         String bucketName = TestFixtures.uniqueName("service-account-auth");
         try (Storage storage = StorageOptions.newBuilder()

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/StsTokenExchangeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/StsTokenExchangeTest.java
@@ -45,6 +45,27 @@ class StsTokenExchangeTest {
 		assertCanExchange(cab);
 	}
 
+	@Test
+	void downscopedCredentialsExchangeServiceAccountSourceToken() throws Exception {
+		var sourceCredentials = TestFixtures.serviceAccountCredentials();
+		CredentialAccessBoundary cab = CredentialAccessBoundary.newBuilder()
+				.addRule(CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+						.setAvailableResource("//storage.googleapis.com/projects/_/buckets/compat-bucket")
+						.setAvailablePermissions(List.of("inRole:roles/storage.objectViewer"))
+						.build())
+				.build();
+		DownscopedCredentials credentials = DownscopedCredentials.newBuilder()
+				.setSourceCredential(sourceCredentials)
+				.setCredentialAccessBoundary(cab)
+				.setHttpTransportFactory(stsTransportFactory())
+				.build();
+
+		AccessToken accessToken = credentials.refreshAccessToken();
+
+		assertThat(accessToken.getTokenValue()).startsWith("floci-gcp-downscoped-");
+		assertThat(accessToken.getExpirationTime()).isAfter(Date.from(Instant.now()));
+	}
+
 	private static void assertCanExchange(CredentialAccessBoundary cab) throws Exception {
 		GoogleCredentials sourceCredentials = GoogleCredentials.create(new AccessToken(
 				"source-token",

--- a/docs/getting-started/gcp-setup.md
+++ b/docs/getting-started/gcp-setup.md
@@ -1,6 +1,6 @@
 # GCP CLI & SDK Setup
 
-floci-gcp accepts all requests unconditionally — no real GCP credentials are needed. GCP SDKs automatically skip credential validation when `*_EMULATOR_HOST` environment variables are set.
+floci-gcp does not require real GCP credentials, and GCP SDKs automatically skip credential validation when `*_EMULATOR_HOST` environment variables are set. Requests with no credential, external credentials, and Floci-issued OAuth or impersonated tokens are accepted. The exception is a Floci-issued downscoped token, whose GCS requests are evaluated against its Credential Access Boundary (CAB).
 
 ## Environment Variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ export SECRET_MANAGER_EMULATOR_HOST=localhost:4588
 export GOOGLE_CLOUD_PROJECT=floci-local
 ```
 
-All GCP services are immediately available at `http://localhost:4588`. Credentials are not validated.
+All GCP services are immediately available at `http://localhost:4588`. Credentials are not cryptographically validated. The exception is a Floci-issued downscoped token, whose GCS requests are evaluated against its Credential Access Boundary (CAB).
 
 [Get started →](getting-started/quick-start.md){ .md-button .md-button--primary }
 [View services →](services/index.md){ .md-button }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -61,7 +61,7 @@ gcloud config set project floci-local
 
 ## Auth Bypass
 
-floci-gcp does not validate credentials. All requests are accepted unconditionally. This matches the behavior of GCP official emulators when `*_EMULATOR_HOST` is set.
+floci-gcp does not cryptographically validate credentials. Requests with no credential, external credentials, and Floci-issued OAuth or impersonated tokens are accepted. The exception is a Floci-issued downscoped token, whose GCS requests are evaluated against its Credential Access Boundary (CAB). This otherwise matches the behavior of GCP official emulators when `*_EMULATOR_HOST` is set.
 
 ## Multi-Project Isolation
 

--- a/docs/services/sts.md
+++ b/docs/services/sts.md
@@ -49,8 +49,8 @@ prefix.
 
 Tokens exchanged from arbitrary external source credentials have a one-hour
 lifetime. When the source is an unexpired impersonated or downscoped token
-issued by floci-gcp, the new token cannot outlive that source token. Unknown or
-expired floci-gcp source tokens are rejected with `invalid_grant`.
+issued by floci-gcp, the new token inherits that source token's expiration time.
+Unknown or expired floci-gcp source tokens are rejected with `invalid_grant`.
 
 ## Scope and deviations
 

--- a/docs/services/sts.md
+++ b/docs/services/sts.md
@@ -59,3 +59,7 @@ Unknown or expired floci-gcp source tokens are rejected with `invalid_grant`.
   subset is accepted.
 - Non-floci source credentials are not validated, matching the emulator's
   general credential-bypass behavior.
+- A downscoped token minted by floci-gcp is enforced only for GCS requests:
+  the request must match one of the token's CAB rules. Other credentials,
+  including Floci-issued OAuth and impersonated tokens, remain accepted without
+  credential validation.

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
@@ -90,7 +90,9 @@ public class CredentialTokenService {
 	}
 
 	private Optional<StoredCredentialToken> lookupBearerToken(String bearerToken, Instant now) {
-		if (bearerToken == null || bearerToken.isBlank() || !bearerToken.startsWith(FLOCI_TOKEN_PREFIX)) {
+		if (bearerToken == null || bearerToken.isBlank()
+				|| (!bearerToken.startsWith(IMPERSONATED_TOKEN_PREFIX)
+						&& !bearerToken.startsWith(DOWNSCOPED_TOKEN_PREFIX))) {
 			return Optional.empty();
 		}
 

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
@@ -68,11 +68,10 @@ public class CredentialTokenService {
 		}
 
 		Instant now = clock.instant();
-		Instant expireTime = now.plusSeconds(DEFAULT_LIFETIME_SECONDS);
 		Optional<StoredCredentialToken> storedSource = lookupBearerToken(sourceToken, now);
-		if (storedSource.isPresent() && storedSource.get().getExpireTime().isBefore(expireTime)) {
-			expireTime = storedSource.get().getExpireTime();
-		}
+		Instant expireTime = storedSource
+				.map(StoredCredentialToken::getExpireTime)
+				.orElseGet(() -> now.plusSeconds(DEFAULT_LIFETIME_SECONDS));
 
 		String tokenValue = DOWNSCOPED_TOKEN_PREFIX + UUID.randomUUID();
 		StoredCredentialToken token = new StoredCredentialToken(

--- a/src/main/java/io/floci/gcp/services/credentials/GcsAuthorizationService.java
+++ b/src/main/java/io/floci/gcp/services/credentials/GcsAuthorizationService.java
@@ -58,7 +58,7 @@ public class GcsAuthorizationService {
 
 	public boolean isBypassed(String authorization) {
 		return bearerToken(authorization)
-				.map(token -> !token.startsWith(CredentialTokenService.FLOCI_TOKEN_PREFIX))
+				.map(token -> !token.startsWith(CredentialTokenService.DOWNSCOPED_TOKEN_PREFIX))
 				.orElse(true);
 	}
 

--- a/src/main/java/io/floci/gcp/services/credentials/GcsAuthorizationService.java
+++ b/src/main/java/io/floci/gcp/services/credentials/GcsAuthorizationService.java
@@ -1,0 +1,124 @@
+package io.floci.gcp.services.credentials;
+
+import io.floci.gcp.core.common.GcpException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@ApplicationScoped
+public class GcsAuthorizationService {
+
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	private final CredentialTokenService tokenService;
+
+	@Inject
+	public GcsAuthorizationService(CredentialTokenService tokenService) {
+		this.tokenService = tokenService;
+	}
+
+	public void requireObjectRead(String authorization, String bucket, String objectName) {
+		lookupDownscopedToken(authorization)
+				.ifPresent(token -> requireMatchingRule(token, bucket, objectName,
+						List.of(CredentialAccessBoundaryParser.LEGACY_OBJECT_READER,
+								CredentialAccessBoundaryParser.OBJECT_VIEWER)));
+	}
+
+	public void requireObjectWrite(String authorization, String bucket, String objectName) {
+		lookupDownscopedToken(authorization)
+				.ifPresent(token -> requireMatchingRule(token, bucket, objectName,
+						List.of(CredentialAccessBoundaryParser.LEGACY_BUCKET_WRITER)));
+	}
+
+	public void requireObjectDelete(String authorization, String bucket, String objectName) {
+		requireObjectWrite(authorization, bucket, objectName);
+	}
+
+	public void requireObjectList(String authorization, String bucket, String prefix) {
+		lookupDownscopedToken(authorization)
+				.ifPresent(token -> requireMatchingPrefix(token, bucket, prefix == null ? "" : prefix,
+						List.of(CredentialAccessBoundaryParser.OBJECT_VIEWER,
+								CredentialAccessBoundaryParser.LEGACY_BUCKET_WRITER)));
+	}
+
+	public void requireSourceReadAndDestinationWrite(String authorization, String srcBucket, String srcObject,
+			String dstBucket, String dstObject) {
+		requireObjectRead(authorization, srcBucket, srcObject);
+		requireObjectWrite(authorization, dstBucket, dstObject);
+	}
+
+	public void rejectDownscopedToken(String authorization) {
+		lookupDownscopedToken(authorization).ifPresent(token -> {
+			throw permissionDenied();
+		});
+	}
+
+	public boolean isBypassed(String authorization) {
+		return bearerToken(authorization)
+				.map(token -> !token.startsWith(CredentialTokenService.FLOCI_TOKEN_PREFIX))
+				.orElse(true);
+	}
+
+	private Optional<StoredCredentialToken> lookupDownscopedToken(String authorization) {
+		Optional<String> bearerToken = bearerToken(authorization);
+		if (bearerToken.isEmpty()) {
+			return Optional.empty();
+		}
+		Optional<StoredCredentialToken> token = tokenService.lookupBearerToken(bearerToken.get());
+		if (token.isEmpty() || token.get().getTokenKind() != StoredCredentialToken.TokenKind.DOWNSCOPED) {
+			return Optional.empty();
+		}
+		return token;
+	}
+
+	private static Optional<String> bearerToken(String authorization) {
+		if (authorization == null || authorization.isBlank()
+				|| !authorization.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+			return Optional.empty();
+		}
+		String token = authorization.substring(BEARER_PREFIX.length()).trim();
+		return token.isEmpty() ? Optional.empty() : Optional.of(token);
+	}
+
+	private static void requireMatchingRule(StoredCredentialToken token, String bucket, String objectName,
+			List<String> acceptedPermissions) {
+		if (token.getGcsRules().stream()
+				.anyMatch(rule -> matchesObject(rule, bucket, objectName)
+						&& hasAnyPermission(rule, acceptedPermissions))) {
+			return;
+		}
+		throw permissionDenied();
+	}
+
+	private static void requireMatchingPrefix(StoredCredentialToken token, String bucket, String prefix,
+			List<String> acceptedPermissions) {
+		if (token.getGcsRules().stream()
+				.anyMatch(rule -> bucket.equals(rule.getBucket())
+						&& prefix.startsWith(rule.getObjectPrefix())
+						&& hasAnyPermission(rule, acceptedPermissions))) {
+			return;
+		}
+		throw permissionDenied();
+	}
+
+	private static boolean matchesObject(CredentialAccessBoundaryRule rule, String bucket, String objectName) {
+		return bucket.equals(rule.getBucket())
+				&& objectName != null
+				&& objectName.startsWith(rule.getObjectPrefix());
+	}
+
+	private static boolean hasAnyPermission(CredentialAccessBoundaryRule rule, List<String> acceptedPermissions) {
+		return rule.getAvailablePermissions().stream()
+				.map(permission -> permission.toLowerCase(Locale.ROOT))
+				.anyMatch(permission -> acceptedPermissions.stream()
+						.map(p -> p.toLowerCase(Locale.ROOT))
+						.anyMatch(permission::equals));
+	}
+
+	private static GcpException permissionDenied() {
+		return GcpException.permissionDenied("Downscoped token does not allow this GCS operation");
+	}
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
@@ -4,8 +4,10 @@ import io.floci.gcp.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
@@ -41,32 +43,34 @@ public class GcsBatchController {
                 .build();
     }
 
-    @POST
-    @Consumes(MediaType.WILDCARD)
-    @Produces(MediaType.WILDCARD)
-    public Response batch(@HeaderParam("Content-Type") String contentType, byte[] body) {
-        String boundary = extractBoundary(contentType);
-        if (boundary == null) {
-            return Response.status(400).entity("Missing multipart boundary").build();
-        }
+	@POST
+	@Consumes(MediaType.WILDCARD)
+	@Produces(MediaType.WILDCARD)
+	public Response batch(@HeaderParam("Content-Type") String contentType,
+			@HeaderParam("Authorization") String authorization,
+			@Context UriInfo uriInfo, byte[] body) {
+		String boundary = extractBoundary(contentType);
+		if (boundary == null) {
+			return Response.status(400).entity("Missing multipart boundary").build();
+		}
 
-        List<SubRequest> subRequests = parseMultipart(boundary, body);
-        LOG.debugf("batch: parsed %d sub-requests", subRequests.size());
+		List<SubRequest> subRequests = parseMultipart(boundary, body);
+		LOG.debugf("batch: parsed %d sub-requests", subRequests.size());
 
-        String responseBoundary = "batch_" + UUID.randomUUID().toString().replace("-", "");
-        StringBuilder responseBody = new StringBuilder();
+		String responseBoundary = "batch_" + UUID.randomUUID().toString().replace("-", "");
+		StringBuilder responseBody = new StringBuilder();
 
-        for (int i = 0; i < subRequests.size(); i++) {
-            SubRequest req = subRequests.get(i);
-            SubResponse resp = dispatch(req);
-            appendResponsePart(responseBody, responseBoundary, i, req.contentId(), resp);
-        }
-        responseBody.append("--").append(responseBoundary).append("--\r\n");
+		for (int i = 0; i < subRequests.size(); i++) {
+			SubRequest req = subRequests.get(i);
+			SubResponse resp = dispatch(req, authorization, requestPort(uriInfo));
+			appendResponsePart(responseBody, responseBoundary, i, req.contentId(), resp);
+		}
+		responseBody.append("--").append(responseBoundary).append("--\r\n");
 
-        return Response.ok(responseBody.toString())
-                .type("multipart/mixed; boundary=" + responseBoundary)
-                .build();
-    }
+		return Response.ok(responseBody.toString())
+				.type("multipart/mixed; boundary=" + responseBoundary)
+				.build();
+	}
 
     private String extractBoundary(String contentType) {
         if (contentType == null) return null;
@@ -169,9 +173,16 @@ public class GcsBatchController {
         return new SubRequest(method, pathAndQuery, headers, requestBody, contentId);
     }
 
-    private SubResponse dispatch(SubRequest req) {
+    private int requestPort(UriInfo uriInfo) {
+        if (uriInfo != null && uriInfo.getBaseUri() != null && uriInfo.getBaseUri().getPort() > 0) {
+            return uriInfo.getBaseUri().getPort();
+        }
+        return config.port();
+    }
+
+    private SubResponse dispatch(SubRequest req, String outerAuthorization, int port) {
         try {
-            URI uri = rewriteToLocalhost(URI.create(req.path()));
+            URI uri = rewriteToLocalhost(URI.create(req.path()), port);
 
             HttpRequest.BodyPublisher bodyPublisher = req.body().isEmpty()
                     ? HttpRequest.BodyPublishers.noBody()
@@ -192,6 +203,10 @@ public class GcsBatchController {
                     }
                 }
             });
+			if (outerAuthorization != null && req.headers().keySet().stream()
+					.noneMatch(header -> header.equalsIgnoreCase("Authorization"))) {
+				builder.header("Authorization", outerAuthorization);
+			}
             if (!req.body().isEmpty() && !req.headers().containsKey("Content-Type")) {
                 builder.header("Content-Type", "application/json");
             }
@@ -206,11 +221,11 @@ public class GcsBatchController {
             return new SubResponse(500,
                     "{\"error\":{\"code\":500,\"message\":\"Internal batch error\"}}");
         }
-    }
+        }
 
-    private URI rewriteToLocalhost(URI original) {
+    private URI rewriteToLocalhost(URI original, int port) {
         String query = original.getRawQuery() == null ? "" : "?" + original.getRawQuery();
-        return URI.create("http://localhost:" + config.port() + original.getRawPath() + query);
+        return URI.create("http://localhost:" + port + original.getRawPath() + query);
     }
 
     private void appendResponsePart(StringBuilder sb, String boundary, int index,

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
@@ -43,34 +43,34 @@ public class GcsBatchController {
                 .build();
     }
 
-	@POST
-	@Consumes(MediaType.WILDCARD)
-	@Produces(MediaType.WILDCARD)
-	public Response batch(@HeaderParam("Content-Type") String contentType,
-			@HeaderParam("Authorization") String authorization,
-			@Context UriInfo uriInfo, byte[] body) {
-		String boundary = extractBoundary(contentType);
-		if (boundary == null) {
-			return Response.status(400).entity("Missing multipart boundary").build();
-		}
+    @POST
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.WILDCARD)
+    public Response batch(@HeaderParam("Content-Type") String contentType,
+            @HeaderParam("Authorization") String authorization,
+            @Context UriInfo uriInfo, byte[] body) {
+        String boundary = extractBoundary(contentType);
+        if (boundary == null) {
+            return Response.status(400).entity("Missing multipart boundary").build();
+        }
 
-		List<SubRequest> subRequests = parseMultipart(boundary, body);
-		LOG.debugf("batch: parsed %d sub-requests", subRequests.size());
+        List<SubRequest> subRequests = parseMultipart(boundary, body);
+        LOG.debugf("batch: parsed %d sub-requests", subRequests.size());
 
-		String responseBoundary = "batch_" + UUID.randomUUID().toString().replace("-", "");
-		StringBuilder responseBody = new StringBuilder();
+        String responseBoundary = "batch_" + UUID.randomUUID().toString().replace("-", "");
+        StringBuilder responseBody = new StringBuilder();
 
-		for (int i = 0; i < subRequests.size(); i++) {
-			SubRequest req = subRequests.get(i);
-			SubResponse resp = dispatch(req, authorization, requestPort(uriInfo));
-			appendResponsePart(responseBody, responseBoundary, i, req.contentId(), resp);
-		}
-		responseBody.append("--").append(responseBoundary).append("--\r\n");
+        for (int i = 0; i < subRequests.size(); i++) {
+            SubRequest req = subRequests.get(i);
+            SubResponse resp = dispatch(req, authorization, requestPort(uriInfo));
+            appendResponsePart(responseBody, responseBoundary, i, req.contentId(), resp);
+        }
+        responseBody.append("--").append(responseBoundary).append("--\r\n");
 
-		return Response.ok(responseBody.toString())
-				.type("multipart/mixed; boundary=" + responseBoundary)
-				.build();
-	}
+        return Response.ok(responseBody.toString())
+                .type("multipart/mixed; boundary=" + responseBoundary)
+                .build();
+    }
 
     private String extractBoundary(String contentType) {
         if (contentType == null) return null;
@@ -203,10 +203,10 @@ public class GcsBatchController {
                     }
                 }
             });
-			if (outerAuthorization != null && req.headers().keySet().stream()
-					.noneMatch(header -> header.equalsIgnoreCase("Authorization"))) {
-				builder.header("Authorization", outerAuthorization);
-			}
+            if (outerAuthorization != null && req.headers().keySet().stream()
+                    .noneMatch(header -> header.equalsIgnoreCase("Authorization"))) {
+                builder.header("Authorization", outerAuthorization);
+            }
             if (!req.body().isEmpty() && !req.headers().containsKey("Content-Type")) {
                 builder.header("Content-Type", "application/json");
             }
@@ -221,7 +221,7 @@ public class GcsBatchController {
             return new SubResponse(500,
                     "{\"error\":{\"code\":500,\"message\":\"Internal batch error\"}}");
         }
-        }
+    }
 
     private URI rewriteToLocalhost(URI original, int port) {
         String query = original.getRawQuery() == null ? "" : "?" + original.getRawQuery();

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.StoredAcl;
 import io.floci.gcp.services.iam.IamService;
@@ -31,14 +32,16 @@ public class GcsBucketController {
     private final EmulatorConfig config;
     private final IamService iamService;
     private final ObjectMapper objectMapper;
+	private final GcsAuthorizationService authorizationService;
 
     @Inject
     public GcsBucketController(GcsService service, EmulatorConfig config, IamService iamService,
-            ObjectMapper objectMapper) {
+			ObjectMapper objectMapper, GcsAuthorizationService authorizationService) {
         this.service = service;
         this.config = config;
         this.iamService = iamService;
         this.objectMapper = objectMapper;
+		this.authorizationService = authorizationService;
     }
 
     @OPTIONS
@@ -56,6 +59,7 @@ public class GcsBucketController {
     @Consumes(MediaType.WILDCARD)
     public Response createBucket(@QueryParam("project") String project,
             @Context HttpHeaders headers, byte[] body) {
+		authorizationService.rejectDownscopedToken(headers.getHeaderString(HttpHeaders.AUTHORIZATION));
         Map<String, Object> parsed = parseJsonBody(body);
         String name = parsed != null ? (String) parsed.get("name") : null;
         if (name == null || name.isBlank()) {
@@ -80,7 +84,9 @@ public class GcsBucketController {
     @GET
     public Response listBuckets(@QueryParam("project") String project,
             @QueryParam("maxResults") @DefaultValue("0") int maxResults,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @QueryParam("pageToken") String pageToken) {
+		authorizationService.rejectDownscopedToken(authorization);
         List<GcsBucket> all = service.listBuckets(project);
         PageToken.Page<GcsBucket> page = PageToken.paginate(all, maxResults, pageToken);
         Map<String, Object> response = new LinkedHashMap<>();
@@ -96,14 +102,18 @@ public class GcsBucketController {
 
     @GET
     @Path("/{bucket}")
-    public Response getBucket(@PathParam("bucket") String bucket) {
+	public Response getBucket(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.getBucket(bucket)).build();
     }
 
     @PATCH
     @Path("/{bucket}")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response patchBucket(@PathParam("bucket") String bucket, Map<String, Object> body) {
+	public Response patchBucket(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.updateBucket(bucket, body)).build();
     }
 
@@ -112,7 +122,9 @@ public class GcsBucketController {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response postBucketMethodOverride(@PathParam("bucket") String bucket,
             @HeaderParam("X-HTTP-Method-Override") String methodOverride,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         if ("PATCH".equalsIgnoreCase(methodOverride)) {
             return Response.ok(service.updateBucket(bucket, body)).build();
         }
@@ -121,7 +133,9 @@ public class GcsBucketController {
 
     @DELETE
     @Path("/{bucket}")
-    public Response deleteBucket(@PathParam("bucket") String bucket) {
+	public Response deleteBucket(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.deleteBucket(bucket);
         return Response.noContent().build();
     }
@@ -129,13 +143,17 @@ public class GcsBucketController {
     @POST
     @Path("/{bucket}/lockRetentionPolicy")
     public Response lockRetentionPolicy(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.lockRetentionPolicy(bucket, ifMetagenerationMatch)).build();
     }
 
     @GET
     @Path("/{bucket}/storageLayout")
-    public Response getStorageLayout(@PathParam("bucket") String bucket) {
+	public Response getStorageLayout(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         GcsBucket b = service.getBucket(bucket);
         String location = b.getLocation() != null ? b.getLocation() : "US";
         Map<String, Object> response = new LinkedHashMap<>();
@@ -158,7 +176,9 @@ public class GcsBucketController {
 
     @GET
     @Path("/{bucket}/iam")
-    public Response getBucketIamPolicy(@PathParam("bucket") String bucket) {
+	public Response getBucketIamPolicy(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.getBucket(bucket);
         StoredPolicy policy = iamService.getPolicy("buckets/" + bucket);
         return Response.ok(bucketIamResponse(bucket, policy)).build();
@@ -167,7 +187,9 @@ public class GcsBucketController {
     @PUT
     @Path("/{bucket}/iam")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response setBucketIamPolicy(@PathParam("bucket") String bucket, Map<String, Object> body) {
+	public Response setBucketIamPolicy(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.getBucket(bucket);
         StoredPolicy policy = parsePolicy(body);
         iamService.setPolicy("buckets/" + bucket, policy);
@@ -178,7 +200,9 @@ public class GcsBucketController {
     @Path("/{bucket}/iam:testPermissions")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response testBucketIamPermissions(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.getBucket(bucket);
         @SuppressWarnings("unchecked")
         List<String> requested = body != null ? (List<String>) body.get("permissions") : List.of();
@@ -190,7 +214,9 @@ public class GcsBucketController {
 
     @GET
     @Path("/{bucket}/acl")
-    public Response listBucketAcls(@PathParam("bucket") String bucket) {
+	public Response listBucketAcls(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         List<StoredAcl> items = service.listBucketAcls(bucket);
         return Response.ok(Map.of("kind", "storage#bucketAccessControls", "items", items)).build();
     }
@@ -198,7 +224,9 @@ public class GcsBucketController {
     @POST
     @Path("/{bucket}/acl")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response insertBucketAcl(@PathParam("bucket") String bucket, Map<String, Object> body) {
+	public Response insertBucketAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         String entity = body != null ? (String) body.get("entity") : null;
         String role = body != null ? (String) body.get("role") : "READER";
         StoredAcl acl = service.upsertBucketAcl(bucket, entity, role);
@@ -208,7 +236,9 @@ public class GcsBucketController {
     @GET
     @Path("/{bucket}/acl/{entity}")
     public Response getBucketAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("entity") String entity) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.getBucketAcl(bucket, decode(entity))).build();
     }
 
@@ -216,7 +246,9 @@ public class GcsBucketController {
     @Path("/{bucket}/acl/{entity}")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response updateBucketAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("entity") String entity, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         String role = body != null ? (String) body.get("role") : "READER";
         StoredAcl acl = service.upsertBucketAcl(bucket, decode(entity), role);
         return Response.ok(acl).build();
@@ -225,7 +257,9 @@ public class GcsBucketController {
     @DELETE
     @Path("/{bucket}/acl/{entity}")
     public Response deleteBucketAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("entity") String entity) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.deleteBucketAcl(bucket, decode(entity));
         return Response.noContent().build();
     }
@@ -234,7 +268,9 @@ public class GcsBucketController {
 
     @GET
     @Path("/{bucket}/defaultObjectAcl")
-    public Response listDefaultAcls(@PathParam("bucket") String bucket) {
+	public Response listDefaultAcls(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         List<StoredAcl> items = service.listDefaultAcls(bucket);
         return Response.ok(Map.of("kind", "storage#objectAccessControls", "items", items)).build();
     }
@@ -242,7 +278,9 @@ public class GcsBucketController {
     @POST
     @Path("/{bucket}/defaultObjectAcl")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response insertDefaultAcl(@PathParam("bucket") String bucket, Map<String, Object> body) {
+	public Response insertDefaultAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         String entity = body != null ? (String) body.get("entity") : null;
         String role = body != null ? (String) body.get("role") : "READER";
         StoredAcl acl = service.upsertDefaultAcl(bucket, entity, role);
@@ -252,7 +290,9 @@ public class GcsBucketController {
     @GET
     @Path("/{bucket}/defaultObjectAcl/{entity}")
     public Response getDefaultAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("entity") String entity) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.getDefaultAcl(bucket, decode(entity))).build();
     }
 
@@ -260,7 +300,9 @@ public class GcsBucketController {
     @Path("/{bucket}/defaultObjectAcl/{entity}")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response updateDefaultAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("entity") String entity, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         String role = body != null ? (String) body.get("role") : "READER";
         StoredAcl acl = service.upsertDefaultAcl(bucket, decode(entity), role);
         return Response.ok(acl).build();
@@ -269,7 +311,9 @@ public class GcsBucketController {
     @DELETE
     @Path("/{bucket}/defaultObjectAcl/{entity}")
     public Response deleteDefaultAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("entity") String entity) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.deleteDefaultAcl(bucket, decode(entity));
         return Response.noContent().build();
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -1,5 +1,6 @@
 package io.floci.gcp.services.gcs;
 
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -7,6 +8,7 @@ import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 
 @ApplicationScoped
@@ -14,10 +16,12 @@ import jakarta.ws.rs.core.Response;
 public class GcsDownloadController {
 
     private final GcsService service;
+    private final GcsAuthorizationService authorizationService;
 
     @Inject
-    public GcsDownloadController(GcsService service) {
+    public GcsDownloadController(GcsService service, GcsAuthorizationService authorizationService) {
         this.service = service;
+        this.authorizationService = authorizationService;
     }
 
     @GET
@@ -27,7 +31,9 @@ public class GcsDownloadController {
             @PathParam("object") String objectPath,
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
+            @HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @HeaderParam("Range") String rangeHeader) {
+        authorizationService.requireObjectRead(authorization, bucket, objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
         return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);

--- a/src/main/java/io/floci/gcp/services/gcs/GcsNotificationController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsNotificationController.java
@@ -1,10 +1,12 @@
 package io.floci.gcp.services.gcs;
 
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.StoredNotification;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
@@ -16,20 +18,26 @@ import java.util.Map;
 public class GcsNotificationController {
 
     private final GcsService service;
+	private final GcsAuthorizationService authorizationService;
 
     @Inject
-    public GcsNotificationController(GcsService service) {
+	public GcsNotificationController(GcsService service, GcsAuthorizationService authorizationService) {
         this.service = service;
+		this.authorizationService = authorizationService;
     }
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response createNotification(@PathParam("bucket") String bucket, Map<String, Object> body) {
+	public Response createNotification(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization, Map<String, Object> body) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.createNotification(bucket, body)).build();
     }
 
     @GET
-    public Response listNotifications(@PathParam("bucket") String bucket) {
+	public Response listNotifications(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+		authorizationService.rejectDownscopedToken(authorization);
         List<StoredNotification> items = service.listNotifications(bucket);
         return Response.ok(Map.of("kind", "storage#notifications", "items", items)).build();
     }
@@ -37,14 +45,18 @@ public class GcsNotificationController {
     @GET
     @Path("/{notification}")
     public Response getNotification(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("notification") String notificationId) {
+		authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.getNotification(bucket, notificationId)).build();
     }
 
     @DELETE
     @Path("/{notification}")
     public Response deleteNotification(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("notification") String notificationId) {
+		authorizationService.rejectDownscopedToken(authorization);
         service.deleteNotification(bucket, notificationId);
         return Response.noContent().build();
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -3,6 +3,7 @@ package io.floci.gcp.services.gcs;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import io.floci.gcp.services.gcs.model.StoredAcl;
@@ -29,11 +30,14 @@ public class GcsObjectController {
 
     private final GcsService service;
     private final EmulatorConfig config;
+	private final GcsAuthorizationService authorizationService;
 
     @Inject
-    public GcsObjectController(GcsService service, EmulatorConfig config) {
+	public GcsObjectController(GcsService service, EmulatorConfig config,
+			GcsAuthorizationService authorizationService) {
         this.service = service;
         this.config = config;
+		this.authorizationService = authorizationService;
     }
 
     @OPTIONS
@@ -48,8 +52,10 @@ public class GcsObjectController {
             @QueryParam("pageToken") String pageToken,
             @QueryParam("prefix") String prefix,
             @QueryParam("delimiter") String delimiter,
-            @QueryParam("startOffset") String startOffset,
+			@QueryParam("startOffset") String startOffset,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @QueryParam("versions") @DefaultValue("false") boolean includeVersions) {
+		authorizationService.requireObjectList(authorization, bucket, prefix);
         List<GcsObjectMeta> all = includeVersions
                 ? service.listObjectVersions(bucket, prefix)
                 : service.listObjects(bucket);
@@ -93,7 +99,9 @@ public class GcsObjectController {
     @GET
     @Path("/{object: .+}/acl")
     public Response listObjectAcls(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("object") String objectPath) {
+        authorizationService.rejectDownscopedToken(authorization);
         List<StoredAcl> items = service.listObjectAcls(bucket, objectPath);
         return Response.ok(Map.of("kind", "storage#objectAccessControls", "items", items)).build();
     }
@@ -102,7 +110,9 @@ public class GcsObjectController {
     @Path("/{object: .+}/acl")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response insertObjectAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("object") String objectPath, Map<String, Object> body) {
+        authorizationService.rejectDownscopedToken(authorization);
         String entity = body != null ? (String) body.get("entity") : null;
         String role = body != null ? (String) body.get("role") : "READER";
         StoredAcl acl = service.upsertObjectAcl(bucket, objectPath, entity, role);
@@ -112,8 +122,10 @@ public class GcsObjectController {
     @GET
     @Path("/{object: .+}/acl/{entity}")
     public Response getObjectAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("object") String objectPath,
             @PathParam("entity") String entity) {
+        authorizationService.rejectDownscopedToken(authorization);
         return Response.ok(service.getObjectAcl(bucket, objectPath, entity)).build();
     }
 
@@ -121,8 +133,10 @@ public class GcsObjectController {
     @Path("/{object: .+}/acl/{entity}")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response updateObjectAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("object") String objectPath,
             @PathParam("entity") String entity, Map<String, Object> body) {
+        authorizationService.rejectDownscopedToken(authorization);
         String role = body != null ? (String) body.get("role") : "READER";
         StoredAcl acl = service.upsertObjectAcl(bucket, objectPath, entity, role);
         return Response.ok(acl).build();
@@ -131,8 +145,10 @@ public class GcsObjectController {
     @DELETE
     @Path("/{object: .+}/acl/{entity}")
     public Response deleteObjectAcl(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @PathParam("object") String objectPath,
             @PathParam("entity") String entity) {
+        authorizationService.rejectDownscopedToken(authorization);
         service.deleteObjectAcl(bucket, objectPath, entity);
         return Response.noContent().build();
     }
@@ -144,7 +160,9 @@ public class GcsObjectController {
             @QueryParam("alt") String alt,
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @HeaderParam("Range") String rangeHeader) {
+        authorizationService.requireObjectRead(authorization, bucket, objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if ("media".equals(alt)) {
             var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
@@ -164,8 +182,10 @@ public class GcsObjectController {
             @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
             @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
-            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+			@QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             Map<String, Object> body) {
+        authorizationService.requireObjectWrite(authorization, bucket, objectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         return Response.ok(service.patchObject(bucket, objectPath, body, preconditions)).build();
@@ -179,8 +199,10 @@ public class GcsObjectController {
             @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
             @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
-            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+			@QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             Map<String, Object> body) {
+        authorizationService.requireObjectWrite(authorization, bucket, objectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         return Response.ok(service.patchObject(bucket, objectPath, body, preconditions)).build();
@@ -196,8 +218,10 @@ public class GcsObjectController {
             @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             Map<String, Object> body) {
         if ("PATCH".equalsIgnoreCase(methodOverride)) {
+            authorizationService.requireObjectWrite(authorization, bucket, objectPath);
             GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                     ifMetagenerationMatch, ifMetagenerationNotMatch);
             return Response.ok(service.patchObject(bucket, objectPath, body, preconditions)).build();
@@ -209,11 +233,13 @@ public class GcsObjectController {
     @Path("/{object: .+}")
     public Response deleteObject(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @QueryParam("generation") String generation,
             @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
             @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch) {
+        authorizationService.requireObjectDelete(authorization, bucket, objectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         if (generation != null) {
@@ -234,6 +260,7 @@ public class GcsObjectController {
             @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @Context HttpHeaders headers, Map<String, Object> body) {
+        String authorization = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> sourceObjects = body != null
                 ? (List<Map<String, Object>>) body.get("sourceObjects") : List.of();
@@ -243,6 +270,10 @@ public class GcsObjectController {
         String contentType = destReq != null ? (String) destReq.get("contentType") : null;
         List<String> sourceNames = sourceObjects == null ? List.of()
                 : sourceObjects.stream().map(s -> (String) s.get("name")).toList();
+        for (String sourceName : sourceNames) {
+            authorizationService.requireObjectRead(authorization, bucket, sourceName);
+        }
+        authorizationService.requireObjectWrite(authorization, bucket, destObjectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, null,
                 ifMetagenerationMatch, null);
         GcsObjectMeta meta = service.composeObject(bucket, destObjectPath, sourceNames, contentType,
@@ -261,6 +292,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @Context HttpHeaders headers) {
+        authorizationService.requireSourceReadAndDestinationWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION),
+                srcBucket, srcObjectPath, dstBucket, dstObjectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
@@ -302,6 +336,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @Context HttpHeaders headers) {
+        authorizationService.requireSourceReadAndDestinationWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION),
+                srcBucket, srcObjectPath, dstBucket, dstObjectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -316,6 +316,10 @@ public class GcsObjectController {
             @QueryParam("ifSourceMetagenerationMatch") Long ifSourceMetagenerationMatch,
             @QueryParam("ifSourceMetagenerationNotMatch") Long ifSourceMetagenerationNotMatch,
             @Context HttpHeaders headers) {
+        String authorization = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
+        authorizationService.requireObjectRead(authorization, bucket, srcObjectPath);
+        authorizationService.requireObjectDelete(authorization, bucket, srcObjectPath);
+        authorizationService.requireObjectWrite(authorization, bucket, dstObjectPath);
         GcsObjectPreconditions sourcePreconditions = new GcsObjectPreconditions(ifSourceGenerationMatch,
                 ifSourceGenerationNotMatch, ifSourceMetagenerationMatch, ifSourceMetagenerationNotMatch);
         GcsObjectPreconditions destinationPreconditions = new GcsObjectPreconditions(ifGenerationMatch,

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -851,6 +851,15 @@ public class GcsService {
         return uploadId;
     }
 
+	public ResumableUpload getResumableUpload(String uploadId) {
+		ResumableUpload upload = resumableUploads.get(uploadId);
+		if (upload == null) {
+			LOG.warnf("getResumableUpload failed: upload not found uploadId=%s", uploadId);
+			throw GcpException.notFound("Resumable upload not found: " + uploadId);
+		}
+		return upload;
+	}
+
     public GcsObjectMeta completeResumableUpload(String uploadId, byte[] data, String baseUrl) {
         LOG.debugf("completeResumableUpload uploadId=%s size=%d", uploadId, data.length);
         ResumableUpload upload = resumableUploads.get(uploadId);

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -3,8 +3,10 @@ package io.floci.gcp.services.gcs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
+import io.floci.gcp.services.gcs.model.ResumableUpload;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -29,12 +31,15 @@ public class GcsUploadController {
     private final GcsService service;
     private final EmulatorConfig config;
     private final ObjectMapper objectMapper;
+	private final GcsAuthorizationService authorizationService;
 
     @Inject
-    public GcsUploadController(GcsService service, EmulatorConfig config, ObjectMapper objectMapper) {
+	public GcsUploadController(GcsService service, EmulatorConfig config, ObjectMapper objectMapper,
+			GcsAuthorizationService authorizationService) {
         this.service = service;
         this.config = config;
         this.objectMapper = objectMapper;
+		this.authorizationService = authorizationService;
     }
 
     @POST
@@ -73,6 +78,9 @@ public class GcsUploadController {
         if (uploadId == null) {
             throw GcpException.invalidArgument("missing upload_id query parameter");
         }
+		ResumableUpload upload = service.getResumableUpload(uploadId);
+		authorizationService.requireObjectWrite(
+				headers.getHeaderString(HttpHeaders.AUTHORIZATION), upload.bucket(), upload.objectName());
         String contentRange = headers.getHeaderString("Content-Range");
         if (contentRange != null && !contentRange.isBlank()) {
             ContentRange range = parseContentRange(contentRange, body.length);
@@ -177,6 +185,8 @@ public class GcsUploadController {
         if (objectContentType == null) {
             objectContentType = extractPartHeader(rawParts[1], "content-type");
         }
+        authorizationService.requireObjectWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, objectName);
         var userMetadata = extractUserMetadata(metadata);
         byte[] dataBytes = extractPartBody(rawParts[1]).getBytes(ISO);
         GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes,
@@ -214,6 +224,8 @@ public class GcsUploadController {
             contentType = "application/octet-stream";
         }
 
+        authorizationService.requireObjectWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, name);
         String uploadId = service.startResumableUpload(bucket, name, contentType,
                 GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions);
         String location = requestBaseUrl(headers, uriInfo) + "/upload/storage/v1/b/" + bucket
@@ -225,6 +237,8 @@ public class GcsUploadController {
     private Response handleMedia(String bucket, String name, HttpHeaders headers, UriInfo uriInfo, byte[] body,
             GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        authorizationService.requireObjectWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, name);
         GcsObjectMeta meta = service.putObject(bucket, name, contentType, body,
                 GcsCustomerEncryption.fromHeaders(headers), preconditions, requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.gcs;
 
 import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -25,11 +26,14 @@ public class GcsXmlDownloadController {
 
     private final GcsService service;
     private final EmulatorConfig config;
+	private final GcsAuthorizationService authorizationService;
 
     @Inject
-    public GcsXmlDownloadController(GcsService service, EmulatorConfig config) {
+	public GcsXmlDownloadController(GcsService service, EmulatorConfig config,
+			GcsAuthorizationService authorizationService) {
         this.service = service;
         this.config = config;
+		this.authorizationService = authorizationService;
     }
 
     @OPTIONS
@@ -51,8 +55,10 @@ public class GcsXmlDownloadController {
             @Context UriInfo uriInfo,
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @HeaderParam("Range") String rangeHeader) {
         GcsSignedUrl.checkNotExpired(uriInfo);
+        authorizationService.requireObjectRead(authorization, bucket, objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
         return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
@@ -69,6 +75,8 @@ public class GcsXmlDownloadController {
             @Context HttpHeaders headers,
             byte[] body) {
         GcsSignedUrl.checkNotExpired(uriInfo);
+        authorizationService.requireObjectWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, objectPath);
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String host = headers.getHeaderString("Host");
         String baseUrl = host != null ? "http://" + host : config.baseUrl();

--- a/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
@@ -41,7 +41,7 @@ class CredentialTokenServiceTest {
 	}
 
 	@Test
-	void capsDownscopedTokenLifetimeToStoredSourceExpiration() {
+	void inheritsStoredSourceExpiration() {
 		StoredCredentialToken source = service.mintImpersonatedToken(
 				"test@test-project.iam.gserviceaccount.com", NOW.plusSeconds(1200));
 
@@ -51,6 +51,18 @@ class CredentialTokenServiceTest {
 		assertEquals(1200, minted.expiresInSeconds());
 		assertEquals(source.getExpireTime(), minted.token().getExpireTime());
 		assertNull(minted.token().getSourceToken());
+	}
+
+	@Test
+	void inheritsStoredSourceExpirationBeyondDefaultLifetime() {
+		StoredCredentialToken source = service.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com", NOW.plusSeconds(7200));
+
+		CredentialTokenService.MintedDownscopedToken minted =
+				service.mintDownscopedToken(source.getTokenValue(), rules());
+
+		assertEquals(7200, minted.expiresInSeconds());
+		assertEquals(source.getExpireTime(), minted.token().getExpireTime());
 	}
 
 	@Test

--- a/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
@@ -106,8 +106,10 @@ class CredentialTokenServiceTest {
 	}
 
 	@Test
-	void nonFlociTokenReturnsEmptyLookupForLaterBypassContract() {
+	void unmanagedTokenReturnsEmptyLookupForLaterBypassContract() {
 		assertTrue(service.lookupBearerToken("external-token").isEmpty());
+		assertTrue(service.lookupBearerToken(
+				CredentialTokenService.FLOCI_TOKEN_PREFIX + "oauth-token").isEmpty());
 		assertTrue(service.lookupBearerToken(null).isEmpty());
 	}
 

--- a/src/test/java/io/floci/gcp/services/gcs/GcsAuthorizationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsAuthorizationTest.java
@@ -31,13 +31,16 @@ class GcsAuthorizationTest {
 	private final GcsAuthorizationService authorizationService = new GcsAuthorizationService(tokenService);
 
 	@Test
-	void missingAndStaticBearerTokensBypassAuthorization() {
+	void missingAndUnmanagedBearerTokensBypassAuthorization() {
 		assertTrue(authorizationService.isBypassed(null));
 		assertTrue(authorizationService.isBypassed("Bearer external-token"));
+		assertTrue(authorizationService.isBypassed("Bearer floci-gcp-oauth-token"));
 
 		assertDoesNotThrow(() -> authorizationService.requireObjectRead(null, "bucket", "outside/file.txt"));
 		assertDoesNotThrow(() -> authorizationService.requireObjectWrite(
 				"Bearer external-token", "bucket", "outside/file.txt"));
+		assertDoesNotThrow(() -> authorizationService.rejectDownscopedToken(
+				"Bearer floci-gcp-oauth-token"));
 	}
 
 	@Test

--- a/src/test/java/io/floci/gcp/services/gcs/GcsAuthorizationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsAuthorizationTest.java
@@ -1,0 +1,151 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.credentials.CredentialAccessBoundaryRule;
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import io.floci.gcp.services.credentials.GcsAuthorizationService;
+import io.floci.gcp.services.credentials.StoredCredentialToken;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GcsAuthorizationTest {
+
+	private static final Instant NOW = Instant.parse("2026-07-15T12:00:00Z");
+	private static final String READER = "inRole:roles/storage.legacyObjectReader";
+	private static final String VIEWER = "inRole:roles/storage.objectViewer";
+	private static final String WRITER = "inRole:roles/storage.legacyBucketWriter";
+
+	private final InMemoryStorage<String, StoredCredentialToken> store = new InMemoryStorage<>();
+	private final CredentialTokenService tokenService =
+			new CredentialTokenService(store, Clock.fixed(NOW, ZoneOffset.UTC));
+	private final GcsAuthorizationService authorizationService = new GcsAuthorizationService(tokenService);
+
+	@Test
+	void missingAndStaticBearerTokensBypassAuthorization() {
+		assertTrue(authorizationService.isBypassed(null));
+		assertTrue(authorizationService.isBypassed("Bearer external-token"));
+
+		assertDoesNotThrow(() -> authorizationService.requireObjectRead(null, "bucket", "outside/file.txt"));
+		assertDoesNotThrow(() -> authorizationService.requireObjectWrite(
+				"Bearer external-token", "bucket", "outside/file.txt"));
+	}
+
+	@Test
+	void storedImpersonatedTokenBypassesDownscopedCabChecks() {
+		String token = tokenService.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com", NOW.plusSeconds(1200)).getTokenValue();
+
+		assertDoesNotThrow(() -> authorizationService.requireObjectWrite(
+				bearer(token), "bucket", "outside/file.txt"));
+	}
+
+	@Test
+	void unknownFlociTokenIsUnauthenticated() {
+		GcpException ex = assertThrows(GcpException.class,
+				() -> authorizationService.requireObjectRead(
+						"Bearer floci-gcp-downscoped-missing", "bucket", "allowed/file.txt"));
+
+		assertEquals("UNAUTHENTICATED", ex.getGcpStatus());
+	}
+
+	@Test
+	void expiredFlociTokenIsUnauthenticated() {
+		StoredCredentialToken expired = new StoredCredentialToken(
+				CredentialTokenService.DOWNSCOPED_TOKEN_PREFIX + "expired",
+				StoredCredentialToken.TokenKind.DOWNSCOPED,
+				NOW.minusSeconds(1),
+				"source-token",
+				null,
+				List.of(rule("bucket", "allowed/", READER)));
+		store.put(expired.getTokenValue(), expired);
+
+		GcpException ex = assertThrows(GcpException.class,
+				() -> authorizationService.requireObjectRead(
+						"Bearer " + expired.getTokenValue(), "bucket", "allowed/file.txt"));
+
+		assertEquals("UNAUTHENTICATED", ex.getGcpStatus());
+		assertTrue(store.get(expired.getTokenValue()).isEmpty());
+	}
+
+	@Test
+	void allowedPrefixAndPermissionsSucceed() {
+		String token = mint("bucket", "allowed/", READER, VIEWER, WRITER);
+
+		assertDoesNotThrow(() -> authorizationService.requireObjectRead(
+				bearer(token), "bucket", "allowed/file.txt"));
+		assertDoesNotThrow(() -> authorizationService.requireObjectList(
+				bearer(token), "bucket", "allowed/nested/"));
+		assertDoesNotThrow(() -> authorizationService.requireObjectWrite(
+				bearer(token), "bucket", "allowed/file.txt"));
+		assertDoesNotThrow(() -> authorizationService.requireObjectDelete(
+				bearer(token), "bucket", "allowed/file.txt"));
+	}
+
+	@Test
+	void siblingPrefixAndNoPrefixListAreForbidden() {
+		String token = mint("bucket", "allowed/", READER, VIEWER, WRITER);
+
+		assertPermissionDenied(() -> authorizationService.requireObjectRead(
+				bearer(token), "bucket", "allowed_sibling/file.txt"));
+		assertPermissionDenied(() -> authorizationService.requireObjectWrite(
+				bearer(token), "bucket", "allowed_sibling/file.txt"));
+		assertPermissionDenied(() -> authorizationService.requireObjectList(
+				bearer(token), "bucket", "allowed_sibling/"));
+		assertPermissionDenied(() -> authorizationService.requireObjectList(
+				bearer(token), "bucket", "allowed"));
+		assertPermissionDenied(() -> authorizationService.requireObjectList(
+				bearer(token), "bucket", null));
+	}
+
+	@Test
+	void wholeBucketRuleAllowsUnprefixedList() {
+		String token = mint("bucket", "", VIEWER);
+
+		assertDoesNotThrow(() -> authorizationService.requireObjectList(
+				bearer(token), "bucket", null));
+		assertDoesNotThrow(() -> authorizationService.requireObjectList(
+				bearer(token), "bucket", ""));
+	}
+
+	@Test
+	void adminSurfaceRejectsDownscopedToken() {
+		String token = mint("bucket", "allowed/", READER, VIEWER, WRITER);
+
+		assertPermissionDenied(() -> authorizationService.rejectDownscopedToken(bearer(token)));
+		assertDoesNotThrow(() -> authorizationService.rejectDownscopedToken("Bearer external-token"));
+	}
+
+	private String mint(String bucket, String prefix, String... permissions) {
+		return tokenService.mintDownscopedToken("source-token",
+				List.of(new CredentialAccessBoundaryRule(bucket, prefix, List.of(permissions))))
+				.token().getTokenValue();
+	}
+
+	private static CredentialAccessBoundaryRule rule(String bucket, String prefix, String... permissions) {
+		return new CredentialAccessBoundaryRule(bucket, prefix, List.of(permissions));
+	}
+
+	private static String bearer(String token) {
+		return "Bearer " + token;
+	}
+
+	private static void assertPermissionDenied(ThrowingRunnable runnable) {
+		GcpException ex = assertThrows(GcpException.class, runnable::run);
+		assertEquals("PERMISSION_DENIED", ex.getGcpStatus());
+	}
+
+	@FunctionalInterface
+	private interface ThrowingRunnable {
+		void run();
+	}
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsScopedTokenRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsScopedTokenRestIntegrationTest.java
@@ -1,0 +1,300 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.services.credentials.CredentialAccessBoundaryRule;
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+class GcsScopedTokenRestIntegrationTest {
+
+	private static final String READER = "inRole:roles/storage.legacyObjectReader";
+	private static final String VIEWER = "inRole:roles/storage.objectViewer";
+	private static final String WRITER = "inRole:roles/storage.legacyBucketWriter";
+
+	@Inject
+	CredentialTokenService tokenService;
+
+	private String bucket;
+
+	@BeforeEach
+	void setUp() {
+		tokenService.clear();
+		bucket = "scoped-" + System.nanoTime();
+		createBucket(bucket);
+	}
+
+	@Test
+	void missingAndStaticBearerTokensPreserveExistingBypassBehavior() {
+		upload(null, "bypass/missing.txt", "missing").statusCode(200);
+		upload("Bearer static-token", "bypass/static.txt", "static").statusCode(200);
+
+		given()
+				.header("Authorization", "Bearer static-token")
+				.when().get("/storage/v1/b/{bucket}/o/{object}?alt=media", bucket, "bypass/static.txt")
+				.then()
+					.statusCode(200)
+					.body(equalTo("static"));
+	}
+
+	@Test
+	void storedImpersonatedBearerTokenPreservesExistingBypassBehavior() {
+		String authorization = bearer(tokenService.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com", java.time.Instant.now().plusSeconds(1200))
+				.getTokenValue());
+
+		upload(authorization, "impersonated/outside.txt", "impersonated").statusCode(200);
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}/o/{object}?alt=media", bucket, "impersonated/outside.txt")
+				.then()
+				.statusCode(200)
+				.body(equalTo("impersonated"));
+	}
+
+	@Test
+	void unknownFlociTokenIsUnauthenticated() {
+		given()
+				.header("Authorization", "Bearer floci-gcp-downscoped-missing")
+				.when().get("/storage/v1/b/{bucket}/o/{object}?alt=media", bucket, "allowed/file.txt")
+				.then()
+				.statusCode(401)
+				.body("error.status", equalTo("UNAUTHENTICATED"));
+	}
+
+	@Test
+	void downscopedTokenAllowsOnlyMatchingPrefixOperations() {
+		String authorization = bearer(mint("allowed/", READER, VIEWER, WRITER));
+
+		upload(authorization, "allowed/file.txt", "allowed").statusCode(200);
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}/o/{object}?alt=media", bucket, "allowed/file.txt")
+				.then()
+				.statusCode(200)
+				.body(equalTo("allowed"));
+
+		given()
+				.header("Authorization", authorization)
+				.queryParam("prefix", "allowed/")
+				.when().get("/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(200)
+				.body("items[0].name", equalTo("allowed/file.txt"));
+
+		given()
+				.header("Authorization", authorization)
+				.when().delete("/storage/v1/b/{bucket}/o/{object}", bucket, "allowed/file.txt")
+				.then()
+				.statusCode(204);
+	}
+
+	@Test
+	void siblingPrefixAndNoPrefixListAreForbidden() {
+		upload(null, "allowed_sibling/file.txt", "sibling").statusCode(200);
+		String authorization = bearer(mint("allowed/", READER, VIEWER, WRITER));
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}/o/{object}?alt=media", bucket, "allowed_sibling/file.txt")
+				.then()
+				.statusCode(403)
+				.body("error.status", equalTo("PERMISSION_DENIED"));
+
+		upload(authorization, "allowed_sibling/write.txt", "denied")
+				.statusCode(403)
+				.body("error.status", equalTo("PERMISSION_DENIED"));
+
+		given()
+				.header("Authorization", authorization)
+				.queryParam("prefix", "allowed_sibling/")
+				.when().get("/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(403);
+
+		given()
+				.header("Authorization", authorization)
+				.queryParam("prefix", "allowed")
+				.when().get("/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(403);
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(403);
+	}
+
+	@Test
+	void wholeBucketRuleAllowsUnprefixedList() {
+		upload(null, "first.txt", "first").statusCode(200);
+		upload(null, "nested/second.txt", "second").statusCode(200);
+		String authorization = bearer(mint("", VIEWER));
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(200)
+				.body("items.name", org.hamcrest.Matchers.hasItems("first.txt", "nested/second.txt"));
+	}
+
+	@Test
+	void composeCopyAndRewriteRequireSourceReadAndDestinationWrite() {
+		upload(null, "allowed/source.txt", "source").statusCode(200);
+		upload(null, "allowed_sibling/source.txt", "source").statusCode(200);
+		String authorization = bearer(mint("allowed/", READER, VIEWER, WRITER));
+
+		given()
+				.header("Authorization", authorization)
+				.contentType("application/json")
+				.body(Map.of("sourceObjects", List.of(Map.of("name", "allowed_sibling/source.txt"))))
+				.when().post("/storage/v1/b/{bucket}/o/{object}/compose", bucket, "allowed/composed.txt")
+				.then()
+				.statusCode(403);
+
+			given()
+					.header("Authorization", authorization)
+					.when().post("/storage/v1/b/{bucket}/o/{source}/copyTo/b/{destBucket}/o/{dest}",
+							bucket, "allowed/source.txt", bucket, "allowed_sibling/copied.txt")
+				.then()
+				.statusCode(403);
+
+			given()
+					.header("Authorization", authorization)
+					.when().post("/storage/v1/b/{bucket}/o/{source}/rewriteTo/b/{destBucket}/o/{dest}",
+							bucket, "allowed_sibling/source.txt", bucket, "allowed/rewritten.txt")
+				.then()
+				.statusCode(403);
+	}
+
+	@Test
+	void resumableUploadRequiresCurrentTokenScopeForCompletion() {
+		String location = given()
+				.contentType("application/json")
+				.queryParam("uploadType", "resumable")
+				.queryParam("name", "allowed/resumable.txt")
+				.body("{}")
+				.when().post("/upload/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(200)
+				.header("Location", containsString("upload_id="))
+				.extract().header("Location");
+
+		String uploadId = location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+		String otherAuthorization = bearer(mint("other/", READER, VIEWER, WRITER));
+
+		given()
+				.header("Authorization", otherAuthorization)
+				.contentType("text/plain")
+				.queryParam("upload_id", uploadId)
+				.body("denied")
+				.when().put("/upload/storage/v1/b/{bucket}/o", bucket)
+				.then()
+				.statusCode(403);
+	}
+
+	@Test
+	void downscopedTokenCannotUseBucketAdminSurfaces() {
+		String authorization = bearer(mint("allowed/", READER, VIEWER, WRITER));
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}", bucket)
+				.then()
+				.statusCode(403);
+
+		given()
+				.header("Authorization", authorization)
+				.when().get("/storage/v1/b/{bucket}/notificationConfigs", bucket)
+				.then()
+				.statusCode(403);
+	}
+
+	@Test
+	void batchRequestsEnforceOuterAndEmbeddedFlociTokens() {
+		upload(null, "allowed_sibling/file.txt", "sibling").statusCode(200);
+		String authorization = bearer(mint("allowed/", READER, VIEWER, WRITER));
+
+		given()
+					.header("Authorization", authorization)
+					.contentType("multipart/mixed; boundary=batch_test")
+					.body(batchRequest("/storage/v1/b/" + bucket + "/o/allowed_sibling/file.txt?alt=media", null)
+							.getBytes(StandardCharsets.UTF_8))
+				.when().post("/batch/storage/v1")
+				.then()
+				.statusCode(200)
+				.body(startsWith("--batch_"))
+				.body(containsString("HTTP/1.1 403 Forbidden"));
+
+		given()
+					.contentType("multipart/mixed; boundary=batch_test")
+					.body(batchRequest("https://storage.googleapis.com/storage/v1/b/" + bucket
+							+ "/o/allowed_sibling/file.txt?alt=media", authorization)
+							.getBytes(StandardCharsets.UTF_8))
+				.when().post("/batch/storage/v1")
+				.then()
+				.statusCode(200)
+				.body(containsString("HTTP/1.1 403 Forbidden"));
+	}
+
+	private void createBucket(String bucketName) {
+		given()
+				.contentType("application/json")
+				.queryParam("project", "test-project")
+				.body(Map.of("name", bucketName))
+				.when().post("/storage/v1/b")
+				.then()
+				.statusCode(200);
+	}
+
+	private io.restassured.response.ValidatableResponse upload(
+			String authorization, String objectName, String content) {
+		var request = given()
+				.contentType("text/plain")
+				.queryParam("uploadType", "media")
+				.queryParam("name", objectName)
+				.body(content.getBytes(StandardCharsets.UTF_8));
+		if (authorization != null) {
+			request.header("Authorization", authorization);
+		}
+		return request.when().post("/upload/storage/v1/b/{bucket}/o", bucket).then();
+	}
+
+	private String mint(String prefix, String... permissions) {
+		return tokenService.mintDownscopedToken("source-token",
+				List.of(new CredentialAccessBoundaryRule(bucket, prefix, List.of(permissions))))
+				.token().getTokenValue();
+	}
+
+	private static String bearer(String token) {
+		return "Bearer " + token;
+	}
+
+	private static String batchRequest(String path, String authorization) {
+		String authHeader = authorization == null ? "" : "Authorization: " + authorization + "\r\n";
+		return """
+				--batch_test\r
+				Content-Type: application/http\r
+				Content-ID: <item1>\r
+				\r
+				GET %s HTTP/1.1\r
+				%s\r
+				--batch_test--\r
+				""".formatted(path, authHeader);
+	}
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsScopedTokenRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsScopedTokenRestIntegrationTest.java
@@ -36,9 +36,10 @@ class GcsScopedTokenRestIntegrationTest {
 	}
 
 	@Test
-	void missingAndStaticBearerTokensPreserveExistingBypassBehavior() {
+	void missingAndUnmanagedBearerTokensPreserveExistingBypassBehavior() {
 		upload(null, "bypass/missing.txt", "missing").statusCode(200);
 		upload("Bearer static-token", "bypass/static.txt", "static").statusCode(200);
+		upload("Bearer floci-gcp-oauth-token", "bypass/oauth.txt", "oauth").statusCode(200);
 
 		given()
 				.header("Authorization", "Bearer static-token")

--- a/src/test/java/io/floci/gcp/services/gcs/GcsScopedTokenRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsScopedTokenRestIntegrationTest.java
@@ -184,6 +184,31 @@ class GcsScopedTokenRestIntegrationTest {
 	}
 
 	@Test
+	void moveRequiresSourceReadAndDeleteAndDestinationWrite() {
+		upload(null, "allowed/move-source.txt", "source").statusCode(200);
+		String missingSourceDelete = bearer(mint(
+				new CredentialAccessBoundaryRule(bucket, "allowed/move-source.txt", List.of(READER)),
+				new CredentialAccessBoundaryRule(bucket, "allowed/move-destination.txt", List.of(WRITER))));
+
+		given()
+				.header("Authorization", missingSourceDelete)
+				.when().post("/storage/v1/b/{bucket}/o/{source}/moveTo/o/{destination}",
+						bucket, "allowed/move-source.txt", "allowed/move-destination.txt")
+				.then()
+				.statusCode(403);
+
+		String authorization = bearer(mint(
+				new CredentialAccessBoundaryRule(bucket, "allowed/move-source.txt", List.of(READER, WRITER)),
+				new CredentialAccessBoundaryRule(bucket, "allowed/move-destination.txt", List.of(WRITER))));
+		given()
+				.header("Authorization", authorization)
+				.when().post("/storage/v1/b/{bucket}/o/{source}/moveTo/o/{destination}",
+						bucket, "allowed/move-source.txt", "allowed/move-destination.txt")
+				.then()
+				.statusCode(200);
+	}
+
+	@Test
 	void resumableUploadRequiresCurrentTokenScopeForCompletion() {
 		String location = given()
 				.contentType("application/json")
@@ -277,8 +302,11 @@ class GcsScopedTokenRestIntegrationTest {
 	}
 
 	private String mint(String prefix, String... permissions) {
-		return tokenService.mintDownscopedToken("source-token",
-				List.of(new CredentialAccessBoundaryRule(bucket, prefix, List.of(permissions))))
+		return mint(new CredentialAccessBoundaryRule(bucket, prefix, List.of(permissions)));
+	}
+
+	private String mint(CredentialAccessBoundaryRule... rules) {
+		return tokenService.mintDownscopedToken("source-token", List.of(rules))
 				.token().getTokenValue();
 	}
 

--- a/src/test/java/io/floci/gcp/services/sts/StsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/sts/StsServiceTest.java
@@ -58,7 +58,7 @@ class StsServiceTest {
 	}
 
 	@Test
-	void capsExpiryToStoredImpersonatedSubjectToken() {
+	void inheritsExpiryFromStoredImpersonatedSubjectToken() {
 		StoredCredentialToken source = tokenService.mintImpersonatedToken(
 				"test@test-project.iam.gserviceaccount.com",
 				Instant.parse("2026-07-15T12:20:00Z"));
@@ -71,6 +71,24 @@ class StsServiceTest {
 				cab());
 
 		assertEquals(1200L, response.get("expires_in"));
+		StoredCredentialToken downscoped = store.get((String) response.get("access_token")).orElseThrow();
+		assertEquals(source.getExpireTime(), downscoped.getExpireTime());
+	}
+
+	@Test
+	void returnsStoredSourceLifetimeBeyondDefaultLifetime() {
+		StoredCredentialToken source = tokenService.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com",
+				Instant.parse("2026-07-15T14:00:00Z"));
+
+		Map<String, Object> response = service.exchangeToken(
+				StsService.TOKEN_EXCHANGE_GRANT_TYPE,
+				StsService.ACCESS_TOKEN_TYPE,
+				source.getTokenValue(),
+				StsService.ACCESS_TOKEN_TYPE,
+				cab());
+
+		assertEquals(7200L, response.get("expires_in"));
 		StoredCredentialToken downscoped = store.get((String) response.get("access_token")).orElseThrow();
 		assertEquals(source.getExpireTime(), downscoped.getExpireTime());
 	}


### PR DESCRIPTION
Enforces Floci downscoped-token CAB rules across GCS object, upload, XML, compose, copy, rewrite, resumable, and batch paths while preserving existing bypass behavior for missing, static, and stored impersonated credentials.

- [x] New feature (`feat:`)

Implements the intentionally limited GCS Credential Access Boundary subset produced by the Google Java downscoped credentials flow. Verified with GcsAuthorizationTest, GcsScopedTokenRestIntegrationTest, existing GCS service coverage, and compatibility-tests/sdk-test-java GcsDownscopedTokenTest against a running emulator.

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits