### PR TITLE
feat(gcs): support service account authentication

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsServiceAccountAuthenticationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsServiceAccountAuthenticationTest.java
@@ -1,0 +1,48 @@
+package io.floci.gcp.test;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GcsServiceAccountAuthenticationTest {
+
+    @Test
+    void serviceAccountCredentialsAuthenticateStorageRequests() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
+                .setClientId("123456789")
+                .setClientEmail("storage-test@test-project.iam.gserviceaccount.com")
+                .setPrivateKey(keyPair.getPrivate())
+                .setPrivateKeyId("test-key")
+                .setScopes(List.of("https://www.googleapis.com/auth/cloud-platform"))
+                .setTokenServerUri(URI.create(TestFixtures.endpoint() + "/token"))
+                .build();
+
+        String bucketName = TestFixtures.uniqueName("service-account-auth");
+        try (Storage storage = StorageOptions.newBuilder()
+                .setHost(TestFixtures.endpoint())
+                .setProjectId(TestFixtures.projectId())
+                .setCredentials(credentials)
+                .build()
+                .getService()) {
+            storage.create(BucketInfo.of(bucketName));
+
+            assertThat(storage.get(bucketName)).isNotNull();
+            assertThat(credentials.getAccessToken().getTokenValue()).isNotBlank();
+
+            assertThat(storage.delete(bucketName)).isTrue();
+        }
+    }
+}

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -20,6 +20,27 @@ export STORAGE_EMULATOR_HOST=http://localhost:4588
 
 GCP Storage SDK clients use this variable to route requests to floci-gcp instead of `storage.googleapis.com`.
 
+## Service Account Authentication
+
+Clients can exercise the normal service-account OAuth flow by setting the
+credential's `token_uri` to the emulator:
+
+```json
+{
+  "type": "service_account",
+  "project_id": "floci-local",
+  "private_key_id": "test-key",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "client_email": "test@floci-local.iam.gserviceaccount.com",
+  "client_id": "123456789",
+  "token_uri": "http://localhost:4588/token"
+}
+```
+
+floci-gcp implements the standard OAuth JWT bearer exchange and returns a
+short-lived Bearer token. As with other emulator credentials, JWT signatures
+and Bearer tokens are not validated.
+
 ## Quick Start
 
 === "gcloud CLI"

--- a/src/main/java/io/floci/gcp/services/credentials/OAuthTokenController.java
+++ b/src/main/java/io/floci/gcp/services/credentials/OAuthTokenController.java
@@ -1,0 +1,51 @@
+package io.floci.gcp.services.credentials;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+@Path("/token")
+@Produces(MediaType.APPLICATION_JSON)
+public class OAuthTokenController {
+
+    private static final String JWT_BEARER_GRANT_TYPE =
+            "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response exchangeServiceAccountJwt(
+            @FormParam("grant_type") String grantType,
+            @FormParam("assertion") String assertion) {
+        if (!JWT_BEARER_GRANT_TYPE.equals(grantType)) {
+            return oauthError("unsupported_grant_type", "Unsupported grant type");
+        }
+        if (assertion == null || assertion.isBlank()) {
+            return oauthError("invalid_grant", "Invalid JWT bearer token request");
+        }
+
+        return Response.ok(Map.of(
+                "access_token", "floci-gcp-" + UUID.randomUUID(),
+                "token_type", "Bearer",
+                "expires_in", 3600))
+                .build();
+    }
+
+    private static Response oauthError(String error, String description) {
+        Map<String, String> body = new LinkedHashMap<>();
+        body.put("error", error);
+        body.put("error_description", description);
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(body)
+                .build();
+    }
+}

--- a/src/test/java/io/floci/gcp/services/credentials/OAuthTokenGcsDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/OAuthTokenGcsDisabledRestIntegrationTest.java
@@ -1,0 +1,35 @@
+package io.floci.gcp.services.credentials;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(OAuthTokenGcsDisabledRestIntegrationTest.DisabledGcsProfile.class)
+class OAuthTokenGcsDisabledRestIntegrationTest {
+
+    @Test
+    void exchangesTokenWhenGcsIsDisabled() {
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
+                .formParam("assertion", "header.payload.signature")
+                .when().post("/token")
+                .then()
+                .statusCode(200)
+                .body("token_type", equalTo("Bearer"));
+    }
+
+    public static class DisabledGcsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-gcp.services.gcs.enabled", "false");
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/credentials/OAuthTokenRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/OAuthTokenRestIntegrationTest.java
@@ -1,0 +1,53 @@
+package io.floci.gcp.services.credentials;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+class OAuthTokenRestIntegrationTest {
+
+    private static final String JWT_BEARER_GRANT_TYPE =
+            "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+    @Test
+    void exchangesServiceAccountJwtForBearerToken() {
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("grant_type", JWT_BEARER_GRANT_TYPE)
+                .formParam("assertion", "header.payload.signature")
+                .when().post("/token")
+                .then()
+                .statusCode(200)
+                .body("access_token", not(emptyOrNullString()))
+                .body("token_type", equalTo("Bearer"))
+                .body("expires_in", equalTo(3600));
+    }
+
+    @Test
+    void rejectsUnsupportedGrantType() {
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("grant_type", "invalid")
+                .formParam("assertion", "header.payload.signature")
+                .when().post("/token")
+                .then()
+                .statusCode(400)
+                .body("error", equalTo("unsupported_grant_type"));
+    }
+
+    @Test
+    void rejectsInvalidAssertion() {
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("grant_type", JWT_BEARER_GRANT_TYPE)
+                .when().post("/token")
+                .then()
+                .statusCode(400)
+                .body("error", equalTo("invalid_grant"));
+    }
+}


### PR DESCRIPTION
Allows GCS clients to use standard service-account credentials against the emulator.