### PR TITLE
fix(gcs): preserve URI-encoded object names

### DIFF
--- a/compatibility-tests/sdk-test-gcloud/test/storage.bats
+++ b/compatibility-tests/sdk-test-gcloud/test/storage.bats
@@ -44,6 +44,20 @@ setup() {
     assert_output --partial "gs://${BUCKET}/data.txt"
 }
 
+@test "storage: preserve URI-encoded object names" {
+    local f="${BATS_TEST_TMPDIR}/encoded.txt"
+    echo "encoded object" > "$f"
+
+    for object in "literal%2Fslash" "literal%20space" "literal%25percent" "literal%2Bplus"; do
+        run gcloud_cmd storage cp "$f" "gs://${BUCKET}/${object}"
+        assert_success
+
+        run gcloud_cmd storage cat "gs://${BUCKET}/${object}"
+        assert_success
+        assert_output --partial "encoded object"
+    done
+}
+
 @test "storage: delete object" {
     local f="${BATS_TEST_TMPDIR}/del.txt"
     echo "x" > "$f"

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsBatchTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsBatchTest.java
@@ -27,6 +27,7 @@ class GcsBatchTest {
     private static final String OBJ1 = "batch/object1.txt";
     private static final String OBJ2 = "batch/object2.txt";
     private static final String OBJ3 = "batch/object3.txt";
+    private static final String ENCODED_OBJECT = "batch/literal%2Fname.txt";
 
     private static Storage storage;
 
@@ -124,5 +125,26 @@ class GcsBatchTest {
         batch.submit();
 
         assertThat(result.get()).isFalse();
+    }
+
+    @Test
+    @Order(6)
+    void batchPreservesEncodedObjectName() {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, ENCODED_OBJECT)).build();
+        storage.create(blobInfo, "encoded name".getBytes(StandardCharsets.UTF_8));
+
+        StorageBatch batch = storage.batch();
+        StorageBatchResult<Blob> getResult = batch.get(blobInfo.getBlobId());
+        batch.submit();
+
+        assertThat(getResult.get()).isNotNull();
+        assertThat(getResult.get().getName()).isEqualTo(ENCODED_OBJECT);
+
+        StorageBatch deleteBatch = storage.batch();
+        StorageBatchResult<Boolean> deleteResult = deleteBatch.delete(blobInfo.getBlobId());
+        deleteBatch.submit();
+
+        assertThat(deleteResult.get()).isTrue();
+        assertThat(storage.get(blobInfo.getBlobId())).isNull();
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
@@ -171,10 +171,7 @@ public class GcsBatchController {
 
     private SubResponse dispatch(SubRequest req) {
         try {
-            String path = req.path();
-            URI uri = path.startsWith("http://") || path.startsWith("https://")
-                    ? rewriteToLocalhost(URI.create(path))
-                    : URI.create("http://localhost:" + config.port() + path);
+            URI uri = rewriteToLocalhost(URI.create(req.path()));
 
             HttpRequest.BodyPublisher bodyPublisher = req.body().isEmpty()
                     ? HttpRequest.BodyPublishers.noBody()
@@ -212,13 +209,8 @@ public class GcsBatchController {
     }
 
     private URI rewriteToLocalhost(URI original) {
-        try {
-            return new URI("http", null, "localhost", config.port(),
-                    original.getRawPath(), original.getRawQuery(), null);
-        } catch (Exception e) {
-            return URI.create("http://localhost:" + config.port() + original.getRawPath()
-                    + (original.getRawQuery() != null ? "?" + original.getRawQuery() : ""));
-        }
+        String query = original.getRawQuery() == null ? "" : "?" + original.getRawQuery();
+        return URI.create("http://localhost:" + config.port() + original.getRawPath() + query);
     }
 
     private void appendResponsePart(StringBuilder sb, String boundary, int index,

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -10,9 +10,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-
 @ApplicationScoped
 @Path("/download/storage/v1/b/{bucket}/o")
 public class GcsDownloadController {
@@ -32,15 +29,14 @@ public class GcsDownloadController {
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam("Range") String rangeHeader) {
-        String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
-            byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
-            GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
+            byte[] data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
+            GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath, generation);
             return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
         }
-        byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
-        GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
+        byte[] data = service.getObjectData(bucket, objectPath, customerEncryption);
+        GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath);
         return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -13,8 +13,6 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -95,8 +93,7 @@ public class GcsObjectController {
     @Path("/{object: .+}/acl")
     public Response listObjectAcls(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath) {
-        String objectName = decode(objectPath);
-        List<StoredAcl> items = service.listObjectAcls(bucket, objectName);
+        List<StoredAcl> items = service.listObjectAcls(bucket, objectPath);
         return Response.ok(Map.of("kind", "storage#objectAccessControls", "items", items)).build();
     }
 
@@ -105,10 +102,9 @@ public class GcsObjectController {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response insertObjectAcl(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath, Map<String, Object> body) {
-        String objectName = decode(objectPath);
         String entity = body != null ? (String) body.get("entity") : null;
         String role = body != null ? (String) body.get("role") : "READER";
-        StoredAcl acl = service.upsertObjectAcl(bucket, objectName, entity, role);
+        StoredAcl acl = service.upsertObjectAcl(bucket, objectPath, entity, role);
         return Response.ok(acl).build();
     }
 
@@ -117,8 +113,7 @@ public class GcsObjectController {
     public Response getObjectAcl(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @PathParam("entity") String entity) {
-        String objectName = decode(objectPath);
-        return Response.ok(service.getObjectAcl(bucket, objectName, decode(entity))).build();
+        return Response.ok(service.getObjectAcl(bucket, objectPath, entity)).build();
     }
 
     @PUT
@@ -127,9 +122,8 @@ public class GcsObjectController {
     public Response updateObjectAcl(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @PathParam("entity") String entity, Map<String, Object> body) {
-        String objectName = decode(objectPath);
         String role = body != null ? (String) body.get("role") : "READER";
-        StoredAcl acl = service.upsertObjectAcl(bucket, objectName, decode(entity), role);
+        StoredAcl acl = service.upsertObjectAcl(bucket, objectPath, entity, role);
         return Response.ok(acl).build();
     }
 
@@ -138,8 +132,7 @@ public class GcsObjectController {
     public Response deleteObjectAcl(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @PathParam("entity") String entity) {
-        String objectName = decode(objectPath);
-        service.deleteObjectAcl(bucket, objectName, decode(entity));
+        service.deleteObjectAcl(bucket, objectPath, entity);
         return Response.noContent().build();
     }
 
@@ -151,22 +144,21 @@ public class GcsObjectController {
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam("Range") String rangeHeader) {
-        String objectName = decode(objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
             if ("media".equals(alt)) {
-                byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
-                GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
+                byte[] data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
+                GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath, generation);
                 return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
             }
-            return Response.ok(service.getObjectMeta(bucket, objectName, generation)).build();
+            return Response.ok(service.getObjectMeta(bucket, objectPath, generation)).build();
         }
         if ("media".equals(alt)) {
-            byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
-            GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
+            byte[] data = service.getObjectData(bucket, objectPath, customerEncryption);
+            GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath);
             return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
         }
-        return Response.ok(service.getObjectMeta(bucket, objectName)).build();
+        return Response.ok(service.getObjectMeta(bucket, objectPath)).build();
     }
 
     @PATCH
@@ -179,10 +171,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             Map<String, Object> body) {
-        String objectName = decode(objectPath);
-        service.checkPreconditions(bucket, objectName, ifGenerationMatch, ifGenerationNotMatch,
+        service.checkPreconditions(bucket, objectPath, ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
-        return Response.ok(service.patchObject(bucket, objectName, body)).build();
+        return Response.ok(service.patchObject(bucket, objectPath, body)).build();
     }
 
     @PUT
@@ -195,10 +186,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             Map<String, Object> body) {
-        String objectName = decode(objectPath);
-        service.checkPreconditions(bucket, objectName, ifGenerationMatch, ifGenerationNotMatch,
+        service.checkPreconditions(bucket, objectPath, ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
-        return Response.ok(service.patchObject(bucket, objectName, body)).build();
+        return Response.ok(service.patchObject(bucket, objectPath, body)).build();
     }
 
     @POST
@@ -213,10 +203,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             Map<String, Object> body) {
         if ("PATCH".equalsIgnoreCase(methodOverride)) {
-            String objectName = decode(objectPath);
-            service.checkPreconditions(bucket, objectName, ifGenerationMatch, ifGenerationNotMatch,
+            service.checkPreconditions(bucket, objectPath, ifGenerationMatch, ifGenerationNotMatch,
                     ifMetagenerationMatch, ifMetagenerationNotMatch);
-            return Response.ok(service.patchObject(bucket, objectName, body)).build();
+            return Response.ok(service.patchObject(bucket, objectPath, body)).build();
         }
         throw GcpException.invalidArgument("Unsupported method override: " + methodOverride);
     }
@@ -226,13 +215,12 @@ public class GcsObjectController {
     public Response deleteObject(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
             @QueryParam("generation") String generation) {
-        String objectName = decode(objectPath);
         if (generation != null) {
-            service.deleteObjectVersion(bucket, objectName, generation);
+            service.deleteObjectVersion(bucket, objectPath, generation);
             return Response.noContent().build();
         }
-        if (!service.deleteObject(bucket, objectName)) {
-            throw GcpException.notFound("Object not found: " + objectName);
+        if (!service.deleteObject(bucket, objectPath)) {
+            throw GcpException.notFound("Object not found: " + objectPath);
         }
         return Response.noContent().build();
     }
@@ -243,7 +231,6 @@ public class GcsObjectController {
     public Response composeObject(@PathParam("bucket") String bucket,
             @PathParam("destObject") String destObjectPath,
             @Context HttpHeaders headers, Map<String, Object> body) {
-        String destObject = decode(destObjectPath);
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> sourceObjects = body != null
                 ? (List<Map<String, Object>>) body.get("sourceObjects") : List.of();
@@ -253,7 +240,7 @@ public class GcsObjectController {
         String contentType = destReq != null ? (String) destReq.get("contentType") : null;
         List<String> sourceNames = sourceObjects == null ? List.of()
                 : sourceObjects.stream().map(s -> (String) s.get("name")).toList();
-        GcsObjectMeta meta = service.composeObject(bucket, destObject, sourceNames, contentType,
+        GcsObjectMeta meta = service.composeObject(bucket, destObjectPath, sourceNames, contentType,
                 requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
@@ -265,9 +252,7 @@ public class GcsObjectController {
             @PathParam("dstBucket") String dstBucket,
             @PathParam("dstObject") String dstObjectPath,
             @Context HttpHeaders headers) {
-        String srcObject = decode(srcObjectPath);
-        String dstObject = decode(dstObjectPath);
-        GcsObjectMeta meta = service.copyObject(srcBucket, srcObject, dstBucket, dstObject,
+        GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
                 requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
@@ -279,9 +264,7 @@ public class GcsObjectController {
             @PathParam("dstBucket") String dstBucket,
             @PathParam("dstObject") String dstObjectPath,
             @Context HttpHeaders headers) {
-        String srcObject = decode(srcObjectPath);
-        String dstObject = decode(dstObjectPath);
-        GcsObjectMeta meta = service.copyObject(srcBucket, srcObject, dstBucket, dstObject,
+        GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
                 requestBaseUrl(headers));
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#rewriteResponse");
@@ -290,10 +273,6 @@ public class GcsObjectController {
         response.put("done", true);
         response.put("resource", meta);
         return Response.ok(response).build();
-    }
-
-    private static String decode(String s) {
-        return URLDecoder.decode(s, StandardCharsets.UTF_8);
     }
 
     private String requestBaseUrl(HttpHeaders headers) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -11,9 +11,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-
 /**
  * Handles GCS XML API requests: GET/PUT /{bucket}/{object}.
  * Used by Go SDK (STORAGE_EMULATOR_HOST) and for signed URL access.
@@ -52,15 +49,14 @@ public class GcsXmlDownloadController {
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam("Range") String rangeHeader) {
         GcsSignedUrl.checkNotExpired(uriInfo);
-        String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
-            byte[] data = service.getObjectData(bucket, objectName, generation, customerEncryption);
-            GcsObjectMeta meta = service.getObjectMeta(bucket, objectName, generation);
+            byte[] data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
+            GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath, generation);
             return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
         }
-        byte[] data = service.getObjectData(bucket, objectName, customerEncryption);
-        GcsObjectMeta meta = service.getObjectMeta(bucket, objectName);
+        byte[] data = service.getObjectData(bucket, objectPath, customerEncryption);
+        GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath);
         return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
     }
 
@@ -75,11 +71,10 @@ public class GcsXmlDownloadController {
             @Context HttpHeaders headers,
             byte[] body) {
         GcsSignedUrl.checkNotExpired(uriInfo);
-        String objectName = URLDecoder.decode(objectPath, StandardCharsets.UTF_8);
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String host = headers.getHeaderString("Host");
         String baseUrl = host != null ? "http://" + host : config.baseUrl();
-        GcsObjectMeta meta = service.putObject(bucket, objectName, contentType, body != null ? body : new byte[0],
+        GcsObjectMeta meta = service.putObject(bucket, objectPath, contentType, body != null ? body : new byte[0],
                 GcsCustomerEncryption.fromHeaders(headers), baseUrl);
         return Response.ok(meta).build();
     }

--- a/src/test/java/io/floci/gcp/services/gcs/GcsObjectNameRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsObjectNameRestIntegrationTest.java
@@ -1,0 +1,72 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class GcsObjectNameRestIntegrationTest {
+
+    private static final String BUCKET = "encoded-object-names";
+    private static final byte[] CONTENT = "encoded object".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void preservesUriEncodedObjectNames() {
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project")
+                .then().statusCode(200);
+
+        for (String objectName : List.of(
+                "literal%2Fslash",
+                "literal%20space",
+                "literal%25percent",
+                "literal%2Bplus")) {
+            String encodedPath = objectName.replace("%", "%25");
+
+            given()
+                    .queryParam("uploadType", "media")
+                    .queryParam("name", objectName)
+                    .contentType("application/octet-stream")
+                    .body(CONTENT)
+                    .when().post("/upload/storage/v1/b/" + BUCKET + "/o")
+                    .then().statusCode(200)
+                    .body("name", equalTo(objectName));
+
+            given()
+                    .urlEncodingEnabled(false)
+                    .when().get("/storage/v1/b/" + BUCKET + "/o/" + encodedPath)
+                    .then().statusCode(200)
+                    .body("name", equalTo(objectName));
+
+            given()
+                    .urlEncodingEnabled(false)
+                    .when().get("/download/storage/v1/b/" + BUCKET + "/o/" + encodedPath)
+                    .then().statusCode(200)
+                    .body(equalTo("encoded object"));
+
+            String xmlObjectName = "xml-" + objectName;
+            String encodedXmlPath = xmlObjectName.replace("%", "%25");
+            given()
+                    .urlEncodingEnabled(false)
+                    .contentType("application/octet-stream")
+                    .body(CONTENT)
+                    .when().put("/" + BUCKET + "/" + encodedXmlPath)
+                    .then().statusCode(200)
+                    .body("name", equalTo(xmlObjectName));
+
+            given()
+                    .urlEncodingEnabled(false)
+                    .when().get("/" + BUCKET + "/" + encodedXmlPath)
+                    .then().statusCode(200)
+                    .body(equalTo("encoded object"));
+        }
+    }
+}


### PR DESCRIPTION
Cloud Storage object names are opaque strings. URI-looking sequences such as
`%2F`, `%20`, `%25`, and `%2B` remain part of the object name; they are not
decoded a second time into `/`, a space, `%`, or `+`.

For an object named `literal%2Fslash`, the percent sign must be URI-encoded as
`%25`. The HTTP request target therefore contains `literal%252Fslash`. GCS
decodes the URI once and returns the original object name, including the
literal `%2F`.

Real GCS preserves the object name when using `gcloud`:

```console
$ printf 'encoded object\n' > gcs-log-http-example.txt
$ gcloud storage cp gcs-log-http-example.txt \
    gs://floci-gcloud-log-http-20260725-085458-47f02e/literal%2Fslash
Copying file://gcs-log-http-example.txt to gs://floci-gcloud-log-http-20260725-085458-47f02e/literal%2Fslash

$ gcloud storage ls 'gs://floci-gcloud-log-http-20260725-085458-47f02e/**'
gs://floci-gcloud-log-http-20260725-085458-47f02e/literal%2Fslash

$ gcloud storage cat \
    gs://floci-gcloud-log-http-20260725-085458-47f02e/literal%2Fslash
encoded object
```

The `gcloud --log-http` output exposes the actual JSON API request and
response. The authorization token is redacted by `gcloud`; unrelated headers
and response fields are omitted below:

```console
$ gcloud storage objects describe \
    gs://floci-gcloud-log-http-20260725-085458-47f02e/literal%2Fslash \
    --format='json(bucket,name,size)' \
    --log-http
=======================
==== request start ====
uri: https://storage.googleapis.com/storage/v1/b/floci-gcloud-log-http-20260725-085458-47f02e/o/literal%252Fslash?alt=json&projection=full
method: GET
== headers start ==
b'accept': b'application/json'
b'authorization': --- Token Redacted ---
== headers end ==
==== request end ====
---- response start ----
status: 200
-- headers start --
Content-Type: application/json; charset=UTF-8
-- headers end --
-- body start --
{
  "kind": "storage#object",
  "id": "floci-gcloud-log-http-20260725-085458-47f02e/literal%2Fslash/1784994917658262",
  "selfLink": "https://www.googleapis.com/storage/v1/b/floci-gcloud-log-http-20260725-085458-47f02e/o/literal%252Fslash",
  "mediaLink": "https://storage.googleapis.com/download/storage/v1/b/floci-gcloud-log-http-20260725-085458-47f02e/o/literal%252Fslash?generation=1784994917658262&alt=media",
  "name": "literal%2Fslash",
  "bucket": "floci-gcloud-log-http-20260725-085458-47f02e",
  "size": "15"
}
-- body end --
---- response end ----
----------------------
{
  "bucket": "floci-gcloud-log-http-20260725-085458-47f02e",
  "name": "literal%2Fslash",
  "size": 15
}
```

This preserves the same behavior across JSON, XML, download, and batch
operations, so clients address the object name they originally supplied.
