### PR TITLE
fix(gcs): enforce object preconditions atomically

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsComposeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsComposeTest.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression coverage for issue #1: object compose was broken
@@ -62,5 +64,21 @@ class GcsComposeTest {
                 StandardCharsets.UTF_8);
         assertThat(content).isEqualTo("hello world");
         assertThat(composed.getSize()).isEqualTo("hello world".getBytes(StandardCharsets.UTF_8).length);
+    }
+
+    @Test
+    void composeDoesNotExistPreconditionFailsWith412() {
+        storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, "precondition-source")).build(), new byte[0]);
+        BlobInfo target = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, "precondition-target")).build();
+        storage.create(target, new byte[0]);
+        Storage.ComposeRequest request = Storage.ComposeRequest.newBuilder()
+                .addSource("precondition-source")
+                .setTarget(target)
+                .setTargetOptions(Storage.BlobTargetOption.doesNotExist())
+                .build();
+
+        assertThatThrownBy(() -> storage.compose(request))
+                .isInstanceOf(StorageException.class)
+                .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(412));
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsCopyRewriteTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsCopyRewriteTest.java
@@ -6,6 +6,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Regression coverage for issue #3: copy/rewrite dropped custom object metadata
@@ -66,5 +68,21 @@ class GcsCopyRewriteTest {
         // Re-read to confirm the metadata is persisted, not just echoed.
         Blob reread = storage.get(BlobId.of(BUCKET_NAME, "dst"));
         assertThat(reread.getMetadata()).containsEntry("tag", "keep-me");
+    }
+
+    @Test
+    void copyDoesNotExistPreconditionFailsWith412() {
+        BlobId source = BlobId.of(BUCKET_NAME, "precondition-source");
+        BlobId target = BlobId.of(BUCKET_NAME, "precondition-target");
+        storage.create(BlobInfo.newBuilder(source).build(), new byte[0]);
+        storage.create(BlobInfo.newBuilder(target).build(), new byte[0]);
+        Storage.CopyRequest copyRequest = Storage.CopyRequest.newBuilder()
+                .setSource(source)
+                .setTarget(target, Storage.BlobTargetOption.doesNotExist())
+                .build();
+
+        assertThatThrownBy(() -> storage.copy(copyRequest).getResult())
+                .isInstanceOf(StorageException.class)
+                .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(412));
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsPreconditionsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsPreconditionsTest.java
@@ -99,4 +99,26 @@ class GcsPreconditionsTest {
                 Storage.BlobTargetOption.metagenerationMatch(blob.getMetageneration()));
         assertThat(updated.getContentType()).isEqualTo("text/markdown");
     }
+
+    @Test
+    @Order(5)
+    void generationNotMatchOnMissingObjectFailsWith412() {
+        BlobInfo info = BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, "missing-object")).build();
+
+        assertThatThrownBy(() -> storage.create(info, new byte[0],
+                Storage.BlobTargetOption.generationNotMatch(1)))
+                .isInstanceOf(StorageException.class)
+                .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(412));
+    }
+
+    @Test
+    @Order(6)
+    void deleteGenerationNotMatchFailsWith412() {
+        Blob blob = storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET_NAME, "delete-target")).build(), new byte[0]);
+
+        assertThatThrownBy(() -> storage.delete(blob.getBlobId(),
+                Storage.BlobSourceOption.generationNotMatch(blob.getGeneration())))
+                .isInstanceOf(StorageException.class)
+                .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(412));
+    }
 }

--- a/compatibility-tests/sdk-test-node/tests/gcs-preconditions.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/gcs-preconditions.test.ts
@@ -48,6 +48,27 @@ describe('GCS preconditions', () => {
     await expectStatus(file.save('v2', { preconditionOpts: { ifGenerationMatch: 0 } }), 412);
   });
 
+  it('ifGenerationMatch=0 atomically creates an object', async () => {
+    const file = storage.bucket(bucketName).file('create-only');
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          file.save(`writer-${index}`, { preconditionOpts: { ifGenerationMatch: 0 } }).then(
+            () => true,
+            (err) => {
+              expect(statusOf(err)).toBe(412);
+              return false;
+            },
+          ),
+        ),
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    } finally {
+      await file.delete().catch(() => {});
+    }
+  });
+
   it('a stale ifGenerationMatch fails with 412', async () => {
     const file = storage.bucket(bucketName).file(objectName);
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -4,6 +4,7 @@ import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.PageToken;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
+import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import io.floci.gcp.services.gcs.model.StoredAcl;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -171,9 +172,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             Map<String, Object> body) {
-        service.checkPreconditions(bucket, objectPath, ifGenerationMatch, ifGenerationNotMatch,
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
-        return Response.ok(service.patchObject(bucket, objectPath, body)).build();
+        return Response.ok(service.patchObject(bucket, objectPath, body, preconditions)).build();
     }
 
     @PUT
@@ -186,9 +187,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             Map<String, Object> body) {
-        service.checkPreconditions(bucket, objectPath, ifGenerationMatch, ifGenerationNotMatch,
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
-        return Response.ok(service.patchObject(bucket, objectPath, body)).build();
+        return Response.ok(service.patchObject(bucket, objectPath, body, preconditions)).build();
     }
 
     @POST
@@ -203,9 +204,9 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             Map<String, Object> body) {
         if ("PATCH".equalsIgnoreCase(methodOverride)) {
-            service.checkPreconditions(bucket, objectPath, ifGenerationMatch, ifGenerationNotMatch,
+            GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                     ifMetagenerationMatch, ifMetagenerationNotMatch);
-            return Response.ok(service.patchObject(bucket, objectPath, body)).build();
+            return Response.ok(service.patchObject(bucket, objectPath, body, preconditions)).build();
         }
         throw GcpException.invalidArgument("Unsupported method override: " + methodOverride);
     }
@@ -214,12 +215,18 @@ public class GcsObjectController {
     @Path("/{object: .+}")
     public Response deleteObject(@PathParam("bucket") String bucket,
             @PathParam("object") String objectPath,
-            @QueryParam("generation") String generation) {
+            @QueryParam("generation") String generation,
+            @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
+            @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
+            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch) {
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
+                ifMetagenerationMatch, ifMetagenerationNotMatch);
         if (generation != null) {
-            service.deleteObjectVersion(bucket, objectPath, generation);
+            service.deleteObjectVersion(bucket, objectPath, generation, preconditions);
             return Response.noContent().build();
         }
-        if (!service.deleteObject(bucket, objectPath)) {
+        if (!service.deleteObject(bucket, objectPath, preconditions)) {
             throw GcpException.notFound("Object not found: " + objectPath);
         }
         return Response.noContent().build();
@@ -230,6 +237,8 @@ public class GcsObjectController {
     @Path("/{destObject: .+}/compose")
     public Response composeObject(@PathParam("bucket") String bucket,
             @PathParam("destObject") String destObjectPath,
+            @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @Context HttpHeaders headers, Map<String, Object> body) {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> sourceObjects = body != null
@@ -240,8 +249,10 @@ public class GcsObjectController {
         String contentType = destReq != null ? (String) destReq.get("contentType") : null;
         List<String> sourceNames = sourceObjects == null ? List.of()
                 : sourceObjects.stream().map(s -> (String) s.get("name")).toList();
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, null,
+                ifMetagenerationMatch, null);
         GcsObjectMeta meta = service.composeObject(bucket, destObjectPath, sourceNames, contentType,
-                requestBaseUrl(headers));
+                preconditions, requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 
@@ -251,9 +262,15 @@ public class GcsObjectController {
             @PathParam("srcObject") String srcObjectPath,
             @PathParam("dstBucket") String dstBucket,
             @PathParam("dstObject") String dstObjectPath,
+            @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
+            @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
+            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @Context HttpHeaders headers) {
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
+                ifMetagenerationMatch, ifMetagenerationNotMatch);
         GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
-                requestBaseUrl(headers));
+                preconditions, requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 
@@ -263,9 +280,15 @@ public class GcsObjectController {
             @PathParam("srcObject") String srcObjectPath,
             @PathParam("dstBucket") String dstBucket,
             @PathParam("dstObject") String dstObjectPath,
+            @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
+            @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
+            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @Context HttpHeaders headers) {
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
+                ifMetagenerationMatch, ifMetagenerationNotMatch);
         GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
-                requestBaseUrl(headers));
+                preconditions, requestBaseUrl(headers));
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#rewriteResponse");
         response.put("totalBytesRewritten", meta.getSize());

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -13,6 +13,7 @@ import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
+import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import io.floci.gcp.services.gcs.model.ResumableUpload;
 import io.floci.gcp.services.gcs.model.StoredAcl;
 import io.floci.gcp.services.gcs.model.StoredNotification;
@@ -38,12 +39,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.CRC32C;
 
 @ApplicationScoped
 public class GcsService {
 
     private static final Logger LOG = Logger.getLogger(GcsService.class);
+    private static final int OBJECT_LOCK_COUNT = 256;
 
     private final StorageBackend<String, GcsBucket> bucketStore;
     private final StorageBackend<String, GcsObjectMeta> objectMetaStore;
@@ -51,6 +54,8 @@ public class GcsService {
     private final StorageBackend<String, StoredAcl> aclStore;
     private final StorageBackend<String, StoredNotification> notificationStore;
     private final ConcurrentHashMap<String, ResumableUpload> resumableUploads = new ConcurrentHashMap<>();
+    private final Object[] objectLocks = createObjectLocks();
+    private final AtomicLong generationSequence;
 
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
@@ -73,6 +78,7 @@ public class GcsService {
                 new TypeReference<Map<String, GcsBucket>>() {});
         this.objectMetaStore = storageFactory.createGlobal("gcs-objects", "gcs-objects.json",
                 new TypeReference<Map<String, GcsObjectMeta>>() {});
+        this.generationSequence = new AtomicLong(maxGeneration(objectMetaStore));
         this.objectDataStore = storageFactory.createGlobal("gcs-object-data", "gcs-object-data.json",
                 new TypeReference<Map<String, byte[]>>() {});
         this.aclStore = storageFactory.createGlobal("gcs-acls", "gcs-acls.json",
@@ -96,6 +102,7 @@ public class GcsService {
             String defaultProjectId) {
         this.bucketStore = bucketStore;
         this.objectMetaStore = objectMetaStore;
+        this.generationSequence = new AtomicLong(maxGeneration(objectMetaStore));
         this.objectDataStore = objectDataStore;
         this.aclStore = aclStore;
         this.defaultProjectId = defaultProjectId;
@@ -221,10 +228,31 @@ public class GcsService {
 
     public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
             GcsCustomerEncryption customerEncryption, String baseUrl) {
-        return putObject(bucket, objectName, contentType, data, customerEncryption, null, baseUrl);
+        return putObject(bucket, objectName, contentType, data, customerEncryption, null,
+                GcsObjectPreconditions.NONE, baseUrl);
     }
 
     public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
+            GcsCustomerEncryption customerEncryption, Map<String, String> userMetadata, String baseUrl) {
+        return putObject(bucket, objectName, contentType, data, customerEncryption, userMetadata,
+                GcsObjectPreconditions.NONE, baseUrl);
+    }
+
+    public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
+            GcsCustomerEncryption customerEncryption, GcsObjectPreconditions preconditions, String baseUrl) {
+        return putObject(bucket, objectName, contentType, data, customerEncryption, null, preconditions, baseUrl);
+    }
+
+    public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
+            GcsCustomerEncryption customerEncryption, Map<String, String> userMetadata,
+            GcsObjectPreconditions preconditions, String baseUrl) {
+        synchronized (objectLock(bucket, objectName)) {
+            checkPreconditions(bucket, objectName, preconditions);
+            return putObjectLocked(bucket, objectName, contentType, data, customerEncryption, userMetadata, baseUrl);
+        }
+    }
+
+    private GcsObjectMeta putObjectLocked(String bucket, String objectName, String contentType, byte[] data,
             GcsCustomerEncryption customerEncryption, Map<String, String> userMetadata, String baseUrl) {
         LOG.debugf("putObject bucket=%s name=%s contentType=%s size=%d", bucket, objectName, contentType, data.length);
         GcsBucket b = bucketStore.get(bucket).orElse(null);
@@ -233,7 +261,6 @@ public class GcsService {
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
         String key = objectKey(bucket, objectName);
-        long generation = System.currentTimeMillis();
         String now = nowTimestamp();
         String encodedName = urlEncode(objectName);
 
@@ -241,6 +268,7 @@ public class GcsService {
         if (existing != null && existing.getTimeDeleted() == null) {
             checkObjectMutable(existing);
         }
+        long generation = nextGeneration();
 
         if (isVersioningEnabled(bucket)) {
             if (existing != null) {
@@ -377,6 +405,17 @@ public class GcsService {
     }
 
     public boolean deleteObject(String bucket, String objectName) {
+        return deleteObject(bucket, objectName, GcsObjectPreconditions.NONE);
+    }
+
+    public boolean deleteObject(String bucket, String objectName, GcsObjectPreconditions preconditions) {
+        synchronized (objectLock(bucket, objectName)) {
+            checkPreconditions(bucket, objectName, preconditions);
+            return deleteObjectLocked(bucket, objectName);
+        }
+    }
+
+    private boolean deleteObjectLocked(String bucket, String objectName) {
         LOG.debugf("deleteObject bucket=%s name=%s", bucket, objectName);
         String key = objectKey(bucket, objectName);
         GcsObjectMeta live = getLiveObjectMeta(bucket, objectName).orElse(null);
@@ -393,7 +432,7 @@ public class GcsService {
             archived.setIsLatest(false);
             objectDataStore.get(key).ifPresent(oldData -> objectDataStore.put(archiveKey, oldData));
             objectMetaStore.put(archiveKey, archived);
-            long markerGen = System.currentTimeMillis() + 1;
+            long markerGen = nextGeneration();
             GcsObjectMeta marker = new GcsObjectMeta();
             marker.setName(objectName);
             marker.setBucket(bucket);
@@ -422,23 +461,50 @@ public class GcsService {
     }
 
     public void deleteObjectVersion(String bucket, String objectName, String generation) {
+        deleteObjectVersion(bucket, objectName, generation, GcsObjectPreconditions.NONE);
+    }
+
+    public void deleteObjectVersion(String bucket, String objectName, String generation,
+            GcsObjectPreconditions preconditions) {
+        synchronized (objectLock(bucket, objectName)) {
+            deleteObjectVersionLocked(bucket, objectName, generation, preconditions);
+        }
+    }
+
+    private void deleteObjectVersionLocked(String bucket, String objectName, String generation,
+            GcsObjectPreconditions preconditions) {
         LOG.debugf("deleteObjectVersion bucket=%s name=%s generation=%s", bucket, objectName, generation);
         String liveKey = objectKey(bucket, objectName);
         GcsObjectMeta live = objectMetaStore.get(liveKey).orElse(null);
         if (live != null && generation.equals(live.getGeneration())) {
+            checkPreconditions(Optional.of(live), preconditions);
             objectMetaStore.delete(liveKey);
             objectDataStore.delete(liveKey);
             return;
         }
         String archiveKey = liveKey + "\0" + generation;
-        if (objectMetaStore.get(archiveKey).isEmpty()) {
+        Optional<GcsObjectMeta> archived = objectMetaStore.get(archiveKey);
+        if (archived.isEmpty()) {
             throw GcpException.notFound("Object version not found: " + objectName + "@" + generation);
         }
+        checkPreconditions(archived, preconditions);
         objectMetaStore.delete(archiveKey);
         objectDataStore.delete(archiveKey);
     }
 
     public GcsObjectMeta patchObject(String bucket, String objectName, Map<String, Object> patch) {
+        return patchObject(bucket, objectName, patch, GcsObjectPreconditions.NONE);
+    }
+
+    public GcsObjectMeta patchObject(String bucket, String objectName, Map<String, Object> patch,
+            GcsObjectPreconditions preconditions) {
+        synchronized (objectLock(bucket, objectName)) {
+            checkPreconditions(bucket, objectName, preconditions);
+            return patchObjectLocked(bucket, objectName, patch);
+        }
+    }
+
+    private GcsObjectMeta patchObjectLocked(String bucket, String objectName, Map<String, Object> patch) {
         LOG.debugf("patchObject bucket=%s name=%s", bucket, objectName);
         String key = objectKey(bucket, objectName);
         GcsObjectMeta meta = getLiveObjectMeta(bucket, objectName)
@@ -476,6 +542,11 @@ public class GcsService {
 
     public GcsObjectMeta composeObject(String bucket, String destObject,
             List<String> sourceNames, String contentType, String baseUrl) {
+        return composeObject(bucket, destObject, sourceNames, contentType, GcsObjectPreconditions.NONE, baseUrl);
+    }
+
+    public GcsObjectMeta composeObject(String bucket, String destObject,
+            List<String> sourceNames, String contentType, GcsObjectPreconditions preconditions, String baseUrl) {
         LOG.debugf("composeObject bucket=%s dest=%s sources=%d", bucket, destObject, sourceNames.size());
         if (bucketStore.get(bucket).isEmpty()) {
             throw GcpException.notFound("Bucket not found: " + bucket);
@@ -494,20 +565,34 @@ public class GcsService {
                     .map(GcsObjectMeta::getContentType).orElse(null);
         }
         return putObject(bucket, destObject, resolvedType != null ? resolvedType : "application/octet-stream",
-                composed, GcsCustomerEncryption.none(), baseUrl);
+                composed, GcsCustomerEncryption.none(), preconditions, baseUrl);
     }
 
-    public void checkPreconditions(String bucket, String objectName,
-            Long ifGenerationMatch, Long ifGenerationNotMatch,
-            Long ifMetagenerationMatch, Long ifMetagenerationNotMatch) {
-        if (ifGenerationMatch == null && ifGenerationNotMatch == null
-                && ifMetagenerationMatch == null && ifMetagenerationNotMatch == null) {
+    private void checkPreconditions(String bucket, String objectName,
+            GcsObjectPreconditions preconditions) {
+        checkPreconditions(getLiveObjectMeta(bucket, objectName), preconditions);
+    }
+
+    private void checkPreconditions(Optional<GcsObjectMeta> metaOpt, GcsObjectPreconditions preconditions) {
+        if (preconditions.isEmpty()) {
             return;
         }
-        Optional<GcsObjectMeta> metaOpt = getLiveObjectMeta(bucket, objectName);
+        Long ifGenerationMatch = preconditions.ifGenerationMatch();
+        Long ifGenerationNotMatch = preconditions.ifGenerationNotMatch();
+        Long ifMetagenerationMatch = preconditions.ifMetagenerationMatch();
+        Long ifMetagenerationNotMatch = preconditions.ifMetagenerationNotMatch();
         if (metaOpt.isEmpty()) {
             if (ifGenerationMatch != null && ifGenerationMatch != 0) {
                 throw GcpException.conditionNotMet("ifGenerationMatch: object does not exist");
+            }
+            if (ifGenerationNotMatch != null) {
+                throw GcpException.conditionNotMet("ifGenerationNotMatch: object does not exist");
+            }
+            if (ifMetagenerationMatch != null) {
+                throw GcpException.conditionNotMet("ifMetagenerationMatch: object does not exist");
+            }
+            if (ifMetagenerationNotMatch != null) {
+                throw GcpException.conditionNotMet("ifMetagenerationNotMatch: object does not exist");
             }
             return;
         }
@@ -529,11 +614,23 @@ public class GcsService {
     }
 
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject, String baseUrl) {
+        return copyObject(srcBucket, srcObject, dstBucket, dstObject, GcsObjectPreconditions.NONE, baseUrl);
+    }
+
+    public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject,
+            GcsObjectPreconditions preconditions, String baseUrl) {
+        synchronized (objectLock(dstBucket, dstObject)) {
+            checkPreconditions(dstBucket, dstObject, preconditions);
+            return copyObjectLocked(srcBucket, srcObject, dstBucket, dstObject, baseUrl);
+        }
+    }
+
+    private GcsObjectMeta copyObjectLocked(String srcBucket, String srcObject, String dstBucket, String dstObject, String baseUrl) {
         LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
         GcsObjectMeta srcMeta = getObjectMeta(srcBucket, srcObject);
         byte[] data = getObjectData(srcBucket, srcObject, GcsCustomerEncryption.none());
-        GcsObjectMeta dstMeta = putObject(dstBucket, dstObject, srcMeta.getContentType(), data,
-                GcsCustomerEncryption.none(), baseUrl);
+        GcsObjectMeta dstMeta = putObjectLocked(dstBucket, dstObject, srcMeta.getContentType(), data,
+                GcsCustomerEncryption.none(), null, baseUrl);
         if (srcMeta.getMetadata() != null) {
             dstMeta.setMetadata(new LinkedHashMap<>(srcMeta.getMetadata()));
         }
@@ -665,6 +762,27 @@ public class GcsService {
 
     public String startResumableUpload(String bucket, String objectName, String contentType,
             GcsCustomerEncryption customerEncryption, Map<String, String> metadata) {
+        return startResumableUpload(bucket, objectName, contentType, customerEncryption, metadata,
+                GcsObjectPreconditions.NONE);
+    }
+
+    public String startResumableUpload(String bucket, String objectName, String contentType,
+            GcsCustomerEncryption customerEncryption, GcsObjectPreconditions preconditions) {
+        return startResumableUpload(bucket, objectName, contentType, customerEncryption, null, preconditions);
+    }
+
+    public String startResumableUpload(String bucket, String objectName, String contentType,
+            GcsCustomerEncryption customerEncryption, Map<String, String> metadata,
+            GcsObjectPreconditions preconditions) {
+        synchronized (objectLock(bucket, objectName)) {
+            return startResumableUploadLocked(bucket, objectName, contentType, customerEncryption, metadata,
+                    preconditions);
+        }
+    }
+
+    private String startResumableUploadLocked(String bucket, String objectName, String contentType,
+            GcsCustomerEncryption customerEncryption, Map<String, String> metadata,
+            GcsObjectPreconditions preconditions) {
         LOG.debugf("startResumableUpload bucket=%s name=%s contentType=%s", bucket, objectName, contentType);
         if (bucketStore.get(bucket).isEmpty()) {
             LOG.warnf("startResumableUpload failed: bucket not found bucket=%s", bucket);
@@ -672,7 +790,7 @@ public class GcsService {
         }
         String uploadId = UUID.randomUUID().toString();
         resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType,
-                customerEncryption.metadata(), metadata, new byte[0]));
+                customerEncryption.metadata(), metadata, preconditions, new byte[0]));
         LOG.debugf("startResumableUpload uploadId=%s", uploadId);
         return uploadId;
     }
@@ -685,7 +803,8 @@ public class GcsService {
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(), baseUrl);
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
+                upload.preconditions(), baseUrl);
     }
 
     public long appendResumableUpload(String uploadId, long start, byte[] data) {
@@ -697,7 +816,7 @@ public class GcsService {
         byte[] combined = appendChunk(upload, start, data);
         resumableUploads.put(uploadId, new ResumableUpload(
                 upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(),
-                upload.metadata(), combined));
+                upload.metadata(), upload.preconditions(), combined));
         return combined.length - 1L;
     }
 
@@ -723,7 +842,8 @@ public class GcsService {
         }
         resumableUploads.remove(uploadId);
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(), baseUrl);
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
+                upload.preconditions(), baseUrl);
     }
 
     public GcsObjectMeta completeResumableUpload(String uploadId, long start, byte[] data,
@@ -740,7 +860,8 @@ public class GcsService {
         }
         resumableUploads.remove(uploadId);
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(), baseUrl);
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
+                upload.preconditions(), baseUrl);
     }
 
     private static byte[] appendChunk(ResumableUpload upload, long start, byte[] data) {
@@ -975,6 +1096,32 @@ public class GcsService {
         copy.setEventBasedHold(src.getEventBasedHold());
         copy.setRetentionExpirationTime(src.getRetentionExpirationTime());
         return copy;
+    }
+
+    private static Object[] createObjectLocks() {
+        Object[] locks = new Object[OBJECT_LOCK_COUNT];
+        for (int i = 0; i < locks.length; i++) {
+            locks[i] = new Object();
+        }
+        return locks;
+    }
+
+    private Object objectLock(String bucket, String objectName) {
+        int index = Math.floorMod(objectKey(bucket, objectName).hashCode(), objectLocks.length);
+        return objectLocks[index];
+    }
+
+    private static long maxGeneration(StorageBackend<String, GcsObjectMeta> objectMetaStore) {
+        return objectMetaStore.scan(key -> true).stream()
+                .map(GcsObjectMeta::getGeneration)
+                .filter(generation -> generation != null)
+                .mapToLong(Long::parseLong)
+                .max()
+                .orElse(0);
+    }
+
+    private long nextGeneration() {
+        return generationSequence.updateAndGet(previous -> Math.max(previous + 1, System.currentTimeMillis()));
     }
 
     private static String objectKey(String bucket, String objectName) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
+import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -46,7 +47,7 @@ public class GcsUploadController {
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @jakarta.ws.rs.core.Context HttpHeaders headers,
             byte[] body) {
-        Preconditions preconditions = new Preconditions(ifGenerationMatch, ifGenerationNotMatch,
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         if ("multipart".equals(uploadType)) {
             return handleMultipart(bucket, nameParam, headers, body, preconditions);
@@ -56,14 +57,6 @@ public class GcsUploadController {
             return handleMedia(bucket, nameParam, headers, body, preconditions);
         }
         throw GcpException.invalidArgument("unsupported uploadType: " + uploadType);
-    }
-
-    private record Preconditions(Long ifGenerationMatch, Long ifGenerationNotMatch,
-            Long ifMetagenerationMatch, Long ifMetagenerationNotMatch) {
-        void check(GcsService service, String bucket, String objectName) {
-            service.checkPreconditions(bucket, objectName, ifGenerationMatch, ifGenerationNotMatch,
-                    ifMetagenerationMatch, ifMetagenerationNotMatch);
-        }
     }
 
     @PUT
@@ -154,7 +147,7 @@ public class GcsUploadController {
     }
 
     private Response handleMultipart(String bucket, String nameParam, HttpHeaders headers, byte[] body,
-            Preconditions preconditions) {
+            GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String[] rawParts = parseMultipartRaw(contentType, new String(body, ISO));
 
@@ -174,15 +167,14 @@ public class GcsUploadController {
             objectContentType = extractPartHeader(rawParts[1], "content-type");
         }
         var userMetadata = extractUserMetadata(metadata);
-        preconditions.check(service, bucket, objectName);
         byte[] dataBytes = extractPartBody(rawParts[1]).getBytes(ISO);
         GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes,
-                GcsCustomerEncryption.fromHeaders(headers), userMetadata, requestBaseUrl(headers));
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions, requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 
     private Response handleStartResumable(String bucket, String nameParam, HttpHeaders headers, byte[] body,
-            Preconditions preconditions) {
+            GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString("X-Upload-Content-Type");
         String name = nameParam;
         Map<String, String> userMetadata = null;
@@ -211,9 +203,8 @@ public class GcsUploadController {
             contentType = "application/octet-stream";
         }
 
-        preconditions.check(service, bucket, name);
         String uploadId = service.startResumableUpload(bucket, name, contentType,
-                GcsCustomerEncryption.fromHeaders(headers), userMetadata);
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions);
         String location = requestBaseUrl(headers) + "/upload/storage/v1/b/" + bucket
                 + "/o?uploadType=resumable&upload_id=" + uploadId;
 
@@ -221,11 +212,10 @@ public class GcsUploadController {
     }
 
     private Response handleMedia(String bucket, String name, HttpHeaders headers, byte[] body,
-            Preconditions preconditions) {
+            GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
-        preconditions.check(service, bucket, name);
         GcsObjectMeta meta = service.putObject(bucket, name, contentType, body,
-                GcsCustomerEncryption.fromHeaders(headers), requestBaseUrl(headers));
+                GcsCustomerEncryption.fromHeaders(headers), preconditions, requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectPreconditions.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectPreconditions.java
@@ -1,0 +1,12 @@
+package io.floci.gcp.services.gcs.model;
+
+public record GcsObjectPreconditions(Long ifGenerationMatch, Long ifGenerationNotMatch,
+        Long ifMetagenerationMatch, Long ifMetagenerationNotMatch) {
+
+    public static final GcsObjectPreconditions NONE = new GcsObjectPreconditions(null, null, null, null);
+
+    public boolean isEmpty() {
+        return ifGenerationMatch == null && ifGenerationNotMatch == null
+                && ifMetagenerationMatch == null && ifMetagenerationNotMatch == null;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
@@ -3,4 +3,5 @@ package io.floci.gcp.services.gcs.model;
 import java.util.Map;
 
 public record ResumableUpload(String bucket, String objectName, String contentType,
-        Map<String, String> customerEncryption, Map<String, String> metadata, byte[] data) {}
+        Map<String, String> customerEncryption, Map<String, String> metadata,
+        GcsObjectPreconditions preconditions, byte[] data) {}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsObjectPreconditionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsObjectPreconditionRestIntegrationTest.java
@@ -1,0 +1,78 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class GcsObjectPreconditionRestIntegrationTest {
+
+    private static final String BUCKET = "object-preconditions";
+
+    @Test
+    void enforcesMutationPreconditions() {
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project")
+                .then().statusCode(200);
+
+        Response upload = upload("delete-target", "data");
+        String generation = upload.path("generation");
+        String metageneration = upload.path("metageneration");
+
+        assertDeleteFails("ifGenerationMatch", "0");
+        assertDeleteFails("ifGenerationNotMatch", generation);
+        assertDeleteFails("ifMetagenerationMatch", "999");
+        assertDeleteFails("ifMetagenerationNotMatch", metageneration);
+
+        upload("compose-source", "source");
+        upload("compose-target", "target");
+
+        given()
+                .queryParam("ifGenerationMatch", 0)
+                .contentType("application/json")
+                .body(Map.of("sourceObjects", List.of(Map.of("name", "compose-source"))))
+                .when().post("/storage/v1/b/" + BUCKET + "/o/compose-target/compose")
+                .then().statusCode(412);
+
+        upload("copy-source", "source");
+        upload("copy-target", "target");
+
+        given()
+                .queryParam("ifGenerationMatch", 0)
+                .when().post("/storage/v1/b/" + BUCKET + "/o/copy-source/copyTo/b/" + BUCKET + "/o/copy-target")
+                .then().statusCode(412);
+
+        upload("rewrite-source", "source");
+        upload("rewrite-target", "target");
+
+        given()
+                .queryParam("ifGenerationMatch", 0)
+                .when().post("/storage/v1/b/" + BUCKET + "/o/rewrite-source/rewriteTo/b/" + BUCKET + "/o/rewrite-target")
+                .then().statusCode(412);
+    }
+
+    private static Response upload(String objectName, String content) {
+        return given()
+                .queryParam("uploadType", "media")
+                .queryParam("name", objectName)
+                .contentType("text/plain")
+                .body(content)
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .extract().response();
+    }
+
+    private static void assertDeleteFails(String precondition, String value) {
+        given()
+                .queryParam(precondition, value)
+                .when().delete("/storage/v1/b/" + BUCKET + "/o/delete-target")
+                .then().statusCode(412);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsObjectPreconditionTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsObjectPreconditionTest.java
@@ -1,0 +1,184 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.gcs.model.GcsBucket;
+import io.floci.gcp.services.gcs.model.GcsObjectMeta;
+import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
+import io.floci.gcp.services.gcs.model.StoredAcl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GcsObjectPreconditionTest {
+
+    private static final String BASE_URL = "http://localhost:4588";
+    private static final String BUCKET = "precondition-bucket";
+    private static final String OBJECT = "object";
+    private static final int WRITERS = 16;
+
+    private GcsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GcsService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                "test-project");
+        service.createBucket(BUCKET, "test-project", BASE_URL, Map.of());
+    }
+
+    @Test
+    void atomicallyCreatesObjectWhenItDoesNotExist() throws Exception {
+        GcsObjectPreconditions createOnly = new GcsObjectPreconditions(0L, null, null, null);
+
+        int successes = runConcurrent(index -> put("value-" + index, createOnly));
+
+        assertEquals(1, successes);
+    }
+
+    @Test
+    void atomicallyReplacesMatchingGeneration() throws Exception {
+        GcsObjectMeta initial = put("initial", GcsObjectPreconditions.NONE);
+        long generation = Long.parseLong(initial.getGeneration());
+        GcsObjectPreconditions matchesGeneration = new GcsObjectPreconditions(generation, null, null, null);
+
+        int successes = runConcurrent(index -> put("value-" + index, matchesGeneration));
+
+        assertEquals(1, successes);
+        assertNotEquals(initial.getGeneration(), service.getObjectMeta(BUCKET, OBJECT).getGeneration());
+    }
+
+    @Test
+    void atomicallyPatchesMatchingMetageneration() throws Exception {
+        put("initial", GcsObjectPreconditions.NONE);
+        GcsObjectPreconditions matchesMetageneration = new GcsObjectPreconditions(null, null, 1L, null);
+
+        int successes = runConcurrent(index -> service.patchObject(
+                BUCKET,
+                OBJECT,
+                Map.of("metadata", Map.of("writer", String.valueOf(index))),
+                matchesMetageneration));
+
+        assertEquals(1, successes);
+        assertEquals("2", service.getObjectMeta(BUCKET, OBJECT).getMetageneration());
+    }
+
+    @Test
+    void generationNotMatchFailsWhenObjectDoesNotExist() {
+        GcsObjectPreconditions preconditions = new GcsObjectPreconditions(null, 1L, null, null);
+
+        GcpException exception = assertThrows(GcpException.class, () -> put("value", preconditions));
+
+        assertEquals(412, exception.getHttpStatus());
+    }
+
+    @Test
+    void checksResumablePreconditionAgainWhenUploadCompletes() {
+        GcsObjectPreconditions createOnly = new GcsObjectPreconditions(0L, null, null, null);
+        String uploadId = service.startResumableUpload(BUCKET, OBJECT, "text/plain", GcsCustomerEncryption.none(), createOnly);
+        byte[] competing = "competing".getBytes(StandardCharsets.UTF_8);
+        service.putObject(BUCKET, OBJECT, "text/plain", competing, BASE_URL);
+
+        GcpException exception = assertThrows(GcpException.class,
+                () -> service.completeResumableUpload(
+                        uploadId, "original".getBytes(StandardCharsets.UTF_8), BASE_URL));
+
+        assertEquals(412, exception.getHttpStatus());
+        assertArrayEquals(competing, service.getObjectData(BUCKET, OBJECT));
+    }
+
+    @Test
+    void defersResumablePreconditionCheckUntilUploadCompletes() {
+        put("existing", GcsObjectPreconditions.NONE);
+        GcsObjectPreconditions createOnly = new GcsObjectPreconditions(0L, null, null, null);
+
+        String uploadId = service.startResumableUpload(BUCKET, OBJECT, "text/plain", GcsCustomerEncryption.none(), createOnly);
+
+        GcpException exception = assertThrows(GcpException.class,
+                () -> service.completeResumableUpload(
+                        uploadId, "replacement".getBytes(StandardCharsets.UTF_8), BASE_URL));
+        assertEquals(412, exception.getHttpStatus());
+        assertArrayEquals("existing".getBytes(StandardCharsets.UTF_8), service.getObjectData(BUCKET, OBJECT));
+    }
+
+    @Test
+    void continuesGenerationSequenceAfterRestart() {
+        InMemoryStorage<String, GcsBucket> bucketStore = new InMemoryStorage<>();
+        InMemoryStorage<String, GcsObjectMeta> objectMetaStore = new InMemoryStorage<>();
+        InMemoryStorage<String, byte[]> objectDataStore = new InMemoryStorage<>();
+        InMemoryStorage<String, StoredAcl> aclStore = new InMemoryStorage<>();
+        GcsService original = new GcsService(bucketStore, objectMetaStore, objectDataStore, aclStore, "test-project");
+        original.createBucket(BUCKET, "test-project", BASE_URL, Map.of());
+        GcsObjectMeta initial = original.putObject(
+                BUCKET, OBJECT, "text/plain", new byte[0], GcsCustomerEncryption.none(), BASE_URL);
+        long persistedGeneration = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        initial.setGeneration(String.valueOf(persistedGeneration));
+
+        GcsService restarted = new GcsService(bucketStore, objectMetaStore, objectDataStore, aclStore, "test-project");
+        GcsObjectMeta replacement = restarted.putObject(
+                BUCKET, OBJECT, "text/plain", new byte[0], GcsCustomerEncryption.none(), BASE_URL);
+
+        assertTrue(Long.parseLong(replacement.getGeneration()) > persistedGeneration);
+    }
+
+    private GcsObjectMeta put(String value, GcsObjectPreconditions preconditions) {
+        return service.putObject(
+                BUCKET,
+                OBJECT,
+                "text/plain",
+                value.getBytes(StandardCharsets.UTF_8),
+                GcsCustomerEncryption.none(),
+                preconditions,
+                BASE_URL);
+    }
+
+    private int runConcurrent(IntConsumer operation) throws Exception {
+        CountDownLatch ready = new CountDownLatch(WRITERS);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Boolean>> results = new ArrayList<>();
+        try (ExecutorService executor = Executors.newFixedThreadPool(WRITERS)) {
+            for (int index = 0; index < WRITERS; index++) {
+                int writer = index;
+                results.add(executor.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(10, TimeUnit.SECONDS));
+                    try {
+                        operation.accept(writer);
+                        return true;
+                    } catch (GcpException e) {
+                        assertEquals(412, e.getHttpStatus());
+                        return false;
+                    }
+                }));
+            }
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+            start.countDown();
+
+            int successes = 0;
+            for (Future<Boolean> result : results) {
+                if (result.get(10, TimeUnit.SECONDS)) {
+                    successes++;
+                }
+            }
+            return successes;
+        }
+    }
+}


### PR DESCRIPTION
Prevents concurrent GCS writes from both succeeding when they use the same object precondition.