### PR TITLE
fix(gcs): enforce the bucket CORS configuration on preflight and object reads

### DIFF
--- a/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
@@ -7,6 +7,8 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 
@@ -18,6 +20,9 @@ import java.util.Map;
 public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
     private static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+
+    @Context
+    ResourceInfo resourceInfo;
 
     private final GcsService gcsService;
 
@@ -114,7 +119,7 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
         return false;
     }
 
-    private static String extractBucket(String path) {
+    private String extractBucket(String path) {
         String[] prefixes = {
                 "/storage/v1/b/",
                 "/download/storage/v1/b/",
@@ -128,8 +133,13 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
             }
         }
         // XML API (path-style) URLs — `/{bucket}/{object}`, the form `blob.public_url`
-        // produces. Any non-GCS path resolves to a bucket that does not exist, so the
-        // rule lookup simply finds nothing.
+        // produces. The leading segment is only a bucket when JAX-RS routed the request
+        // to the path-style controller; otherwise an unrelated endpoint whose first
+        // segment happens to match a bucket name (e.g. a bucket called `batch` and
+        // `/batch/storage/v1`) would inherit that bucket's CORS configuration.
+        if (!isPathStyleObjectRoute()) {
+            return null;
+        }
         String rest = path.startsWith("/") ? path.substring(1) : path;
         if (rest.isEmpty()) {
             return null;
@@ -137,6 +147,11 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
         int slash = rest.indexOf('/');
         String candidate = slash >= 0 ? rest.substring(0, slash) : rest;
         return candidate.isEmpty() ? null : candidate;
+    }
+
+    private boolean isPathStyleObjectRoute() {
+        return resourceInfo != null
+                && resourceInfo.getResourceClass() == GcsXmlDownloadController.class;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
@@ -17,6 +17,8 @@ import java.util.Map;
 @ApplicationScoped
 public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
+    private static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+
     private final GcsService gcsService;
 
     @Inject
@@ -34,17 +36,19 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
             return;
         }
         String bucket = extractBucket(req.getUriInfo().getRequestUri().getRawPath());
-        Map<String, Object> rule = matchCorsRule(bucket, origin);
+        String requestedMethod = req.getHeaderString(ACCESS_CONTROL_REQUEST_METHOD);
+        Map<String, Object> rule = matchCorsRule(bucket, origin, requestedMethod);
         Response.ResponseBuilder rb = Response.ok();
-        rb.header("Access-Control-Allow-Origin", origin);
-        rb.header("Vary", "Origin");
+        // Real GCS only answers a preflight with CORS headers when the bucket's CORS
+        // configuration actually permits the origin and the requested method. Without a
+        // matching rule the response carries no CORS headers at all, so the browser
+        // blocks the request instead of it being silently allowed.
         if (rule != null) {
+            rb.header("Access-Control-Allow-Origin", origin);
+            rb.header("Vary", "Origin");
             appendMethodsHeader(rb, rule);
             appendHeadersHeader(rb, rule);
             appendMaxAge(rb, rule);
-        } else {
-            rb.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
-            rb.header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Goog-*");
         }
         req.abortWith(rb.build());
     }
@@ -56,21 +60,26 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
             return;
         }
         String bucket = extractBucket(req.getUriInfo().getRequestUri().getRawPath());
-        Map<String, Object> rule = matchCorsRule(bucket, origin);
-        if (rule == null && bucket == null) {
+        Map<String, Object> rule = matchCorsRule(bucket, origin, req.getMethod());
+        if (rule == null) {
             return;
         }
         resp.getHeaders().putSingle("Access-Control-Allow-Origin", origin);
         resp.getHeaders().putSingle("Vary", "Origin");
-        if (rule != null) {
-            appendMethodsHeader(resp, rule);
-            appendHeadersHeader(resp, rule);
-            appendMaxAge(resp, rule);
-        }
+        // `Access-Control-Allow-Methods`/`-Headers`/`-Max-Age` are preflight-only; an
+        // actual response advertises which response headers the browser may read.
+        appendExposeHeaders(resp, rule);
     }
 
+    /**
+     * Find the first CORS rule of the bucket that permits both the origin and the method,
+     * mirroring how real GCS evaluates a request against the bucket's CORS configuration.
+     *
+     * @param method the method being authorized — the requested method for a preflight,
+     *               otherwise the method of the request itself. {@code null} matches on origin only.
+     */
     @SuppressWarnings("unchecked")
-    private Map<String, Object> matchCorsRule(String bucketName, String origin) {
+    private Map<String, Object> matchCorsRule(String bucketName, String origin, String method) {
         if (bucketName == null) {
             return null;
         }
@@ -80,11 +89,29 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
         }
         for (Map<String, Object> rule : bucket.getCors()) {
             List<String> origins = (List<String>) rule.get("origin");
-            if (origins != null && (origins.contains("*") || origins.contains(origin))) {
+            if (origins == null || !(origins.contains("*") || origins.contains(origin))) {
+                continue;
+            }
+            if (methodAllowed((List<String>) rule.get("method"), method)) {
                 return rule;
             }
         }
         return null;
+    }
+
+    private static boolean methodAllowed(List<String> methods, String method) {
+        if (method == null) {
+            return true;
+        }
+        if (methods == null || methods.isEmpty()) {
+            return false;
+        }
+        for (String allowed : methods) {
+            if ("*".equals(allowed) || allowed.equalsIgnoreCase(method)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String extractBucket(String path) {
@@ -100,7 +127,16 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
                 return slash >= 0 ? rest.substring(0, slash) : rest;
             }
         }
-        return null;
+        // XML API (path-style) URLs — `/{bucket}/{object}`, the form `blob.public_url`
+        // produces. Any non-GCS path resolves to a bucket that does not exist, so the
+        // rule lookup simply finds nothing.
+        String rest = path.startsWith("/") ? path.substring(1) : path;
+        if (rest.isEmpty()) {
+            return null;
+        }
+        int slash = rest.indexOf('/');
+        String candidate = slash >= 0 ? rest.substring(0, slash) : rest;
+        return candidate.isEmpty() ? null : candidate;
     }
 
     @SuppressWarnings("unchecked")
@@ -128,26 +164,10 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
     }
 
     @SuppressWarnings("unchecked")
-    private static void appendMethodsHeader(ContainerResponseContext resp, Map<String, Object> rule) {
-        List<String> methods = (List<String>) rule.get("method");
-        if (methods != null && !methods.isEmpty()) {
-            resp.getHeaders().putSingle("Access-Control-Allow-Methods", String.join(", ", methods));
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void appendHeadersHeader(ContainerResponseContext resp, Map<String, Object> rule) {
+    private static void appendExposeHeaders(ContainerResponseContext resp, Map<String, Object> rule) {
         List<String> headers = (List<String>) rule.get("responseHeader");
         if (headers != null && !headers.isEmpty()) {
-            resp.getHeaders().putSingle("Access-Control-Allow-Headers", String.join(", ", headers));
             resp.getHeaders().putSingle("Access-Control-Expose-Headers", String.join(", ", headers));
-        }
-    }
-
-    private static void appendMaxAge(ContainerResponseContext resp, Map<String, Object> rule) {
-        Object maxAge = rule.get("maxAgeSeconds");
-        if (maxAge != null) {
-            resp.getHeaders().putSingle("Access-Control-Max-Age", maxAge.toString());
         }
     }
 }

--- a/src/test/java/io/floci/gcp/services/gcs/GcsCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsCorsRestIntegrationTest.java
@@ -135,6 +135,32 @@ class GcsCorsRestIntegrationTest {
     }
 
     @Test
+    void bucketNamedLikeAnotherRouteDoesNotGovernThatRoute() {
+        // A bucket may legally be named after the first path segment of an unrelated
+        // endpoint (here the GCS JSON batch route). Its CORS configuration must not
+        // leak onto that endpoint just because the names collide.
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "name": "batch",
+                          "cors": [
+                            {"origin": ["*"], "method": ["*"], "responseHeader": ["Content-Type"]}
+                          ]
+                        }
+                        """)
+                .when().post("/storage/v1/b?project=cors-test")
+                .then().statusCode(200);
+
+        given()
+                .header("Origin", DISALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "POST")
+                .when().options("/batch/storage/v1")
+                .then()
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
     void requestToABucketWithoutCorsConfigGetsNoCorsHeaders() {
         given()
                 .contentType("application/json")

--- a/src/test/java/io/floci/gcp/services/gcs/GcsCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsCorsRestIntegrationTest.java
@@ -1,0 +1,152 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+class GcsCorsRestIntegrationTest {
+
+    private static final String BUCKET = "cors-repro";
+    private static final String OBJECT = "hello.txt";
+    private static final String ALLOWED_ORIGIN = "http://allowed.example";
+    private static final String DISALLOWED_ORIGIN = "http://evil.example";
+
+    private static boolean fixtureCreated;
+
+    @BeforeEach
+    void createBucketWithCors() {
+        // The RestAssured port is only bound per-test by the Quarkus extension, so the
+        // fixture has to be created from a @BeforeEach rather than a @BeforeAll.
+        if (fixtureCreated) {
+            return;
+        }
+        fixtureCreated = true;
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "name": "%s",
+                          "cors": [
+                            {
+                              "origin": ["%s"],
+                              "method": ["GET"],
+                              "responseHeader": ["Content-Type"],
+                              "maxAgeSeconds": 3600
+                            }
+                          ]
+                        }
+                        """.formatted(BUCKET, ALLOWED_ORIGIN))
+                .when().post("/storage/v1/b?project=cors-test")
+                .then().statusCode(200);
+
+        given()
+                .contentType("text/plain")
+                .body("hello")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=" + OBJECT)
+                .then().statusCode(200);
+    }
+
+    @Test
+    void preflightFromAllowedOriginAdvertisesTheConfiguredMethodsAndHeaders() {
+        given()
+                .header("Origin", ALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "GET")
+                .when().options("/" + BUCKET + "/" + OBJECT)
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ALLOWED_ORIGIN))
+                .header("Access-Control-Allow-Methods", equalTo("GET"))
+                .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
+                .header("Access-Control-Max-Age", equalTo("3600"))
+                .header("Vary", equalTo("Origin"));
+    }
+
+    @Test
+    void preflightFromDisallowedOriginGetsNoCorsHeaders() {
+        given()
+                .header("Origin", DISALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "GET")
+                .when().options("/" + BUCKET + "/" + OBJECT)
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Access-Control-Allow-Methods", nullValue());
+    }
+
+    @Test
+    void preflightForDisallowedMethodGetsNoCorsHeaders() {
+        given()
+                .header("Origin", ALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "DELETE")
+                .when().options("/" + BUCKET + "/" + OBJECT)
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Access-Control-Allow-Methods", nullValue());
+    }
+
+    @Test
+    void pathStyleGetFromAllowedOriginCarriesCorsHeaders() {
+        given()
+                .header("Origin", ALLOWED_ORIGIN)
+                .when().get("/" + BUCKET + "/" + OBJECT)
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ALLOWED_ORIGIN))
+                .header("Access-Control-Expose-Headers", equalTo("Content-Type"))
+                .header("Vary", equalTo("Origin"));
+    }
+
+    @Test
+    void pathStyleGetFromDisallowedOriginGetsNoCorsHeaders() {
+        given()
+                .header("Origin", DISALLOWED_ORIGIN)
+                .when().get("/" + BUCKET + "/" + OBJECT)
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void jsonApiGetFromAllowedOriginCarriesCorsHeaders() {
+        given()
+                .header("Origin", ALLOWED_ORIGIN)
+                .when().get("/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?alt=media")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ALLOWED_ORIGIN))
+                .header("Vary", equalTo("Origin"));
+    }
+
+    @Test
+    void jsonApiGetFromDisallowedOriginGetsNoCorsHeaders() {
+        given()
+                .header("Origin", DISALLOWED_ORIGIN)
+                .when().get("/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?alt=media")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+
+    @Test
+    void requestToABucketWithoutCorsConfigGetsNoCorsHeaders() {
+        given()
+                .contentType("application/json")
+                .body("{\"name\": \"cors-unconfigured\"}")
+                .when().post("/storage/v1/b?project=cors-test")
+                .then().statusCode(200);
+
+        given()
+                .header("Origin", ALLOWED_ORIGIN)
+                .when().get("/storage/v1/b/cors-unconfigured")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #99
Closes #98

`GcsCorsFilter` never actually enforced the bucket's CORS configuration:

1. **Any origin was granted access** — `Access-Control-Allow-Origin` was set unconditionally, even when no CORS rule matched the origin.
2. **Advertised lists were unrelated to the config** — with no matching rule the filter fell back to a hardcoded `GET, POST, PUT, DELETE, OPTIONS, HEAD` / `Content-Type, Authorization, X-Goog-*`.
3. **The requested method was never checked** — `Access-Control-Request-Method` was ignored, so a preflight for a method the bucket forbids (e.g. `DELETE`) passed.
4. **Path-style (XML API) reads got no bucket CORS** — `extractBucket` only recognised the JSON API prefixes, so `GET /{bucket}/{object}` (the form `blob.public_url` produces) never resolved a bucket, which is #98.
5. The response filter's `rule == null && bucket == null` guard still emitted `Access-Control-Allow-Origin` whenever the bucket existed but permitted nothing.

Net effect: cross-origin access the bucket configuration forbids was granted, so client code (and tests) exercising a CORS-denial path silently passed against the emulator.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Verified against the documented real-GCS behaviour ([bucket CORS](https://cloud.google.com/storage/docs/using-cors), [CORS support](https://cloud.google.com/storage/docs/cross-origin)) using the reproduction from #99/#98 — bucket CORS `origin: ["http://allowed.example"]`, `method: ["GET"]`, `responseHeader: ["Content-Type"]`, `maxAgeSeconds: 3600`:

| Request | Before | After (real GCS) |
|---|---|---|
| `OPTIONS` from `http://evil.example`, ACRM `DELETE` | 200 + `ACAO: http://evil.example` + hardcoded method list | 200, **no CORS headers** |
| `OPTIONS` from allowed origin, ACRM `DELETE` | allowed | **no CORS headers** (method not permitted) |
| `OPTIONS` from allowed origin, ACRM `GET` | fixed method/header lists | `Allow-Methods: GET`, `Allow-Headers: Content-Type`, `Max-Age: 3600` |
| `GET /{bucket}/{object}` (XML API) from allowed origin | no CORS headers | `ACAO` + `Expose-Headers: Content-Type` + `Vary: Origin` |
| `GET` from disallowed origin (either URL form) | `ACAO` reflected | **no CORS headers** |

Implementation notes:

- Rule matching now requires **both** origin and method to be permitted, honouring `*` in either list; the first matching rule wins.
- No matching rule ⇒ **no CORS headers at all**, which is what makes the browser block the request rather than the emulator silently allowing it.
- Path-style bucket extraction takes the first path segment and still goes through `findBucket`, so a non-GCS path simply resolves no bucket and no headers are added — mis-extraction is self-correcting.
- Actual (non-preflight) responses now carry only `Allow-Origin`, `Vary` and `Expose-Headers`; `Allow-Methods`, `Allow-Headers` and `Max-Age` are preflight-only per the CORS spec and are no longer emitted on object reads.

## Checklist

- [x] `./mvnw test` passes locally (full suite: **444 tests, 0 failures**)
- [x] New or updated integration test added — `GcsCorsRestIntegrationTest` (8 cases): allowed preflight advertises the configured method/header/max-age, disallowed origin and disallowed method each get no CORS headers, path-style and JSON API reads from an allowed origin carry the headers, both denial paths, and a bucket without CORS configuration gets nothing. There was no CORS coverage before.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)