### PR TITLE
fix(pubsub): apply subscription filters when delivering messages

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
@@ -3,6 +3,7 @@ package io.floci.gcp.test;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
@@ -39,6 +40,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class PubSubTest {
@@ -350,6 +352,156 @@ class PubSubTest {
                 .forEach(t -> topicNames.add(t.getName()));
 
         assertThat(topicNames).doesNotContain(topicName.toString());
+    }
+
+    @Test
+    @Order(14)
+    void subscriptionFilterOnlyDeliversMatchingMessages() throws Exception {
+        String topicId = TestFixtures.uniqueName("filter-topic");
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, topicId);
+        ProjectSubscriptionName filtered =
+                ProjectSubscriptionName.of(PROJECT_ID, TestFixtures.uniqueName("filtered-sub"));
+        ProjectSubscriptionName unfiltered =
+                ProjectSubscriptionName.of(PROJECT_ID, TestFixtures.uniqueName("unfiltered-sub"));
+
+        topicAdminClient.createTopic(topicName);
+        subscriptionAdminClient.createSubscription(Subscription.newBuilder()
+                .setName(filtered.toString())
+                .setTopic(topicName.toString())
+                .setAckDeadlineSeconds(10)
+                .setFilter("attributes.event_type = \"ocr-invoice\"")
+                .build());
+        subscriptionAdminClient.createSubscription(
+                unfiltered, topicName, PushConfig.getDefaultInstance(), 10);
+
+        try {
+            assertThat(subscriptionAdminClient.getSubscription(filtered).getFilter())
+                    .isEqualTo("attributes.event_type = \"ocr-invoice\"");
+
+            Publisher publisher = Publisher.newBuilder(topicName)
+                    .setChannelProvider(channelProvider)
+                    .setCredentialsProvider(credentialsProvider)
+                    .build();
+            try {
+                publisher.publish(PubsubMessage.newBuilder()
+                        .setData(ByteString.copyFromUtf8("excluded"))
+                        .putAttributes("event_type", "portal.upload")
+                        .build()).get(10, TimeUnit.SECONDS);
+                publisher.publish(PubsubMessage.newBuilder()
+                        .setData(ByteString.copyFromUtf8("included"))
+                        .putAttributes("event_type", "ocr-invoice")
+                        .build()).get(10, TimeUnit.SECONDS);
+            } finally {
+                publisher.shutdown();
+                publisher.awaitTermination(5, TimeUnit.SECONDS);
+            }
+
+            SubscriberStubSettings subscriberStubSettings = SubscriberStubSettings.newBuilder()
+                    .setTransportChannelProvider(channelProvider)
+                    .setCredentialsProvider(credentialsProvider)
+                    .build();
+
+            try (GrpcSubscriberStub subscriberStub = GrpcSubscriberStub.create(subscriberStubSettings)) {
+                PullResponse filteredResponse = subscriberStub.pullCallable().call(PullRequest.newBuilder()
+                        .setSubscription(filtered.toString())
+                        .setMaxMessages(10)
+                        .build());
+
+                assertThat(filteredResponse.getReceivedMessagesList()).hasSize(1);
+                assertThat(filteredResponse.getReceivedMessages(0).getMessage().getData().toStringUtf8())
+                        .isEqualTo("included");
+
+                PullResponse unfilteredResponse = subscriberStub.pullCallable().call(PullRequest.newBuilder()
+                        .setSubscription(unfiltered.toString())
+                        .setMaxMessages(10)
+                        .build());
+
+                assertThat(unfilteredResponse.getReceivedMessagesList()).hasSize(2);
+            }
+        } finally {
+            try { subscriptionAdminClient.deleteSubscription(filtered); } catch (Exception ignored) {}
+            try { subscriptionAdminClient.deleteSubscription(unfiltered); } catch (Exception ignored) {}
+            try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
+        }
+    }
+
+    @Test
+    @Order(15)
+    void hasPrefixFilterOnlyDeliversMatchingMessages() throws Exception {
+        String topicId = TestFixtures.uniqueName("prefix-topic");
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, topicId);
+        ProjectSubscriptionName subName =
+                ProjectSubscriptionName.of(PROJECT_ID, TestFixtures.uniqueName("prefix-sub"));
+
+        topicAdminClient.createTopic(topicName);
+        subscriptionAdminClient.createSubscription(Subscription.newBuilder()
+                .setName(subName.toString())
+                .setTopic(topicName.toString())
+                .setAckDeadlineSeconds(10)
+                .setFilter("hasPrefix(attributes.event_type, \"portal.\")")
+                .build());
+
+        try {
+            Publisher publisher = Publisher.newBuilder(topicName)
+                    .setChannelProvider(channelProvider)
+                    .setCredentialsProvider(credentialsProvider)
+                    .build();
+            try {
+                publisher.publish(PubsubMessage.newBuilder()
+                        .setData(ByteString.copyFromUtf8("excluded"))
+                        .putAttributes("event_type", "ocr-invoice")
+                        .build()).get(10, TimeUnit.SECONDS);
+                publisher.publish(PubsubMessage.newBuilder()
+                        .setData(ByteString.copyFromUtf8("included"))
+                        .putAttributes("event_type", "portal.upload")
+                        .build()).get(10, TimeUnit.SECONDS);
+            } finally {
+                publisher.shutdown();
+                publisher.awaitTermination(5, TimeUnit.SECONDS);
+            }
+
+            SubscriberStubSettings subscriberStubSettings = SubscriberStubSettings.newBuilder()
+                    .setTransportChannelProvider(channelProvider)
+                    .setCredentialsProvider(credentialsProvider)
+                    .build();
+
+            try (GrpcSubscriberStub subscriberStub = GrpcSubscriberStub.create(subscriberStubSettings)) {
+                PullResponse response = subscriberStub.pullCallable().call(PullRequest.newBuilder()
+                        .setSubscription(subName.toString())
+                        .setMaxMessages(10)
+                        .build());
+
+                assertThat(response.getReceivedMessagesList()).hasSize(1);
+                assertThat(response.getReceivedMessages(0).getMessage().getData().toStringUtf8())
+                        .isEqualTo("included");
+            }
+        } finally {
+            try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
+            try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
+        }
+    }
+
+    @Test
+    @Order(16)
+    void unparseableFilterIsRejected() {
+        String topicId = TestFixtures.uniqueName("bad-filter-topic");
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, topicId);
+        ProjectSubscriptionName subName =
+                ProjectSubscriptionName.of(PROJECT_ID, TestFixtures.uniqueName("bad-filter-sub"));
+
+        topicAdminClient.createTopic(topicName);
+        try {
+            assertThatThrownBy(() -> subscriptionAdminClient.createSubscription(Subscription.newBuilder()
+                    .setName(subName.toString())
+                    .setTopic(topicName.toString())
+                    .setAckDeadlineSeconds(10)
+                    .setFilter("this is not a filter (((")
+                    .build()))
+                    .isInstanceOf(InvalidArgumentException.class);
+        } finally {
+            try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
+            try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
+        }
     }
 
     @Test

--- a/compatibility-tests/sdk-test-python/tests/test_pubsub.py
+++ b/compatibility-tests/sdk-test-python/tests/test_pubsub.py
@@ -70,6 +70,101 @@ def test_publish_and_pull_messages(pubsub_publisher, pubsub_subscriber, project_
         pubsub_publisher.delete_topic(request={"topic": topic_path})
 
 
+def test_subscription_filter_only_delivers_matching_messages(
+    pubsub_publisher, pubsub_subscriber, project_id, unique_name
+):
+    topic_path = pubsub_publisher.topic_path(project_id, f"filter-topic-{unique_name}")
+    filtered_path = pubsub_subscriber.subscription_path(project_id, f"filtered-sub-{unique_name}")
+    unfiltered_path = pubsub_subscriber.subscription_path(project_id, f"unfiltered-sub-{unique_name}")
+
+    pubsub_publisher.create_topic(request={"name": topic_path})
+    sub = pubsub_subscriber.create_subscription(
+        request={
+            "name": filtered_path,
+            "topic": topic_path,
+            "filter": 'attributes.event_type = "ocr-invoice"',
+        }
+    )
+    pubsub_subscriber.create_subscription(
+        request={"name": unfiltered_path, "topic": topic_path}
+    )
+
+    try:
+        assert sub.filter == 'attributes.event_type = "ocr-invoice"'
+
+        pubsub_publisher.publish(topic_path, b"excluded", event_type="portal.upload").result(timeout=10)
+        pubsub_publisher.publish(topic_path, b"included", event_type="ocr-invoice").result(timeout=10)
+
+        time.sleep(0.2)
+        filtered = pubsub_subscriber.pull(
+            request={"subscription": filtered_path, "max_messages": 10}
+        )
+        assert len(filtered.received_messages) == 1
+        assert filtered.received_messages[0].message.data == b"included"
+
+        unfiltered = pubsub_subscriber.pull(
+            request={"subscription": unfiltered_path, "max_messages": 10}
+        )
+        assert len(unfiltered.received_messages) == 2
+    finally:
+        pubsub_subscriber.delete_subscription(request={"subscription": filtered_path})
+        pubsub_subscriber.delete_subscription(request={"subscription": unfiltered_path})
+        pubsub_publisher.delete_topic(request={"topic": topic_path})
+
+
+def test_has_prefix_filter_only_delivers_matching_messages(
+    pubsub_publisher, pubsub_subscriber, project_id, unique_name
+):
+    topic_path = pubsub_publisher.topic_path(project_id, f"prefix-topic-{unique_name}")
+    sub_path = pubsub_subscriber.subscription_path(project_id, f"prefix-sub-{unique_name}")
+
+    pubsub_publisher.create_topic(request={"name": topic_path})
+    pubsub_subscriber.create_subscription(
+        request={
+            "name": sub_path,
+            "topic": topic_path,
+            "filter": 'hasPrefix(attributes.event_type, "portal.")',
+        }
+    )
+
+    try:
+        pubsub_publisher.publish(topic_path, b"excluded", event_type="ocr-invoice").result(timeout=10)
+        pubsub_publisher.publish(topic_path, b"included", event_type="portal.upload").result(timeout=10)
+
+        time.sleep(0.2)
+        response = pubsub_subscriber.pull(
+            request={"subscription": sub_path, "max_messages": 10}
+        )
+        assert len(response.received_messages) == 1
+        assert response.received_messages[0].message.data == b"included"
+    finally:
+        pubsub_subscriber.delete_subscription(request={"subscription": sub_path})
+        pubsub_publisher.delete_topic(request={"topic": topic_path})
+
+
+def test_unparseable_filter_is_rejected(
+    pubsub_publisher, pubsub_subscriber, project_id, unique_name
+):
+    from google.api_core.exceptions import InvalidArgument
+
+    topic_path = pubsub_publisher.topic_path(project_id, f"bad-filter-topic-{unique_name}")
+    sub_path = pubsub_subscriber.subscription_path(project_id, f"bad-filter-sub-{unique_name}")
+
+    pubsub_publisher.create_topic(request={"name": topic_path})
+
+    try:
+        with pytest.raises(InvalidArgument):
+            pubsub_subscriber.create_subscription(
+                request={
+                    "name": sub_path,
+                    "topic": topic_path,
+                    "filter": "this is not a filter (((",
+                }
+            )
+    finally:
+        pubsub_publisher.delete_topic(request={"topic": topic_path})
+
+
 def test_list_topics(pubsub_publisher, project_id, unique_name):
     topic_id = f"test-topic-{unique_name}"
     topic_path = pubsub_publisher.topic_path(project_id, topic_id)

--- a/docs/services/pubsub.md
+++ b/docs/services/pubsub.md
@@ -159,6 +159,57 @@ The REST surface supports topic and subscription create/read/list/update/delete,
         print(msg.message.data.decode())
     ```
 
+## Subscription Filters
+
+A subscription can declare a `filter` so it only receives messages whose attributes match it.
+Non-matching messages are never delivered to that subscription — as in GCP, which acknowledges
+them automatically on your behalf. Subscriptions without a filter receive every message published
+to the topic.
+
+```java
+subscriptionAdminClient.createSubscription(Subscription.newBuilder()
+    .setName(SubscriptionName.of("floci-local", "invoices").toString())
+    .setTopic(TopicName.of("floci-local", "events").toString())
+    .setAckDeadlineSeconds(10)
+    .setFilter("attributes.event_type = \"ocr-invoice\"")
+    .build());
+```
+
+```python
+subscriber.create_subscription(request={
+    "name": sub_path,
+    "topic": topic_path,
+    "filter": 'attributes.event_type = "ocr-invoice"',
+})
+```
+
+### Supported syntax
+
+| Form | Example | Matches |
+|---|---|---|
+| Attribute exists | `attributes:name` | messages that carry a `name` attribute |
+| Quoted key | `attributes:"iana.org/language_tag"` | keys with characters other than hyphens, underscores or alphanumerics |
+| Equality | `attributes.name = "com"` | `name` is exactly `com` |
+| Inequality | `attributes.name != "com"` | `name` differs from `com`, **including when the attribute is absent** |
+| Prefix | `hasPrefix(attributes.name, "co")` | `name` starts with `co` |
+| Conjunction | `attributes:a AND attributes.b = "1"` | both operands match |
+| Disjunction | `attributes.a = "1" OR attributes.a = "2"` | either operand matches |
+| Negation | `NOT attributes:a` / `-attributes:a` | operand does not match |
+
+Rules that mirror GCP:
+
+- Keys and values are **case-sensitive**; `AND`, `OR` and `NOT` must be **uppercase**.
+- `NOT` has the highest precedence; `-` is a unary alias for it.
+- `AND` and `OR` **cannot be combined without parentheses**. `a AND b OR c` is a syntax error;
+  write `a AND (b OR c)`.
+- `hasPrefix` is the only function — there is no regular-expression support.
+- String literals may contain unicode, hexadecimal and octal escape sequences, for example
+  `attributes:"みんな"`. Escapes outside a string literal are invalid.
+- A filter must be at most **256 bytes**.
+
+An unparseable filter, or one over the byte limit, is rejected with `INVALID_ARGUMENT` when the
+subscription is created or updated, rather than being accepted and silently ignored.
+
 ## Push Subscriptions
 
 floci-gcp supports push subscriptions — it delivers messages to an HTTP endpoint you configure:

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -249,15 +249,15 @@ public class PubSubService {
             com.google.protobuf.FieldMask updateMask) {
         LOG.infof("updateSubscription name=%s", subProto.getName());
         StoredSubscription stored = getSubscription(subProto.getName());
+        if (updateMask.getPathsList().contains("filter")) {
+            SubscriptionFilter.validate(subProto.getFilter());
+        }
         for (String path : updateMask.getPathsList()) {
             switch (path) {
                 case "ack_deadline_seconds" -> stored.setAckDeadlineSeconds(subProto.getAckDeadlineSeconds());
                 case "labels" -> stored.setLabels(subProto.getLabelsMap().isEmpty() ? null
                         : new java.util.HashMap<>(subProto.getLabelsMap()));
-                case "filter" -> {
-                    SubscriptionFilter.validate(subProto.getFilter());
-                    stored.setFilter(subProto.getFilter().isEmpty() ? null : subProto.getFilter());
-                }
+                case "filter" -> stored.setFilter(subProto.getFilter().isEmpty() ? null : subProto.getFilter());
                 case "retain_acked_messages" -> stored.setRetainAckedMessages(subProto.getRetainAckedMessages());
                 case "message_retention_duration" -> {
                     if (subProto.hasMessageRetentionDuration()) {
@@ -303,6 +303,10 @@ public class PubSubService {
         StoredSubscription stored = getSubscription(name);
         boolean replaceAll = updateMaskPaths == null || updateMaskPaths.isEmpty();
 
+        if (replaceAll || masked(updateMaskPaths, "filter")) {
+            SubscriptionFilter.validate(filter);
+        }
+
         if (replaceAll || masked(updateMaskPaths, "ack_deadline_seconds")) {
             if (ackDeadlineSeconds > 0) {
                 stored.setAckDeadlineSeconds(ackDeadlineSeconds);
@@ -320,7 +324,6 @@ public class PubSubService {
             stored.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
         }
         if (replaceAll || masked(updateMaskPaths, "filter")) {
-            SubscriptionFilter.validate(filter);
             stored.setFilter(blankToNull(filter));
         }
         if (replaceAll || masked(updateMaskPaths, "push_config")) {

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -33,11 +33,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 @ApplicationScoped
 public class PubSubService {
 
     private static final Logger LOG = Logger.getLogger(PubSubService.class);
+
+    private static final Predicate<Map<String, String>> NEVER_MATCHES = attributes -> false;
 
     private final StorageBackend<String, StoredTopic> topicStore;
     private final StorageBackend<String, StoredSubscription> subStore;
@@ -46,6 +49,7 @@ public class PubSubService {
     private final ConcurrentHashMap<String, ConcurrentLinkedDeque<StoredMessage>> queues = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, StoredMessage>> delivered = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, CopyOnWriteArrayList<MessageListener>> listeners = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Predicate<Map<String, String>>> compiledFilters = new ConcurrentHashMap<>();
     private final AtomicLong messageIdCounter = new AtomicLong(0);
 
     private final ServiceRegistry serviceRegistry;
@@ -172,8 +176,13 @@ public class PubSubService {
     // ── Subscriptions ──────────────────────────────────────────────────────────
 
     public StoredSubscription createSubscription(String name, String topicName, int ackDeadlineSeconds) {
+        return createSubscription(name, topicName, ackDeadlineSeconds, null);
+    }
+
+    public StoredSubscription createSubscription(String name, String topicName, int ackDeadlineSeconds,
+            String filter) {
         return createSubscription(name, topicName, ackDeadlineSeconds, null, false, null,
-                null, null, null, null, null, null, 0, false, false);
+                filter, null, null, null, null, null, 0, false, false);
     }
 
     public StoredSubscription createSubscription(String name,
@@ -200,6 +209,7 @@ public class PubSubService {
             LOG.warnf("createSubscription failed: topic not found topic=%s", topicName);
             throw GcpException.notFound("Topic not found: " + topicName);
         }
+        SubscriptionFilter.validate(filter);
         int deadline = ackDeadlineSeconds > 0 ? ackDeadlineSeconds : 10;
         StoredSubscription sub = new StoredSubscription(name, topicName, deadline);
         sub.setLabels(emptyToNull(labels));
@@ -244,7 +254,10 @@ public class PubSubService {
                 case "ack_deadline_seconds" -> stored.setAckDeadlineSeconds(subProto.getAckDeadlineSeconds());
                 case "labels" -> stored.setLabels(subProto.getLabelsMap().isEmpty() ? null
                         : new java.util.HashMap<>(subProto.getLabelsMap()));
-                case "filter" -> stored.setFilter(subProto.getFilter().isEmpty() ? null : subProto.getFilter());
+                case "filter" -> {
+                    SubscriptionFilter.validate(subProto.getFilter());
+                    stored.setFilter(subProto.getFilter().isEmpty() ? null : subProto.getFilter());
+                }
                 case "retain_acked_messages" -> stored.setRetainAckedMessages(subProto.getRetainAckedMessages());
                 case "message_retention_duration" -> {
                     if (subProto.hasMessageRetentionDuration()) {
@@ -307,6 +320,7 @@ public class PubSubService {
             stored.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
         }
         if (replaceAll || masked(updateMaskPaths, "filter")) {
+            SubscriptionFilter.validate(filter);
             stored.setFilter(blankToNull(filter));
         }
         if (replaceAll || masked(updateMaskPaths, "push_config")) {
@@ -403,10 +417,14 @@ public class PubSubService {
                 stored.setAttributes(msg.getAttributesMap());
             }
 
+            Map<String, String> attributes = stored.getAttributes() == null
+                    ? Map.of() : stored.getAttributes();
+
             int fanOut = 0;
             for (var entry : subStore.keys()) {
                 StoredSubscription sub = subStore.get(entry).orElse(null);
-                if (sub != null && !sub.isDetached() && topicName.equals(sub.getTopic())) {
+                if (sub != null && !sub.isDetached() && topicName.equals(sub.getTopic())
+                        && matchesFilter(sub, attributes)) {
                     queues.computeIfAbsent(entry, k -> new ConcurrentLinkedDeque<>()).add(stored);
                     notifyListeners(entry);
                     fanOut++;
@@ -422,6 +440,24 @@ public class PubSubService {
             }
         }
         return messageIds;
+    }
+
+    private boolean matchesFilter(StoredSubscription sub, Map<String, String> attributes) {
+        String filter = sub.getFilter();
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        return compiledFilters.computeIfAbsent(filter, PubSubService::compileFilter).test(attributes);
+    }
+
+    private static Predicate<Map<String, String>> compileFilter(String filter) {
+        try {
+            return SubscriptionFilter.parse(filter);
+        } catch (GcpException e) {
+            LOG.warnf("unparseable subscription filter, no message will match it filter=%s error=%s",
+                    filter, e.getMessage());
+            return NEVER_MATCHES;
+        }
     }
 
     // ── Pull ───────────────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubSubscriberController.java
@@ -32,7 +32,8 @@ public class PubSubSubscriberController extends SubscriberGrpc.SubscriberImplBas
         LOG.infof("createSubscription name=%s topic=%s", request.getName(), request.getTopic());
         try {
             StoredSubscription stored = service.createSubscription(
-                    request.getName(), request.getTopic(), request.getAckDeadlineSeconds());
+                    request.getName(), request.getTopic(), request.getAckDeadlineSeconds(),
+                    request.getFilter());
             responseObserver.onNext(buildSubscription(stored));
             responseObserver.onCompleted();
         } catch (Exception e) {

--- a/src/main/java/io/floci/gcp/services/pubsub/SubscriptionFilter.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/SubscriptionFilter.java
@@ -1,0 +1,305 @@
+package io.floci.gcp.services.pubsub;
+
+import io.floci.gcp.core.common.GcpException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Parses the Pub/Sub subscription filter language into a predicate over message attributes.
+ * Supports attribute existence ({@code attributes:key}), {@code =}, {@code !=},
+ * {@code hasPrefix(attributes.key, "prefix")}, the uppercase boolean operators {@code AND},
+ * {@code OR} and {@code NOT} with {@code -} as a unary alias for {@code NOT}, parentheses, and
+ * quoted keys containing unicode, hexadecimal or octal escape sequences. Keys and values are
+ * case-sensitive. As in GCP, {@code AND} and {@code OR} cannot be combined at the same level
+ * without parentheses, and an unparseable filter is rejected with {@code INVALID_ARGUMENT}
+ * rather than silently ignored.
+ */
+final class SubscriptionFilter {
+
+    private static final int MAX_FILTER_BYTES = 256;
+
+    private final List<Token> tokens;
+    private int position;
+
+    private SubscriptionFilter(List<Token> tokens) {
+        this.tokens = tokens;
+    }
+
+    static Predicate<Map<String, String>> parse(String filter) {
+        if (filter == null || filter.isBlank()) {
+            return attributes -> true;
+        }
+        SubscriptionFilter parser = new SubscriptionFilter(tokenize(filter));
+        Predicate<Map<String, String>> predicate = parser.expression();
+        parser.expect(TokenType.END, "end of filter");
+        return predicate;
+    }
+
+    static void validate(String filter) {
+        if (filter == null || filter.isBlank()) {
+            return;
+        }
+        int bytes = filter.getBytes(StandardCharsets.UTF_8).length;
+        if (bytes > MAX_FILTER_BYTES) {
+            throw GcpException.invalidArgument("Invalid subscription filter: the filter must be at most "
+                    + MAX_FILTER_BYTES + " bytes, but was " + bytes + " bytes");
+        }
+        parse(filter);
+    }
+
+    // ── Grammar ────────────────────────────────────────────────────────────────
+
+    private Predicate<Map<String, String>> expression() {
+        Predicate<Map<String, String>> predicate = term();
+        String operator = null;
+        while (peek().type() == TokenType.IDENT && isBooleanOperator(peek().text())) {
+            String next = advance().text();
+            if (operator != null && !operator.equals(next)) {
+                throw invalid("AND and OR cannot be combined without parentheses");
+            }
+            operator = next;
+            Predicate<Map<String, String>> right = term();
+            predicate = "AND".equals(operator) ? predicate.and(right) : predicate.or(right);
+        }
+        return predicate;
+    }
+
+    private Predicate<Map<String, String>> term() {
+        if (peek().type() == TokenType.MINUS || isKeyword(peek(), "NOT")) {
+            advance();
+            return term().negate();
+        }
+        return primary();
+    }
+
+    private Predicate<Map<String, String>> primary() {
+        Token token = peek();
+        if (token.type() == TokenType.LPAREN) {
+            advance();
+            Predicate<Map<String, String>> predicate = expression();
+            expect(TokenType.RPAREN, "')'");
+            return predicate;
+        }
+        if (isKeyword(token, "attributes")) {
+            advance();
+            return attributeComparison();
+        }
+        if (isKeyword(token, "hasPrefix")) {
+            advance();
+            return hasPrefix();
+        }
+        throw invalid("expected an attribute comparison but found " + describe(token));
+    }
+
+    private Predicate<Map<String, String>> attributeComparison() {
+        Token token = advance();
+        if (token.type() == TokenType.COLON) {
+            String key = key();
+            return attributes -> attributes.containsKey(key);
+        }
+        if (token.type() == TokenType.DOT) {
+            String key = key();
+            Token operator = advance();
+            if (operator.type() != TokenType.EQ && operator.type() != TokenType.NE) {
+                throw invalid("expected '=' or '!=' but found " + describe(operator));
+            }
+            String value = string();
+            return operator.type() == TokenType.EQ
+                    ? attributes -> value.equals(attributes.get(key))
+                    : attributes -> !value.equals(attributes.get(key));
+        }
+        throw invalid("expected ':' or '.' after 'attributes' but found " + describe(token));
+    }
+
+    private Predicate<Map<String, String>> hasPrefix() {
+        expect(TokenType.LPAREN, "'('");
+        Token attributes = advance();
+        if (!isKeyword(attributes, "attributes")) {
+            throw invalid("hasPrefix expects an attribute as its first argument but found "
+                    + describe(attributes));
+        }
+        expect(TokenType.DOT, "'.'");
+        String key = key();
+        expect(TokenType.COMMA, "','");
+        String prefix = string();
+        expect(TokenType.RPAREN, "')'");
+        return values -> {
+            String value = values.get(key);
+            return value != null && value.startsWith(prefix);
+        };
+    }
+
+    private String key() {
+        Token token = advance();
+        if (token.type() == TokenType.IDENT || token.type() == TokenType.STRING) {
+            return token.text();
+        }
+        throw invalid("expected an attribute key but found " + describe(token));
+    }
+
+    private String string() {
+        Token token = advance();
+        if (token.type() != TokenType.STRING) {
+            throw invalid("expected a quoted string but found " + describe(token));
+        }
+        return token.text();
+    }
+
+    private static boolean isBooleanOperator(String text) {
+        return "AND".equals(text) || "OR".equals(text);
+    }
+
+    private static boolean isKeyword(Token token, String keyword) {
+        return token.type() == TokenType.IDENT && keyword.equals(token.text());
+    }
+
+    private Token peek() {
+        return tokens.get(position);
+    }
+
+    private Token advance() {
+        Token token = tokens.get(position);
+        if (token.type() != TokenType.END) {
+            position++;
+        }
+        return token;
+    }
+
+    private void expect(TokenType type, String expected) {
+        Token token = advance();
+        if (token.type() != type) {
+            throw invalid("expected " + expected + " but found " + describe(token));
+        }
+    }
+
+    // ── Tokenizer ──────────────────────────────────────────────────────────────
+
+    private enum TokenType { IDENT, STRING, COLON, DOT, EQ, NE, LPAREN, RPAREN, COMMA, MINUS, END }
+
+    private record Token(TokenType type, String text) {}
+
+    private static List<Token> tokenize(String filter) {
+        List<Token> tokens = new ArrayList<>();
+        int i = 0;
+        while (i < filter.length()) {
+            char c = filter.charAt(i);
+            if (Character.isWhitespace(c)) {
+                i++;
+                continue;
+            }
+            switch (c) {
+                case ':' -> { tokens.add(new Token(TokenType.COLON, ":")); i++; }
+                case '.' -> { tokens.add(new Token(TokenType.DOT, ".")); i++; }
+                case '(' -> { tokens.add(new Token(TokenType.LPAREN, "(")); i++; }
+                case ')' -> { tokens.add(new Token(TokenType.RPAREN, ")")); i++; }
+                case ',' -> { tokens.add(new Token(TokenType.COMMA, ",")); i++; }
+                case '-' -> { tokens.add(new Token(TokenType.MINUS, "-")); i++; }
+                case '=' -> { tokens.add(new Token(TokenType.EQ, "=")); i++; }
+                case '!' -> {
+                    if (i + 1 >= filter.length() || filter.charAt(i + 1) != '=') {
+                        throw invalid("unexpected character '!'");
+                    }
+                    tokens.add(new Token(TokenType.NE, "!="));
+                    i += 2;
+                }
+                case '"' -> {
+                    StringBuilder value = new StringBuilder();
+                    i = readStringLiteral(filter, i, value);
+                    tokens.add(new Token(TokenType.STRING, value.toString()));
+                }
+                default -> {
+                    if (!isIdentifierStart(c)) {
+                        throw invalid("unexpected character '" + c + "'");
+                    }
+                    int start = i;
+                    while (i < filter.length() && isIdentifierPart(filter.charAt(i))) {
+                        i++;
+                    }
+                    tokens.add(new Token(TokenType.IDENT, filter.substring(start, i)));
+                }
+            }
+        }
+        tokens.add(new Token(TokenType.END, ""));
+        return tokens;
+    }
+
+    private static boolean isIdentifierStart(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+
+    private static boolean isIdentifierPart(char c) {
+        return isIdentifierStart(c) || c == '-';
+    }
+
+    private static int readStringLiteral(String filter, int start, StringBuilder out) {
+        int i = start + 1;
+        while (i < filter.length()) {
+            char c = filter.charAt(i);
+            if (c == '"') {
+                return i + 1;
+            }
+            if (c == '\\') {
+                i = readEscapeSequence(filter, i, out);
+                continue;
+            }
+            out.append(c);
+            i++;
+        }
+        throw invalid("unterminated string literal");
+    }
+
+    private static int readEscapeSequence(String filter, int start, StringBuilder out) {
+        int i = start + 1;
+        if (i >= filter.length()) {
+            throw invalid("unterminated escape sequence");
+        }
+        char c = filter.charAt(i);
+        switch (c) {
+            case 'n' -> out.append('\n');
+            case 't' -> out.append('\t');
+            case 'r' -> out.append('\r');
+            case 'b' -> out.append('\b');
+            case 'f' -> out.append('\f');
+            case '\\' -> out.append('\\');
+            case '"' -> out.append('"');
+            case '\'' -> out.append('\'');
+            case '/' -> out.append('/');
+            case 'u' -> { return appendEscapedCodePoint(filter, i + 1, 4, 16, out); }
+            case 'U' -> { return appendEscapedCodePoint(filter, i + 1, 8, 16, out); }
+            case 'x', 'X' -> { return appendEscapedCodePoint(filter, i + 1, 2, 16, out); }
+            default -> {
+                if (c >= '0' && c <= '7') {
+                    return appendEscapedCodePoint(filter, i, 3, 8, out);
+                }
+                throw invalid("unsupported escape sequence '\\" + c + "'");
+            }
+        }
+        return i + 1;
+    }
+
+    private static int appendEscapedCodePoint(String filter, int start, int digits, int radix,
+            StringBuilder out) {
+        if (start + digits > filter.length()) {
+            throw invalid("truncated escape sequence");
+        }
+        String text = filter.substring(start, start + digits);
+        try {
+            out.appendCodePoint(Integer.parseInt(text, radix));
+        } catch (IllegalArgumentException e) {
+            throw invalid("invalid escape sequence '" + text + "'");
+        }
+        return start + digits;
+    }
+
+    private static String describe(Token token) {
+        return token.type() == TokenType.END ? "end of filter" : "'" + token.text() + "'";
+    }
+
+    private static GcpException invalid(String detail) {
+        return GcpException.invalidArgument("Invalid subscription filter: " + detail);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
@@ -181,4 +181,117 @@ class PubSubRestIntegrationTest {
                 .statusCode(200)
                 .body("$", anEmptyMap());
     }
+
+    @Test
+    void filteredSubscriptionOnlyReceivesMatchingMessages() {
+        String project = "pubsub-rest-filter-it";
+        String topic = "events";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/" + topic).then().statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "topic": "projects/%s/topics/%s",
+                          "filter": "attributes.event_type = \\"ocr-invoice\\""
+                        }
+                        """.formatted(project, topic))
+                .when().put(base + "/subscriptions/filtered")
+                .then()
+                .statusCode(200)
+                .body("filter", equalTo("attributes.event_type = \"ocr-invoice\""));
+
+        given()
+                .contentType("application/json")
+                .body("{\"topic\": \"projects/%s/topics/%s\"}".formatted(project, topic))
+                .when().put(base + "/subscriptions/unfiltered")
+                .then()
+                .statusCode(200);
+
+        String payload = Base64.getEncoder().encodeToString("body".getBytes());
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "messages": [
+                            {"data": "%s", "attributes": {"event_type": "portal.upload"}},
+                            {"data": "%s", "attributes": {"event_type": "ocr-invoice"}}
+                          ]
+                        }
+                        """.formatted(payload, payload))
+                .when().post(base + "/topics/" + topic + ":publish")
+                .then()
+                .statusCode(200)
+                .body("messageIds.size()", equalTo(2));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"maxMessages\": 10}")
+                .when().post(base + "/subscriptions/filtered:pull")
+                .then()
+                .statusCode(200)
+                .body("receivedMessages.size()", equalTo(1))
+                .body("receivedMessages[0].message.attributes.event_type", equalTo("ocr-invoice"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"maxMessages\": 10}")
+                .when().post(base + "/subscriptions/unfiltered:pull")
+                .then()
+                .statusCode(200)
+                .body("receivedMessages.size()", equalTo(2));
+    }
+
+    @Test
+    void unparseableFilterIsRejectedWithInvalidArgument() {
+        String project = "pubsub-rest-filter-invalid-it";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/events").then().statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "topic": "projects/%s/topics/events",
+                          "filter": "this is not a filter ((("
+                        }
+                        """.formatted(project))
+                .when().put(base + "/subscriptions/bad")
+                .then()
+                .statusCode(400)
+                .body("error.code", equalTo(400))
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+
+        given()
+                .when().get(base + "/subscriptions/bad")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void filterOverTheByteLimitIsRejectedWithInvalidArgument() {
+        String project = "pubsub-rest-filter-length-it";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/events").then().statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "topic": "projects/%s/topics/events",
+                          "filter": "attributes.name = \\"%s\\""
+                        }
+                        """.formatted(project, "x".repeat(300)))
+                .when().put(base + "/subscriptions/too-long")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
 }

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
@@ -222,6 +222,48 @@ class PubSubServiceTest {
     }
 
     @Test
+    void rejectedUpdateLeavesEarlierFieldsUnchanged() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+
+        assertThrows(GcpException.class,
+                () -> service.updateSubscription("projects/p1/subscriptions/s1", 30,
+                        Map.of("env", "local"), null, null, "attributes.name = ", null, null, null,
+                        null, null, null, null, null,
+                        List.of("ackDeadlineSeconds", "labels", "filter")));
+
+        StoredSubscription unchanged = service.getSubscription("projects/p1/subscriptions/s1");
+        assertEquals(10, unchanged.getAckDeadlineSeconds());
+        assertNull(unchanged.getLabels());
+        assertNull(unchanged.getFilter());
+    }
+
+    @Test
+    void rejectedUpdateViaFieldMaskLeavesEarlierFieldsUnchanged() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+
+        assertThrows(GcpException.class,
+                () -> service.updateSubscription(
+                        com.google.pubsub.v1.Subscription.newBuilder()
+                                .setName("projects/p1/subscriptions/s1")
+                                .setAckDeadlineSeconds(30)
+                                .putLabels("env", "local")
+                                .setFilter("attributes.name = ")
+                                .build(),
+                        com.google.protobuf.FieldMask.newBuilder()
+                                .addPaths("ack_deadline_seconds")
+                                .addPaths("labels")
+                                .addPaths("filter")
+                                .build()));
+
+        StoredSubscription unchanged = service.getSubscription("projects/p1/subscriptions/s1");
+        assertEquals(10, unchanged.getAckDeadlineSeconds());
+        assertNull(unchanged.getLabels());
+        assertNull(unchanged.getFilter());
+    }
+
+    @Test
     void updateSubscriptionDoesNotValidateFilterOutsideTheUpdateMask() {
         service.createTopic("projects/p1/topics/t1");
         StoredSubscription corrupted =

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
@@ -12,18 +12,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class PubSubServiceTest {
 
     private PubSubService service;
+    private InMemoryStorage<String, StoredSubscription> subStore;
 
     @BeforeEach
     void setUp() {
+        subStore = new InMemoryStorage<>();
         service = new PubSubService(
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>(),
+                subStore,
                 new InMemoryStorage<>());
     }
 
@@ -105,6 +108,152 @@ class PubSubServiceTest {
     }
 
     @Test
+    void publishSkipsSubscriptionWhoseFilterDoesNotMatch() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"match\"");
+
+        service.publish("projects/p1/topics/t1", List.of(message("body", "event_type", "nomatch")));
+
+        assertTrue(service.pull("projects/p1/subscriptions/s1", 10).isEmpty());
+    }
+
+    @Test
+    void publishDeliversToSubscriptionWhoseFilterMatches() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"match\"");
+
+        service.publish("projects/p1/topics/t1", List.of(message("body", "event_type", "match")));
+
+        List<ReceivedMessage> messages = service.pull("projects/p1/subscriptions/s1", 10);
+        assertEquals(1, messages.size());
+        assertEquals("body", messages.get(0).getMessage().getData().toStringUtf8());
+    }
+
+    @Test
+    void publishDeliversEveryMessageToSubscriptionWithoutFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+
+        service.publish("projects/p1/topics/t1", List.of(
+                message("first", "event_type", "a"),
+                message("second", "event_type", "b"),
+                PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("third")).build()));
+
+        assertEquals(3, service.pull("projects/p1/subscriptions/s1", 10).size());
+    }
+
+    @Test
+    void publishFansOutIndependentlyPerSubscriptionFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/matching", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+        createFilteredSubscription("projects/p1/subscriptions/other", "projects/p1/topics/t1",
+                "attributes.event_type = \"b\"");
+        service.createSubscription("projects/p1/subscriptions/unfiltered", "projects/p1/topics/t1", 10);
+
+        service.publish("projects/p1/topics/t1", List.of(message("body", "event_type", "a")));
+
+        assertEquals(1, service.pull("projects/p1/subscriptions/matching", 10).size());
+        assertTrue(service.pull("projects/p1/subscriptions/other", 10).isEmpty());
+        assertEquals(1, service.pull("projects/p1/subscriptions/unfiltered", 10).size());
+    }
+
+    @Test
+    void createSubscriptionRejectsUnparseableFilter() {
+        service.createTopic("projects/p1/topics/t1");
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> createFilteredSubscription("projects/p1/subscriptions/s1",
+                        "projects/p1/topics/t1", "this is not a filter ((("));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertThrows(GcpException.class, () -> service.getSubscription("projects/p1/subscriptions/s1"));
+    }
+
+    @Test
+    void createSubscriptionRejectsFilterOverTheByteLimit() {
+        service.createTopic("projects/p1/topics/t1");
+        String filter = "attributes.name = \"" + "x".repeat(300) + "\"";
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> createFilteredSubscription("projects/p1/subscriptions/s1",
+                        "projects/p1/topics/t1", filter));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void createSubscriptionStoresValidFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        assertEquals("attributes.event_type = \"a\"",
+                service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void updateSubscriptionRejectsUnparseableFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription("projects/p1/subscriptions/s1", 0, null, null, null,
+                        "attributes.name = ", null, null, null, null, null, null, null, null,
+                        List.of("filter")));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertNull(service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void updateSubscriptionViaFieldMaskRejectsUnparseableFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription(
+                        com.google.pubsub.v1.Subscription.newBuilder()
+                                .setName("projects/p1/subscriptions/s1")
+                                .setFilter("attributes.name = ")
+                                .build(),
+                        com.google.protobuf.FieldMask.newBuilder().addPaths("filter").build()));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertNull(service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void updateSubscriptionDoesNotValidateFilterOutsideTheUpdateMask() {
+        service.createTopic("projects/p1/topics/t1");
+        StoredSubscription corrupted =
+                new StoredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+        corrupted.setFilter("this is not a filter (((");
+        subStore.put(corrupted.getName(), corrupted);
+
+        StoredSubscription updated = service.updateSubscription("projects/p1/subscriptions/s1", 0,
+                Map.of("env", "local"), null, null, null, null, null, null, null, null, null, null, null,
+                List.of("labels"));
+
+        assertEquals("local", updated.getLabels().get("env"));
+        assertEquals("this is not a filter (((", updated.getFilter());
+    }
+
+    @Test
+    void publishTreatsPersistedUnparseableFilterAsNoMatchWithoutFailing() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/healthy", "projects/p1/topics/t1", 10);
+
+        StoredSubscription corrupted =
+                new StoredSubscription("projects/p1/subscriptions/corrupted", "projects/p1/topics/t1", 10);
+        corrupted.setFilter("this is not a filter (((");
+        subStore.put(corrupted.getName(), corrupted);
+
+        service.publish("projects/p1/topics/t1", List.of(message("body", "event_type", "a")));
+
+        assertEquals(1, service.pull("projects/p1/subscriptions/healthy", 10).size());
+        assertTrue(service.pull("projects/p1/subscriptions/corrupted", 10).isEmpty());
+    }
+
+    @Test
     void acknowledgeRemovesMessageFromQueue() {
         service.createTopic("projects/p1/topics/t1");
         service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
@@ -119,5 +268,17 @@ class PubSubServiceTest {
 
         List<ReceivedMessage> second = service.pull("projects/p1/subscriptions/s1", 10);
         assertTrue(second.isEmpty());
+    }
+
+    private void createFilteredSubscription(String name, String topic, String filter) {
+        service.createSubscription(name, topic, 10, null, false, null, filter,
+                null, null, null, null, null, 0, false, false);
+    }
+
+    private static PubsubMessage message(String data, String attributeKey, String attributeValue) {
+        return PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8(data))
+                .putAttributes(attributeKey, attributeValue)
+                .build();
     }
 }

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubSubscriberControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubSubscriberControllerTest.java
@@ -4,7 +4,10 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.StreamingPullRequest;
 import com.google.pubsub.v1.StreamingPullResponse;
+import com.google.pubsub.v1.Subscription;
 import io.floci.gcp.core.storage.InMemoryStorage;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +19,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -61,6 +66,80 @@ class PubSubSubscriberControllerTest {
                 response.getReceivedMessages(0).getMessage().getAttributesOrThrow("source"));
 
         requestObserver.onCompleted();
+    }
+
+    @Test
+    void streamingPullOnlyReceivesMessagesMatchingTheSubscriptionFilter() throws Exception {
+        String topic = "projects/p1/topics/t1";
+        String subscription = "projects/p1/subscriptions/s1";
+        service.createTopic(topic);
+        service.createSubscription(subscription, topic, 10, null, false, null,
+                "attributes.event_type = \"match\"", null, null, null, null, null, 0, false, false);
+
+        RecordingObserver<StreamingPullResponse> responseObserver = new RecordingObserver<>();
+        StreamObserver<StreamingPullRequest> requestObserver = controller.streamingPull(responseObserver);
+
+        requestObserver.onNext(StreamingPullRequest.newBuilder()
+                .setSubscription(subscription)
+                .build());
+
+        service.publish(topic, List.of(PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8("dropped"))
+                .putAttributes("event_type", "nomatch")
+                .build()));
+
+        assertFalse(responseObserver.awaitValue(),
+                "streaming pull should not deliver a message the filter excludes");
+
+        service.publish(topic, List.of(PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8("delivered"))
+                .putAttributes("event_type", "match")
+                .build()));
+
+        assertTrue(responseObserver.awaitValue(), "streaming pull should deliver the matching message");
+        assertNull(responseObserver.error.get());
+        StreamingPullResponse response = responseObserver.values.get(0);
+        assertEquals(1, response.getReceivedMessagesCount());
+        assertEquals("delivered", response.getReceivedMessages(0).getMessage().getData().toStringUtf8());
+
+        requestObserver.onCompleted();
+    }
+
+    @Test
+    void createSubscriptionOverGrpcStoresTheFilter() {
+        service.createTopic("projects/p1/topics/t1");
+
+        RecordingObserver<Subscription> responseObserver = new RecordingObserver<>();
+        controller.createSubscription(Subscription.newBuilder()
+                .setName("projects/p1/subscriptions/s1")
+                .setTopic("projects/p1/topics/t1")
+                .setAckDeadlineSeconds(10)
+                .setFilter("attributes.event_type = \"match\"")
+                .build(), responseObserver);
+
+        assertNull(responseObserver.error.get());
+        assertEquals("attributes.event_type = \"match\"", responseObserver.values.get(0).getFilter());
+        assertEquals("attributes.event_type = \"match\"",
+                service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void createSubscriptionOverGrpcRejectsUnparseableFilter() {
+        service.createTopic("projects/p1/topics/t1");
+
+        RecordingObserver<Subscription> responseObserver = new RecordingObserver<>();
+        controller.createSubscription(Subscription.newBuilder()
+                .setName("projects/p1/subscriptions/s1")
+                .setTopic("projects/p1/topics/t1")
+                .setAckDeadlineSeconds(10)
+                .setFilter("this is not a filter (((")
+                .build(), responseObserver);
+
+        Throwable error = responseObserver.error.get();
+        assertNotNull(error);
+        assertEquals(Status.Code.INVALID_ARGUMENT,
+                ((StatusRuntimeException) error).getStatus().getCode());
+        assertTrue(responseObserver.values.isEmpty());
     }
 
     private static final class RecordingObserver<T> implements StreamObserver<T> {

--- a/src/test/java/io/floci/gcp/services/pubsub/SubscriptionFilterTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/SubscriptionFilterTest.java
@@ -49,6 +49,26 @@ class SubscriptionFilterTest {
     }
 
     @Test
+    void unquotedKeyMayContainHyphensAndUnderscores() {
+        assertTrue(matches("attributes:is-even", Map.of("is-even", "false")));
+        assertFalse(matches("attributes:is-even", Map.of("is_even", "false")));
+        assertTrue(matches("attributes.is-even = \"false\"", Map.of("is-even", "false")));
+        assertFalse(matches("attributes.is-even = \"false\"", Map.of("is-even", "true")));
+        assertTrue(matches("hasPrefix(attributes.event-type, \"portal.\")",
+                Map.of("event-type", "portal.upload")));
+        assertTrue(matches("attributes.event_type = \"a\"", Map.of("event_type", "a")));
+    }
+
+    @Test
+    void unaryMinusIsDistinguishedFromAHyphenInsideAKey() {
+        assertTrue(matches("-attributes:is-even", Map.of("other", "x")));
+        assertFalse(matches("-attributes:is-even", Map.of("is-even", "false")));
+        assertTrue(matches("attributes.a = \"1\" AND -attributes:is-even", Map.of("a", "1")));
+        assertFalse(matches("attributes.a = \"1\" AND -attributes:is-even",
+                Map.of("a", "1", "is-even", "false")));
+    }
+
+    @Test
     void existenceKeyIsCaseSensitive() {
         assertFalse(matches("attributes:name", Map.of("Name", "com")));
     }

--- a/src/test/java/io/floci/gcp/services/pubsub/SubscriptionFilterTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/SubscriptionFilterTest.java
@@ -1,0 +1,396 @@
+package io.floci.gcp.services.pubsub;
+
+import io.floci.gcp.core.common.GcpException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SubscriptionFilterTest {
+
+    @Test
+    void blankFilterMatchesEverything() {
+        assertTrue(matches(null, Map.of()));
+        assertTrue(matches("", Map.of("a", "b")));
+        assertTrue(matches("   ", Map.of("a", "b")));
+    }
+
+    // ── Existence ──────────────────────────────────────────────────────────────
+
+    @Test
+    void existenceMatchesWhenKeyPresent() {
+        assertTrue(matches("attributes:name", Map.of("name", "com")));
+    }
+
+    @Test
+    void existenceMatchesRegardlessOfValue() {
+        assertTrue(matches("attributes:name", Map.of("name", "")));
+    }
+
+    @Test
+    void existenceDoesNotMatchWhenKeyAbsent() {
+        assertFalse(matches("attributes:name", Map.of("other", "com")));
+    }
+
+    @Test
+    void existenceAcceptsQuotedKey() {
+        assertTrue(matches("attributes:\"name\"", Map.of("name", "com")));
+    }
+
+    @Test
+    void existenceAcceptsQuotedKeyWithSpecialCharacters() {
+        assertTrue(matches("attributes:\"iana.org/language_tag\"",
+                Map.of("iana.org/language_tag", "en")));
+        assertFalse(matches("attributes:\"iana.org/language_tag\"", Map.of("iana", "en")));
+    }
+
+    @Test
+    void existenceKeyIsCaseSensitive() {
+        assertFalse(matches("attributes:name", Map.of("Name", "com")));
+    }
+
+    // ── Equality ───────────────────────────────────────────────────────────────
+
+    @Test
+    void equalityMatchesExactValue() {
+        assertTrue(matches("attributes.name = \"com\"", Map.of("name", "com")));
+    }
+
+    @Test
+    void equalityDoesNotMatchDifferentValue() {
+        assertFalse(matches("attributes.name = \"com\"", Map.of("name", "org")));
+    }
+
+    @Test
+    void equalityDoesNotMatchAbsentKey() {
+        assertFalse(matches("attributes.name = \"com\"", Map.of("other", "com")));
+    }
+
+    @Test
+    void equalityValueIsCaseSensitive() {
+        assertFalse(matches("attributes.name = \"com\"", Map.of("name", "COM")));
+    }
+
+    @Test
+    void equalityKeyIsCaseSensitive() {
+        assertFalse(matches("attributes.name = \"com\"", Map.of("NAME", "com")));
+    }
+
+    @Test
+    void equalityAcceptsQuotedKey() {
+        assertTrue(matches("attributes.\"iana.org/language_tag\" = \"en\"",
+                Map.of("iana.org/language_tag", "en")));
+    }
+
+    @Test
+    void equalityMatchesEmptyValue() {
+        assertTrue(matches("attributes.name = \"\"", Map.of("name", "")));
+    }
+
+    // ── Inequality ─────────────────────────────────────────────────────────────
+
+    @Test
+    void inequalityDoesNotMatchEqualValue() {
+        assertFalse(matches("attributes.name != \"com\"", Map.of("name", "com")));
+    }
+
+    @Test
+    void inequalityMatchesDifferentValue() {
+        assertTrue(matches("attributes.name != \"com\"", Map.of("name", "org")));
+    }
+
+    @Test
+    void inequalityMatchesAbsentKey() {
+        assertTrue(matches("attributes.name != \"com\"", Map.of("other", "com")));
+        assertTrue(matches("attributes.name != \"com\"", Map.of()));
+    }
+
+    // ── hasPrefix ──────────────────────────────────────────────────────────────
+
+    @Test
+    void hasPrefixMatchesValueWithPrefix() {
+        assertTrue(matches("hasPrefix(attributes.name, \"co\")", Map.of("name", "com")));
+    }
+
+    @Test
+    void hasPrefixMatchesWholeValue() {
+        assertTrue(matches("hasPrefix(attributes.name, \"com\")", Map.of("name", "com")));
+    }
+
+    @Test
+    void hasPrefixDoesNotMatchOtherPrefix() {
+        assertFalse(matches("hasPrefix(attributes.name, \"co\")", Map.of("name", "org")));
+    }
+
+    @Test
+    void hasPrefixDoesNotMatchAbsentKey() {
+        assertFalse(matches("hasPrefix(attributes.name, \"co\")", Map.of("other", "com")));
+    }
+
+    @Test
+    void hasPrefixIsCaseSensitive() {
+        assertFalse(matches("hasPrefix(attributes.name, \"CO\")", Map.of("name", "com")));
+    }
+
+    @Test
+    void hasPrefixAcceptsQuotedKey() {
+        assertTrue(matches("hasPrefix(attributes.\"iana.org/language_tag\", \"en\")",
+                Map.of("iana.org/language_tag", "en-GB")));
+    }
+
+    @Test
+    void hasPrefixMatchesEmptyPrefix() {
+        assertTrue(matches("hasPrefix(attributes.name, \"\")", Map.of("name", "com")));
+    }
+
+    // ── Boolean operators ──────────────────────────────────────────────────────
+
+    @Test
+    void andRequiresBothOperands() {
+        String filter = "attributes.a = \"1\" AND attributes.b = \"2\"";
+        assertTrue(matches(filter, Map.of("a", "1", "b", "2")));
+        assertFalse(matches(filter, Map.of("a", "1", "b", "9")));
+        assertFalse(matches(filter, Map.of("a", "9", "b", "2")));
+    }
+
+    @Test
+    void orRequiresEitherOperand() {
+        String filter = "attributes.a = \"1\" OR attributes.b = \"2\"";
+        assertTrue(matches(filter, Map.of("a", "1")));
+        assertTrue(matches(filter, Map.of("b", "2")));
+        assertFalse(matches(filter, Map.of("a", "9", "b", "9")));
+    }
+
+    @Test
+    void notNegatesOperand() {
+        assertTrue(matches("NOT attributes:name", Map.of("other", "x")));
+        assertFalse(matches("NOT attributes:name", Map.of("name", "x")));
+    }
+
+    @Test
+    void unaryMinusIsAliasForNot() {
+        assertTrue(matches("-attributes:name", Map.of("other", "x")));
+        assertFalse(matches("-attributes:name", Map.of("name", "x")));
+    }
+
+    @Test
+    void notBindsTighterThanAnd() {
+        String filter = "NOT attributes:a AND attributes:b";
+        assertTrue(matches(filter, Map.of("b", "1")));
+        assertFalse(matches(filter, Map.of("a", "1", "b", "1")));
+        assertFalse(matches(filter, Map.of("a", "1")));
+    }
+
+    @Test
+    void andCombinesWithNegatedEquality() {
+        String filter = "attributes:\"iana.org/language_tag\" AND NOT attributes.name = \"com\"";
+        assertTrue(matches(filter, Map.of("iana.org/language_tag", "en", "name", "org")));
+        assertFalse(matches(filter, Map.of("iana.org/language_tag", "en", "name", "com")));
+        assertFalse(matches(filter, Map.of("name", "org")));
+    }
+
+    @Test
+    void parenthesesGroupOrInsideAnd() {
+        String filter = "attributes:\"iana.org/language_tag\" "
+                + "AND (attributes.name = \"net\" OR attributes.name = \"org\")";
+        assertTrue(matches(filter, Map.of("iana.org/language_tag", "en", "name", "net")));
+        assertTrue(matches(filter, Map.of("iana.org/language_tag", "en", "name", "org")));
+        assertFalse(matches(filter, Map.of("iana.org/language_tag", "en", "name", "com")));
+        assertFalse(matches(filter, Map.of("name", "net")));
+    }
+
+    @Test
+    void unaryMinusCombinesWithAnd() {
+        String filter = "attributes.name = \"com\" AND -attributes:\"iana.org/language_tag\"";
+        assertTrue(matches(filter, Map.of("name", "com")));
+        assertFalse(matches(filter, Map.of("name", "com", "iana.org/language_tag", "en")));
+    }
+
+    @Test
+    void nestedParenthesesAreSupported() {
+        String filter = "((attributes.a = \"1\"))";
+        assertTrue(matches(filter, Map.of("a", "1")));
+        assertFalse(matches(filter, Map.of("a", "2")));
+    }
+
+    @Test
+    void doubleNegationIsSupported() {
+        assertTrue(matches("NOT NOT attributes:a", Map.of("a", "1")));
+        assertFalse(matches("NOT NOT attributes:a", Map.of()));
+    }
+
+    // ── String literals and escapes ────────────────────────────────────────────
+
+    @Test
+    void unicodeEscapeSequencesInStringLiteral() {
+        assertTrue(matches("attributes:\"\\u307F\\u3093\\u306A\"", Map.of("\u307F\u3093\u306A", "x")));
+    }
+
+    @Test
+    void hexEscapeSequenceInStringLiteral() {
+        assertTrue(matches("attributes.name = \"\\x41\"", Map.of("name", "A")));
+    }
+
+    @Test
+    void octalEscapeSequenceInStringLiteral() {
+        assertTrue(matches("attributes.name = \"\\101\"", Map.of("name", "A")));
+    }
+
+    @Test
+    void escapedQuoteInStringLiteral() {
+        assertTrue(matches("attributes.name = \"a\\\"b\"", Map.of("name", "a\"b")));
+    }
+
+    @Test
+    void escapedBackslashInStringLiteral() {
+        assertTrue(matches("attributes.name = \"a\\\\b\"", Map.of("name", "a\\b")));
+    }
+
+    @Test
+    void commonControlCharacterEscapesInStringLiteral() {
+        assertTrue(matches("attributes.name = \"a\\tb\"", Map.of("name", "a\tb")));
+        assertTrue(matches("attributes.name = \"a\\nb\"", Map.of("name", "a\nb")));
+    }
+
+    // ── Invalid syntax ─────────────────────────────────────────────────────────
+
+    @Test
+    void mixingAndWithOrWithoutParenthesesIsRejected() {
+        assertInvalid("attributes:\"iana.org/language_tag\" AND attributes.name = \"net\" "
+                + "OR attributes.name = \"org\"");
+    }
+
+    @Test
+    void valueOnLeftHandSideIsRejected() {
+        assertInvalid("\"com\" = attributes.name");
+    }
+
+    @Test
+    void comparingTwoAttributesIsRejected() {
+        assertInvalid("attributes.name = attributes.website");
+    }
+
+    @Test
+    void escapeSequenceOutsideStringLiteralIsRejected() {
+        assertInvalid("attributes:\\u307F\\u3093\\u306A");
+    }
+
+    @Test
+    void bareValuesInParenthesesAreRejected() {
+        assertInvalid("attributes.name = \"com\" AND (\"net\" OR \"org\")");
+    }
+
+    @Test
+    void unbalancedParenthesesAreRejected() {
+        assertInvalid("(attributes.name = \"com\"");
+        assertInvalid("attributes.name = \"com\")");
+    }
+
+    @Test
+    void lowercaseBooleanOperatorsAreRejected() {
+        assertInvalid("attributes:a and attributes:b");
+        assertInvalid("attributes:a or attributes:b");
+        assertInvalid("not attributes:a");
+    }
+
+    @Test
+    void unterminatedStringLiteralIsRejected() {
+        assertInvalid("attributes.name = \"com");
+    }
+
+    @Test
+    void trailingOperatorIsRejected() {
+        assertInvalid("attributes:a AND");
+        assertInvalid("attributes.name =");
+    }
+
+    @Test
+    void unknownFunctionIsRejected() {
+        assertInvalid("matches(attributes.name, \"co.*\")");
+    }
+
+    @Test
+    void hasPrefixWithWrongArgumentCountIsRejected() {
+        assertInvalid("hasPrefix(attributes.name)");
+        assertInvalid("hasPrefix(attributes.name, \"a\", \"b\")");
+    }
+
+    @Test
+    void hasPrefixWithNonLiteralPrefixIsRejected() {
+        assertInvalid("hasPrefix(attributes.name, attributes.other)");
+    }
+
+    @Test
+    void unsupportedFieldIsRejected() {
+        assertInvalid("data = \"com\"");
+        assertInvalid("attribute.name = \"com\"");
+    }
+
+    @Test
+    void unsupportedOperatorIsRejected() {
+        assertInvalid("attributes.name > \"com\"");
+    }
+
+    @Test
+    void emptyParenthesesAreRejected() {
+        assertInvalid("()");
+    }
+
+    @Test
+    void garbageIsRejected() {
+        assertInvalid("this is not a filter (((");
+    }
+
+    // ── Length limit ───────────────────────────────────────────────────────────
+
+    @Test
+    void filterAtTheByteLimitIsAccepted() {
+        String filter = filterOfLength(256);
+        assertEquals(256, filter.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
+        SubscriptionFilter.validate(filter);
+    }
+
+    @Test
+    void filterOverTheByteLimitIsRejected() {
+        GcpException ex = assertThrows(GcpException.class,
+                () -> SubscriptionFilter.validate(filterOfLength(257)));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void lengthLimitCountsUtf8BytesNotCharacters() {
+        String key = "\u00E1".repeat(120);
+        String filter = "attributes.name = \"" + key + "\"";
+        assertTrue(filter.length() <= 256);
+        assertTrue(filter.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > 256);
+
+        GcpException ex = assertThrows(GcpException.class, () -> SubscriptionFilter.validate(filter));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+
+    @Test
+    void validateAcceptsBlankFilter() {
+        SubscriptionFilter.validate(null);
+        SubscriptionFilter.validate("");
+    }
+
+    private static String filterOfLength(int totalBytes) {
+        String prefix = "attributes.name = \"";
+        int padding = totalBytes - prefix.length() - 1;
+        return prefix + "x".repeat(padding) + "\"";
+    }
+
+    private static boolean matches(String filter, Map<String, String> attributes) {
+        return SubscriptionFilter.parse(filter).test(attributes);
+    }
+
+    private static void assertInvalid(String filter) {
+        GcpException ex = assertThrows(GcpException.class, () -> SubscriptionFilter.parse(filter),
+                "expected filter to be rejected: " + filter);
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+    }
+}


### PR DESCRIPTION
Closes #102

## Problem

Subscription filters were accepted and then ignored, differently on each transport:

- **REST** stored and echoed back `filter` but never evaluated it — `publish()` fanned out to every
  non-detached subscription on the topic (`PubSubService.java:407-414`), so a filtered subscription
  received every message.
- **gRPC** dropped the field before it reached the service: `PubSubSubscriberController` called the
  three-argument `createSubscription` overload, so `GetSubscription` reported an empty filter for a
  subscription created with one.

Unparseable filters and filters over the 256-byte limit were accepted with `200`/`OK`.

## Change

`SubscriptionFilter` — a tokenizer plus recursive-descent parser for the documented grammar,
compiling a filter into a `Predicate<Map<String, String>>` over message attributes:

| Form | Example |
|---|---|
| Existence | `attributes:name`, `attributes:"iana.org/language_tag"` |
| Equality / inequality | `attributes.name = "com"`, `attributes.name != "com"` |
| Prefix | `hasPrefix(attributes.name, "co")` |
| Boolean | `AND`, `OR`, `NOT`, `-` as a unary alias, parentheses |

Matching GCP semantics:

- Keys and values are case-sensitive; boolean operators must be uppercase.
- `NOT` binds tightest; `AND` and `OR` cannot be combined without parentheses (`a AND b OR c` is a
  syntax error, per the documentation — not standard precedence).
- `!=` matches when the attribute is **absent**, while `=` and `:` do not.
- String literals accept unicode, hexadecimal and octal escapes; escapes outside a literal are invalid.
- `hasPrefix` is the only function; no regular expressions.

Wiring:

- Filters are evaluated in `PubSubService.publish()` **before enqueueing**, so `Pull` and
  `StreamingPull` are both covered over gRPC and REST from a single place. Compiled predicates are
  memoized by filter string, keyed so that a `patch` that changes the filter needs no invalidation.
- `SubscriptionFilter.validate` rejects unparseable and oversized filters with `INVALID_ARGUMENT` at
  create time and on both `updateSubscription` overloads — only when `filter` is in the update mask,
  so unrelated patches are unaffected. Without this a typo silently became "matches nothing", which
  is worse than today's behaviour.
- The gRPC create path now passes `filter` through to the service.
- A filter that is already persisted and cannot be parsed is logged once and treated as matching
  nothing, so one bad subscription cannot break publishing for a whole topic.
- Subscriptions without a filter keep receiving every message.

The 256-byte limit is measured in UTF-8 bytes, not characters.

## Tests

`mvn test` — **513 tests, 0 failures** (Java 25 in a container). New coverage:

- `SubscriptionFilterTest` — 60 cases: every grammar form, case-sensitivity, `!=` against a missing
  attribute, escape sequences, the byte limit, and 16 invalid-syntax cases including the documented
  `AND`/`OR`-without-parentheses error and each invalid example from the GCP documentation.
- `PubSubServiceTest` — non-matching messages are not delivered, matching ones are, per-subscription
  fan-out is independent, a subscription **without** a filter still receives everything, validation
  on create and both update paths, and a persisted unparseable filter degrades to no-match instead of
  breaking `publish()`.
- `PubSubSubscriberControllerTest` — `StreamingPull` only receives matching messages; the gRPC create
  path stores the filter and rejects an invalid one with `INVALID_ARGUMENT`.
- `PubSubRestIntegrationTest` — the filtered/unfiltered pair over REST, plus `400 INVALID_ARGUMENT`
  for an unparseable and an oversized filter.

Each test was confirmed to fail against the unfixed code before the fix landed.

## Compatibility suites

Both SDK suites were run locally against a JVM build of this branch on a shared Docker network, with
a baseline run against `floci/floci-gcp:0.5.0` for comparison:

| Suite | 0.5.0 baseline | This branch |
|---|---|---|
| `sdk-test-java` (218 tests) | 16 failures | 11 failures |
| `sdk-test-python` (51 tests) | 12 failures | 9 failures |

The deltas are the three new Pub/Sub filter cases in each suite, plus two `GcsNotificationTest` cases
that 88908fb already fixed on `main` but that are not in the 0.5.0 image. The remaining failures are
**identical in both runs** and environmental to my machine: services that launch Docker sidecars
(CloudRun, Kafka, CloudSQL, CloudFunctions, GKE) had no Docker socket, and three raw-HTTP GCS tests
cannot reach the host from inside the suite container.

New cases added to both suites: an equality filter with a filtered/unfiltered subscription pair on
the same topic, a `hasPrefix` filter, and an unparseable filter expecting `InvalidArgument`.

Not run locally: `sdk-test-node`, `sdk-test-go`, `sdk-test-gcloud`, `compat-terraform`,
`compat-opentofu` (Pub/Sub is gRPC-only, so the IaC suites do not reach it), and the native GraalVM
build. `SubscriptionFilter` is package-private, uses no reflection and returns lambdas from a static
method, so it needs no native-image configuration; controller return types are unchanged.

## Docs

`docs/services/pubsub.md` gains a **Subscription Filters** section — Java and Python examples, a
syntax table, the GCP rules that are easy to get wrong (case sensitivity, uppercase operators,
mandatory parentheses when mixing `AND` and `OR`, the 256-byte limit), and the validation behaviour.

## Out of scope

In real GCP `filter` is immutable after creation, but `subscriptions.patch` still accepts changes to
it here. Left alone deliberately to keep this to one fix; noted in the issue.
