### PR TITLE
fix(storage): converge storage cluster on floci-aws baseline 0142dc4

### DIFF
--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -317,6 +317,12 @@ public interface EmulatorConfig {
         Duration apiTimeout();
 
         Optional<String> dockerConfigPath();
+
+        /**
+         * Optional namespace inserted into Floci-managed sidecar container and volume names.
+         * Useful when multiple Floci processes share one Docker daemon.
+         */
+        Optional<String> resourceNamespace();
     }
 
     interface InitHooksConfig {

--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerStorageHelper.java
@@ -8,11 +8,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Central helper for sidecar container volume management.
+ * Central helper for sidecar container volume management (Kafka/Redpanda, CloudSQL, …).
  *
- * Two modes:
- * - Named-volume (default) — manages per-resource Docker named volumes labelled floci-gcp=true.
- * - Host-path (legacy) — active when storage.host-persistent-path is set to an absolute path.
+ * <p>Two modes:
+ * <ul>
+ *   <li>Named-volume (default) — Floci manages per-resource Docker named volumes labelled
+ *       {@code floci-gcp=true}. Active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH}
+ *       is not set.</li>
+ *   <li>Host-path (legacy) — active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH} is set;
+ *       callers fall through to their existing bind-mount logic.</li>
+ * </ul>
  */
 public final class ContainerStorageHelper {
 
@@ -20,33 +25,103 @@ public final class ContainerStorageHelper {
 
     private ContainerStorageHelper() {}
 
+    /**
+     * Canonical container/volume name for a resource. Uses {@code volumeId} when set;
+     * falls back to {@code fallbackId} (the resource name) for resources created before
+     * this change.
+     */
     public static String resourceName(String service, String volumeId, String fallbackId) {
-        return "floci-gcp-" + service + "-" + (volumeId != null ? volumeId : fallbackId);
+        return resourceName(null, service, volumeId, fallbackId);
     }
 
+    public static String resourceName(EmulatorConfig config, String service, String volumeId, String fallbackId) {
+        return dockerName(config, "floci-gcp-" + service + "-" + (volumeId != null ? volumeId : fallbackId));
+    }
+
+    public static String dockerName(EmulatorConfig config, String baseName) {
+        String namespace = resourceNamespace(config);
+        if (namespace.isBlank()) {
+            return baseName;
+        }
+        if (baseName.startsWith("floci-gcp-")) {
+            return "floci-gcp-" + namespace + "-" + baseName.substring("floci-gcp-".length());
+        }
+        return "floci-gcp-" + namespace + "-" + baseName;
+    }
+
+    public static Path hostResourcePath(EmulatorConfig config, String service, String resourceId) {
+        String namespace = resourceNamespace(config);
+        Path base = Path.of(config.storage().hostPersistentPath());
+        if (namespace.isBlank()) {
+            return base.resolve(service).resolve(resourceId);
+        }
+        return base.resolve(namespace).resolve(service).resolve(resourceId);
+    }
+
+    private static String resourceNamespace(EmulatorConfig config) {
+        if (config == null || config.docker() == null || config.docker().resourceNamespace() == null) {
+            return "";
+        }
+        return sanitizeNamePart(config.docker().resourceNamespace().orElse(""));
+    }
+
+    private static String sanitizeNamePart(String value) {
+        String cleaned = value.trim().replaceAll("[^A-Za-z0-9_.-]+", "-");
+        while (cleaned.startsWith("-")) {
+            cleaned = cleaned.substring(1);
+        }
+        while (cleaned.endsWith("-")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+        if (cleaned.equals(".") || cleaned.equals("..")) {
+            return "";
+        }
+        return cleaned;
+    }
+
+    /**
+     * Returns {@code true} when named-volume mode is active.
+     * Returns {@code false} only when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH} is set to
+     * an absolute path, indicating the caller should use a host bind-mount instead.
+     * Volume names and relative paths are not supported in {@code host-persistent-path} —
+     * they are treated as named-volume mode.
+     */
     public static boolean isNamedVolumeMode(EmulatorConfig config) {
         return !config.storage().hostPersistentPath().startsWith("/");
     }
 
+    /**
+     * Ensures the named volume exists and mounts it to {@code internalMount} in the container.
+     * Must only be called when {@link #isNamedVolumeMode} returns {@code true}.
+     */
     public static void applyStorage(
             ContainerBuilder.Builder builder,
             ContainerLifecycleManager lifecycleManager,
+            EmulatorConfig config,
             String service,
             String volumeId,
             String fallbackId,
             String internalMount) {
-        String volumeName = resourceName(service, volumeId, fallbackId);
+        String volumeName = resourceName(config, service, volumeId, fallbackId);
         lifecycleManager.ensureVolume(volumeName);
         builder.withNamedVolume(volumeName, internalMount);
     }
 
+    /**
+     * Removes the named volume on resource delete, honouring the configured prune policy.
+     *
+     * <ul>
+     *   <li>In {@code memory} storage mode: always removes (data cannot survive a restart anyway).</li>
+     *   <li>In persistent modes: removes only when {@code prune-volumes-on-delete: true}.</li>
+     * </ul>
+     */
     public static void removeStorage(
             EmulatorConfig config,
             ContainerLifecycleManager lifecycleManager,
             String service,
             String volumeId,
             String fallbackId) {
-        String volumeName = resourceName(service, volumeId, fallbackId);
+        String volumeName = resourceName(config, service, volumeId, fallbackId);
         boolean isMemory = "memory".equals(config.storage().mode());
         if (isMemory || config.storage().pruneVolumesOnDelete()) {
             lifecycleManager.removeVolume(volumeName);
@@ -55,6 +130,10 @@ public final class ContainerStorageHelper {
         }
     }
 
+    /**
+     * Ensures the host data directory exists for host-path mode (absolute paths only).
+     * Called by managers in their legacy host-path code paths.
+     */
     public static void ensureHostDir(String hostDataPath) {
         try {
             Files.createDirectories(Path.of(hostDataPath));

--- a/src/main/java/io/floci/gcp/core/storage/HybridStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/HybridStorage.java
@@ -24,6 +24,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * Hybrid storage: in-memory reads with async flush to disk.
+ * Writes go to memory immediately, then flushed to disk periodically.
+ */
 public class HybridStorage<K, V> implements StorageBackend<K, V> {
 
     private static final Logger LOG = Logger.getLogger(HybridStorage.class);
@@ -89,6 +93,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public void load() {
         if (!Files.exists(filePath)) {
+            LOG.debugv("No persistent file found at {0}, starting with empty store", filePath);
             return;
         }
         try {
@@ -132,6 +137,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
             Path tempFile = filePath.resolveSibling(filePath.getFileName() + ".tmp");
             objectMapper.writeValue(tempFile.toFile(), store);
             Files.move(tempFile, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            LOG.debugv("Flushed {0} entries to {1}", store.size(), filePath);
         } catch (IOException e) {
             LOG.errorv(e, "Failed to persist data to {0}", filePath);
             dirty.set(true);

--- a/src/main/java/io/floci/gcp/core/storage/InMemoryStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/InMemoryStorage.java
@@ -8,6 +8,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
+/**
+ * Thread-safe in-memory storage backed by ConcurrentHashMap.
+ * No persistence — data is lost on shutdown unless explicitly flushed.
+ */
 public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
 
     private final ConcurrentHashMap<K, V> store = new ConcurrentHashMap<>();
@@ -44,10 +48,14 @@ public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void flush() {}
+    public void flush() {
+        // No-op for in-memory storage
+    }
 
     @Override
-    public void load() {}
+    public void load() {
+        // No-op for in-memory storage
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/io/floci/gcp/core/storage/PersistentStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/PersistentStorage.java
@@ -20,6 +20,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * JSON file-backed persistent storage.
+ * Loads all data into memory on startup for fast reads.
+ * Write-through on every put/delete.
+ * Uses atomic writes (temp file + rename) for safety.
+ */
 public class PersistentStorage<K, V> implements StorageBackend<K, V> {
 
     private static final Logger LOG = Logger.getLogger(PersistentStorage.class);
@@ -76,6 +82,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public void load() {
         if (!Files.exists(filePath)) {
+            LOG.debugv("No persistent file found at {0}, starting with empty store", filePath);
             return;
         }
         try {
@@ -84,7 +91,25 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
             store.putAll(data);
             LOG.infov("Loaded {0} entries from {1}", store.size(), filePath);
         } catch (IOException e) {
-            LOG.errorv(e, "Failed to load data from {0}", filePath);
+            // Starting empty here silently drops all persisted state for this store, which can leave
+            // other services referencing resources that now appear missing. Quarantine the
+            // unreadable file and log loudly so the data loss is detectable rather than
+            // masquerading as an empty store.
+            quarantineUnreadableFile(e);
+        }
+    }
+
+    private void quarantineUnreadableFile(IOException cause) {
+        Path quarantine = filePath.resolveSibling(filePath.getFileName() + ".corrupt");
+        try {
+            Files.move(filePath, quarantine, StandardCopyOption.REPLACE_EXISTING);
+            LOG.errorv(cause, "Failed to load persisted data from {0}; moved the unreadable file to "
+                    + "{1} and started with an empty store. This store's state was lost.",
+                    filePath, quarantine);
+        } catch (IOException moveError) {
+            LOG.errorv(cause, "Failed to load persisted data from {0}; could not quarantine it ({1}). "
+                    + "Starting with an empty store. This store's state was lost.",
+                    filePath, moveError.getMessage());
         }
     }
 

--- a/src/main/java/io/floci/gcp/core/storage/StorageBackend.java
+++ b/src/main/java/io/floci/gcp/core/storage/StorageBackend.java
@@ -5,6 +5,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
+/**
+ * Generic storage abstraction for GCP emulator services.
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ */
 public interface StorageBackend<K, V> {
 
     void put(K key, V value);
@@ -13,13 +19,21 @@ public interface StorageBackend<K, V> {
 
     void delete(K key);
 
+    /**
+     * Return a new mutable list of values whose keys pass the filter. Callers may sort,
+     * filter, or otherwise mutate the returned list without affecting the underlying store.
+     */
     List<V> scan(Predicate<K> keyFilter);
 
+    /** Return all keys in this store. */
     Set<K> keys();
 
+    /** Persist data to disk if applicable. */
     void flush();
 
+    /** Load data from disk on startup. */
     void load();
 
+    /** Clear all data. */
     void clear();
 }

--- a/src/main/java/io/floci/gcp/core/storage/StorageFactory.java
+++ b/src/main/java/io/floci/gcp/core/storage/StorageFactory.java
@@ -10,13 +10,16 @@ import org.jboss.logging.Logger;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Creates {@link ProjectAwareStorageBackend} instances based on configuration.
- * Every backend is wrapped in a project-aware decorator so resources are automatically
- * namespaced by the calling GCP project ID.
+ * Factory that creates {@link ProjectAwareStorageBackend} instances based on configuration.
+ * Every backend created via {@link #create} is wrapped in a project-aware decorator so
+ * resources are automatically namespaced by the calling GCP project ID; globally
+ * namespaced services (e.g. GCS buckets) use {@link #createGlobal} instead.
+ * Tracks all created backends for lifecycle management.
  */
 @ApplicationScoped
 public class StorageFactory {
@@ -25,6 +28,10 @@ public class StorageFactory {
 
     private final EmulatorConfig config;
     private final List<StorageBackend<?, ?>> allBackends = new ArrayList<>();
+    // A file path identifies one logical store: callers sharing a path are expected to agree on
+    // its value type, storage mode, and scoping (global vs project-aware). The first create wins;
+    // repeat calls reuse that backend.
+    private final Map<Path, StorageBackend<?, ?>> backendsByPath = new HashMap<>();
     private final List<HybridStorage<?, ?>> hybridBackends = new ArrayList<>();
     private final List<WalStorage<?, ?>> walBackends = new ArrayList<>();
 
@@ -37,103 +44,133 @@ public class StorageFactory {
     }
 
     /**
-     * Creates a global (non-project-scoped) backend for services whose resources are
+     * Create a global (non-project-scoped) backend for services whose resources are
      * globally namespaced (e.g. GCS, where bucket names are globally unique).
+     *
+     * @param serviceName   the service name (gcs, pubsub, iam, …)
+     * @param fileName      the JSON file name for persistent storage
+     * @param typeReference Jackson type reference for deserialization
      */
-    public <V> StorageBackend<String, V> createGlobal(String serviceName, String fileName,
+    public synchronized <V> StorageBackend<String, V> createGlobal(String serviceName, String fileName,
                                                        TypeReference<Map<String, V>> typeReference) {
-        return createGlobal(serviceName, fileName, typeReference, config.storage().mode());
-    }
+        String mode = config.storage().mode();
+        Path filePath = Path.of(config.storage().persistentPath()).resolve(fileName);
 
-    public <V> StorageBackend<String, V> createGlobal(String serviceName, String fileName,
-                                                       TypeReference<Map<String, V>> typeReference,
-                                                       String modeOverride) {
-        String mode = modeOverride != null ? modeOverride : config.storage().mode();
-        Path basePath = Path.of(config.storage().persistentPath());
-        Path filePath = basePath.resolve(fileName);
+        StorageBackend<String, V> existing = findExisting(mode, serviceName, filePath);
+        if (existing != null) {
+            return existing;
+        }
 
-        LOG.debugv("Creating {0} global storage for service {1}", mode, serviceName);
+        LOG.debugv("Creating {0} global storage for service {1} (file: {2})", mode, serviceName, filePath);
 
-        StorageBackend<String, V> inner = switch (mode) {
-            case "memory" -> new InMemoryStorage<>();
-            case "persistent" -> new PersistentStorage<>(filePath, typeReference);
-            case "hybrid" -> {
-                var hybrid = new HybridStorage<>(filePath, typeReference, 5000L);
-                hybridBackends.add(hybrid);
-                yield hybrid;
-            }
-            case "wal" -> {
-                Path snapshotPath = basePath.resolve(fileName.replace(".json", "-snapshot.json"));
-                Path walFilePath = basePath.resolve(fileName.replace(".json", ".wal"));
-                long compactionInterval = config.storage().wal().compactionIntervalMs();
-                var wal = new WalStorage<>(snapshotPath, walFilePath, typeReference, compactionInterval);
-                walBackends.add(wal);
-                yield wal;
-            }
-            default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
-        };
-
+        StorageBackend<String, V> inner = createInner(mode, fileName, filePath, typeReference);
         inner.load();
         allBackends.add(inner);
+        backendsByPath.put(filePath, inner);
         return inner;
     }
 
-    public <V> ProjectAwareStorageBackend<V> create(String serviceName, String fileName,
+    /**
+     * Create a project-aware storage backend for the given service.
+     * All keys are automatically prefixed with the current project ID derived from
+     * the request context. Async workers should use the {@code *ForProject} overloads
+     * on {@link ProjectAwareStorageBackend} with the project ID stored on the resource model.
+     *
+     * @param serviceName   the service name (cloudsql, bigquery, monitoring, …)
+     * @param fileName      the JSON file name for persistent storage
+     * @param typeReference Jackson type reference for deserialization
+     */
+    public synchronized <V> StorageBackend<String, V> create(String serviceName, String fileName,
                                                      TypeReference<Map<String, V>> typeReference) {
-        return create(serviceName, fileName, typeReference, config.storage().mode());
-    }
+        String mode = config.storage().mode();
+        Path filePath = Path.of(config.storage().persistentPath()).resolve(fileName);
 
-    public <V> ProjectAwareStorageBackend<V> create(String serviceName, String fileName,
-                                                     TypeReference<Map<String, V>> typeReference,
-                                                     String modeOverride) {
-        String mode = modeOverride != null ? modeOverride : config.storage().mode();
-        Path basePath = Path.of(config.storage().persistentPath());
-        Path filePath = basePath.resolve(fileName);
+        StorageBackend<String, V> existing = findExisting(mode, serviceName, filePath);
+        if (existing != null) {
+            return existing;
+        }
 
-        LOG.debugv("Creating {0} storage for service {1}", mode, serviceName);
+        LOG.debugv("Creating {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
 
-        StorageBackend<String, V> inner = switch (mode) {
-            case "memory" -> new InMemoryStorage<>();
-            case "persistent" -> new PersistentStorage<>(filePath, typeReference);
-            case "hybrid" -> {
-                var hybrid = new HybridStorage<>(filePath, typeReference, 5000L);
-                hybridBackends.add(hybrid);
-                yield hybrid;
-            }
-            case "wal" -> {
-                Path snapshotPath = basePath.resolve(fileName.replace(".json", "-snapshot.json"));
-                Path walFilePath = basePath.resolve(fileName.replace(".json", ".wal"));
-                long compactionInterval = config.storage().wal().compactionIntervalMs();
-                var wal = new WalStorage<>(snapshotPath, walFilePath, typeReference, compactionInterval);
-                walBackends.add(wal);
-                yield wal;
-            }
-            default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
-        };
-
+        StorageBackend<String, V> inner = createInner(mode, fileName, filePath, typeReference);
         inner.load();
 
         ProjectAwareStorageBackend<V> backend = new ProjectAwareStorageBackend<>(
                 inner, requestContextInstance, config.defaultProjectId());
         allBackends.add(backend);
+        backendsByPath.put(filePath, backend);
         return backend;
     }
 
-    public void loadAll() {
+    /**
+     * Reuse an existing backend bound to the same file. Handing out a second backend bound to
+     * the same path creates a duplicate in-memory store; on shutdown the stale duplicate flushes
+     * after the active instance and clobbers persisted state.
+     */
+    private <V> StorageBackend<String, V> findExisting(String mode, String serviceName, Path filePath) {
+        StorageBackend<?, ?> existing = backendsByPath.get(filePath);
+        if (existing == null) {
+            return null;
+        }
+        LOG.debugv("Reusing existing {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
+        @SuppressWarnings("unchecked")
+        StorageBackend<String, V> typed = (StorageBackend<String, V>) existing;
+        return typed;
+    }
+
+    private <V> StorageBackend<String, V> createInner(String mode, String fileName, Path filePath,
+                                                      TypeReference<Map<String, V>> typeReference) {
+        Path basePath = Path.of(config.storage().persistentPath());
+        return switch (mode) {
+            case "memory" -> new InMemoryStorage<>();
+            case "persistent" -> new PersistentStorage<>(filePath, typeReference);
+            case "hybrid" -> {
+                var hybrid = new HybridStorage<>(filePath, typeReference, 5000L);
+                hybridBackends.add(hybrid);
+                yield hybrid;
+            }
+            case "wal" -> {
+                Path snapshotPath = basePath.resolve(fileName.replace(".json", "-snapshot.json"));
+                Path walFilePath = basePath.resolve(fileName.replace(".json", ".wal"));
+                long compactionInterval = config.storage().wal().compactionIntervalMs();
+                var wal = new WalStorage<>(snapshotPath, walFilePath, typeReference, compactionInterval);
+                walBackends.add(wal);
+                yield wal;
+            }
+            default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
+        };
+    }
+
+    /** Load all storage backends from disk. */
+    public synchronized void loadAll() {
         for (StorageBackend<?, ?> backend : allBackends) {
             backend.load();
         }
     }
 
-    public void shutdownAll() {
+    /** Flush all storage backends to disk. */
+    public synchronized void flushAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.flush();
+        }
+    }
+
+    /** Clear all storage backends. */
+    public synchronized void clearAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.clear();
+        }
+        flushAll();
+    }
+
+    /** Shutdown all managed backends (stop schedulers, close connections). */
+    public synchronized void shutdownAll() {
         for (HybridStorage<?, ?> hybrid : hybridBackends) {
             hybrid.shutdown();
         }
         for (WalStorage<?, ?> wal : walBackends) {
             wal.shutdown();
         }
-        for (StorageBackend<?, ?> backend : allBackends) {
-            backend.flush();
-        }
+        flushAll();
     }
 }

--- a/src/main/java/io/floci/gcp/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/WalStorage.java
@@ -25,12 +25,14 @@ import java.util.stream.Collectors;
 /**
  * Write-Ahead Log storage: in-memory reads with append-only binary WAL for durability.
  * Periodic compaction writes a full snapshot and truncates the WAL.
+ * On startup: load snapshot, then replay WAL entries after snapshot.
  *
  * Binary WAL entry format:
  *   PUT:    [0x01] [4-byte key length] [key bytes] [4-byte value length] [value bytes]
  *   DELETE: [0x02] [4-byte key length] [key bytes]
  *
- * Key/value bytes are CBOR-serialized (compact binary). Snapshots use indented JSON.
+ * Key and value bytes are serialized via Jackson CBOR (compact binary format).
+ * Snapshot files use indented JSON for debuggability.
  */
 public class WalStorage<K, V> implements StorageBackend<K, V> {
 
@@ -114,7 +116,9 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void flush() { compact(); }
+    public void flush() {
+        compact();
+    }
 
     @Override
     public void load() {
@@ -128,10 +132,12 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                 LOG.errorv(e, "Failed to load snapshot from {0}", snapshotPath);
             }
         }
+
         if (Files.exists(walPath)) {
             int replayed = replayWal();
             LOG.infov("Replayed {0} WAL entries from {1}", replayed, walPath);
         }
+
         openWalWriter();
     }
 
@@ -175,9 +181,12 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
             snapshotMapper.writeValue(tempFile.toFile(), store);
             Files.move(tempFile, snapshotPath, StandardCopyOption.REPLACE_EXISTING,
                     StandardCopyOption.ATOMIC_MOVE);
+
             closeWalWriter();
             Files.deleteIfExists(walPath);
             openWalWriter();
+
+            LOG.debugv("Compacted {0} entries to snapshot, WAL truncated", store.size());
         } catch (IOException e) {
             LOG.errorv(e, "Failed to compact WAL storage");
         } finally {
@@ -232,14 +241,16 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                 } catch (EOFException e) {
                     break;
                 }
+
                 int keyLen = in.readInt();
                 byte[] keyBytes = in.readNBytes(keyLen);
-                if (keyBytes.length < keyLen) break;
+                if (keyBytes.length < keyLen) break; // truncated entry
 
                 if (op == OP_PUT) {
                     int valueLen = in.readInt();
                     byte[] valueBytes = in.readNBytes(valueLen);
-                    if (valueBytes.length < valueLen) break;
+                    if (valueBytes.length < valueLen) break; // truncated entry
+
                     K key = (K) walMapper.readValue(keyBytes, Object.class);
                     V value = walMapper.readValue(valueBytes,
                             walMapper.constructType(typeReference.getType()).getContentType());
@@ -255,7 +266,8 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                 }
             }
         } catch (IOException e) {
-            LOG.errorv(e, "Failed to replay WAL from {0} (replayed {1} entries)", walPath, replayed);
+            LOG.errorv(e, "Failed to replay WAL from {0} (replayed {1} entries before error)",
+                    walPath, replayed);
         }
         return replayed;
     }
@@ -263,8 +275,8 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     private void openWalWriter() {
         try {
             Files.createDirectories(walPath.getParent());
-            walWriter = new DataOutputStream(new BufferedOutputStream(
-                    Files.newOutputStream(walPath,
+            walWriter = new DataOutputStream(
+                    new BufferedOutputStream(Files.newOutputStream(walPath,
                             java.nio.file.StandardOpenOption.CREATE,
                             java.nio.file.StandardOpenOption.APPEND)));
         } catch (IOException e) {

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
@@ -76,7 +76,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
 
         String internalMountPath = getInternalMountPath(stringValue(updated.get("databaseVersion")));
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "cloudsql", volumeId, fallbackId, internalMountPath);
         } else {
             String hostDataPath = Path.of(config.storage().hostPersistentPath(), "cloudsql",
@@ -99,7 +99,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
                 lifecycleManager.stopAndRemove(containerId, null);
             }
             if (newVolume && ContainerStorageHelper.isNamedVolumeMode(config)) {
-                lifecycleManager.removeVolume(ContainerStorageHelper.resourceName("cloudsql", volumeId, fallbackId));
+                lifecycleManager.removeVolume(ContainerStorageHelper.resourceName(config, "cloudsql", volumeId, fallbackId));
             }
             throw e;
         }

--- a/src/main/java/io/floci/gcp/services/kafka/RedpandaManager.java
+++ b/src/main/java/io/floci/gcp/services/kafka/RedpandaManager.java
@@ -70,7 +70,7 @@ public class RedpandaManager {
         }
 
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "kafka", cluster.getVolumeId(), clusterId(cluster.getName()),
                     "/var/lib/redpanda/data");
         } else {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,7 @@ floci-gcp:
     log-max-file: "3"
     docker-host: "unix:///var/run/docker.sock"
     api-timeout: 30s
+    resource-namespace: ""          # FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE; scopes sidecar container/volume names
   init-hooks:
     shell-executable: /bin/sh
     shutdown-grace-period-seconds: 2


### PR DESCRIPTION
## Summary

Converges the storage cluster on floci-aws baseline 0142dc4:

- **PersistentStorage** quarantines unreadable JSON as `.corrupt` with loud
  logging instead of silently starting empty (floci-aws 04e0f2dd)
- **StorageFactory** dedupes backends by resolved file path across `create()`
  and `createGlobal()` so shared paths cannot clobber persisted state on
  shutdown flush (551df637); synchronized entry points; `flushAll`/`clearAll`
  lifecycle methods and flush-on-shutdown (f4c7a84d); drops the unused 4-arg
  `modeOverride` overloads (zero call sites)
- **ContainerStorageHelper** gains config-aware `resourceName`/`dockerName`/
  `hostResourcePath` with a sanitized `floci-gcp-` prefix (073e653d) and the
  new optional `floci-gcp.docker.resource-namespace` config
  (`FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE`)
- Storage backends restore baseline javadoc (incl. the `scan()` mutable-list
  contract) and debug logs — now byte-identical to the baseline modulo
  package naming

Kept: `createGlobal()` API (30+ call sites), `ProjectAwareStorageBackend`
seam, global `storage.mode` resolution (ServiceConfigAccess deliberately
deferred).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

No wire-protocol changes — internal persistence/storage hardening only.
Behavior was converged line-by-line against the floci-aws baseline 0142dc4;
the storage backends are byte-identical to it modulo package naming.

## Checklist

- [x] `./mvnw test` passes locally (440 tests, 0 failures)
- [ ] New or updated integration test added — no new tests; the changed
  behaviors (corrupt-file quarantine, backend dedupe, flush-on-shutdown) are
  covered upstream in the floci-aws baseline this is converged on
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
