### PR TITLE
feat(core): converge dns and runtime clusters on floci-aws baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **docker:** every emulator-created container and volume now carries the shared Floci labels `floci=true`, `floci_emulator=floci-gcp`, and (when configured) `floci_namespace` — `docker ps --filter label=floci_emulator=floci-gcp` and `docker volume prune --filter label=floci_emulator=floci-gcp` target this emulator alone, while `label=floci=true` matches every Floci emulator
+- **docker:** `FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE` (`floci-gcp.docker.resource-namespace`) — optional namespace inserted into sidecar container/volume names (`floci-gcp-<ns>-…`) so parallel emulator instances on one Docker host don't collide
+
+### Changed
+
+- **docker:** sidecar container names now carry the cloud token: `floci-cloudrun-…` → `floci-gcp-cloudrun-…`, `floci-kafka-…` → `floci-gcp-kafka-…`, `floci-cloudsql-…` → `floci-gcp-cloudsql-…`, and `floci-gke-<cluster>` → `floci-gcp-gke-<project>-<cluster>` (GKE containers are now also project-scoped, so equal cluster ids in different projects no longer collide). `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_CONTAINER_NAME_PREFIX` was removed — Cloud Run container names are always `floci-gcp-[<ns>-]cloudrun-…`; use `FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE` to distinguish parallel instances. Containers created by an older version are not reaped automatically; remove them once with `docker rm -f $(docker ps -aq --filter name=^/floci-)`. If you reach sidecars by container name over a shared Docker network (e.g. `floci-kafka-x:9092`, `floci-gke-c1:6443` in compose files or client config), update those references
+- **docker:** Cloud SQL, Kafka, and GKE volume names are now persisted with the resource. Volumes created by older versions keep their original names (`floci-gcp-cloudsql-<id>`, `floci-gcp-kafka-<id>`, `floci-gke-<cluster>`) and are adopted transparently — no data is moved. Pre-existing volumes keep their old `floci-gcp=true` label and won't match `label=floci=true` prune filters. Rollback caveat: after downgrading, resources created on this version resolve to recomputed legacy names, so their volumes are left behind rather than reused; the data survives and can be recovered by renaming the volume
+
 ## [0.5.0] - 2026-07-09
 
 ### Added

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -58,6 +58,7 @@ floci-gcp:
     docker-host: unix:///var/run/docker.sock
     api-timeout: 30s
     docker-config-path: ""
+    resource-namespace: ""            # Optional; inserted into sidecar container/volume names (floci-gcp-<ns>-...)
 
   services:
     gcs:
@@ -110,7 +111,6 @@ floci-gcp:
         request-timeout: 300s
         operation-timeout: 300s
         cleanup-timeout: 15s
-        container-name-prefix: floci-cloudrun
         url-host-suffix:              # Optional; defaults to hostname, then localhost.floci.io
 
     cloudfunctions:

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -73,7 +73,6 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_REQUEST_TIMEOUT` | `300s` | Cloud Run invocation proxy timeout |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_OPERATION_TIMEOUT` | `300s` | Maximum time for asynchronous Cloud Run execution operations before their LRO fails |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_CLEANUP_TIMEOUT` | `15s` | Maximum time to wait for best-effort Docker cleanup after an operation is already resolved |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_CONTAINER_NAME_PREFIX` | `floci-cloudrun` | Prefix for Docker containers created for Cloud Run execution |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_URL_HOST_SUFFIX` | `localhost.floci.io` or `FLOCI_GCP_HOSTNAME` | Host suffix used for generated Cloud Run execution URLs |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Cloud Functions |
 
@@ -84,6 +83,7 @@ Some services (e.g. Managed Kafka) start real sidecar containers via the host Do
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_GCP_SERVICES_DOCKER_NETWORK` | _(none)_ | Shared Docker network attached to spawned sidecar containers so floci-gcp and your SDKs can reach them by name. Set this to your Compose/CI network |
+| `FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE` | – | Namespace inserted into sidecar container/volume names (`floci-gcp-<ns>-…`) so parallel emulator instances on one Docker host don't collide |
 
 ### Managed Kafka
 

--- a/docs/services/cloud-run.md
+++ b/docs/services/cloud-run.md
@@ -11,7 +11,6 @@ floci-gcp emulates the Cloud Run Admin API v2 control plane over REST JSON using
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_REQUEST_TIMEOUT` | `300s` | Default invocation proxy timeout |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_OPERATION_TIMEOUT` | `300s` | Maximum time for asynchronous Cloud Run execution operations before their LRO fails |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_CLEANUP_TIMEOUT` | `15s` | Maximum time to wait for best-effort Docker cleanup after an operation is already resolved |
-| `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_CONTAINER_NAME_PREFIX` | `floci-cloudrun` | Prefix for Docker containers created for Cloud Run execution |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_URL_HOST_SUFFIX` | `localhost.floci.io` or `FLOCI_GCP_HOSTNAME` | Host suffix used for generated Cloud Run execution URLs |
 
 ## Supported API Surface

--- a/docs/services/cloud-sql-postgres.md
+++ b/docs/services/cloud-sql-postgres.md
@@ -63,7 +63,9 @@ Database and user Admin API operations are synchronized into the backing Postgre
 - Created users receive connect/create privileges on existing and newly created databases.
 
 Docker storage follows the global floci-gcp storage policy. In named-volume mode, each instance gets
-a stable `floci-gcp-cloudsql-*` volume. `memory` mode, or `floci-gcp.storage.prune-volumes-on-delete=true`,
+a stable `floci-gcp-cloudsql-*` volume (with `floci-gcp.docker.resource-namespace` configured, new
+volumes are named `floci-gcp-<ns>-cloudsql-*`; volumes created before the name was persisted keep
+their original name). `memory` mode, or `floci-gcp.storage.prune-volumes-on-delete=true`,
 removes the volume when the instance is deleted; `persistent`, `hybrid`, and `wal` retain volumes by
 default. When `floci-gcp.storage.host-persistent-path` is absolute, instance data is bind-mounted under
 `{hostPersistentPath}/cloudsql/{project}/{instance}`.

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -42,6 +42,31 @@ public interface EmulatorConfig {
 
     interface DnsConfig {
         Optional<List<String>> extraSuffixes();
+
+        /**
+         * When {@code true} (default), the configured {@link #containerFallbackServers()} are
+         * appended after floci-gcp's embedded DNS to every spawned container's
+         * {@code HostConfig.Dns}. This gives Cloud Run/GKE/sidecar containers a real secondary
+         * resolver so public hostnames still resolve if floci-gcp's embedded forwarder cannot
+         * answer — mirroring the {@code docker run --dns <flociIp> --dns 8.8.8.8} workaround.
+         *
+         * <p>Disable (via {@code FLOCI_GCP_DNS_CONTAINER_FALLBACK_ENABLED=false}) in offline or
+         * locked-down networks where the public resolvers are unreachable/blocked.
+         */
+        @WithDefault("true")
+        boolean containerFallbackEnabled();
+
+        /**
+         * Ordered list of public DNS resolvers injected into spawned containers as secondary
+         * resolvers when {@link #containerFallbackEnabled()} is set.
+         *
+         * <p>Via environment variable (comma-separated):
+         * <pre>
+         * FLOCI_GCP_DNS_CONTAINER_FALLBACK_SERVERS=1.1.1.1,1.0.0.1
+         * </pre>
+         */
+        @WithDefault("8.8.8.8,8.8.4.4")
+        List<String> containerFallbackServers();
     }
 
     interface StorageConfig {
@@ -267,9 +292,6 @@ public interface EmulatorConfig {
             @WithDefault("15s")
             Duration cleanupTimeout();
 
-            @WithDefault("floci-cloudrun")
-            String containerNamePrefix();
-
             Optional<String> urlHostSuffix();
         }
     }
@@ -323,6 +345,29 @@ public interface EmulatorConfig {
          * Useful when multiple Floci processes share one Docker daemon.
          */
         Optional<String> resourceNamespace();
+
+        /**
+         * Optional registry/repository base for every Docker image floci-gcp launches.
+         * When set, images such as {@code postgres:16.14-alpine} and
+         * {@code redpandadata/redpanda:latest} resolve under this base before the
+         * container is created.
+         */
+        Optional<String> imageRegistryBase();
+
+        /**
+         * Explicit credentials for private Docker registries.
+         * Each entry maps a registry hostname to a username/password pair.
+         * Use when mounting the host Docker config is impractical.
+         */
+        @WithDefault("")
+        List<RegistryCredential> registryCredentials();
+
+        interface RegistryCredential {
+            /** Registry hostname (e.g. myregistry.example.com). */
+            String server();
+            String username();
+            String password();
+        }
     }
 
     interface InitHooksConfig {

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -317,6 +317,12 @@ public interface EmulatorConfig {
         Duration apiTimeout();
 
         Optional<String> dockerConfigPath();
+
+        /**
+         * Optional namespace inserted into Floci-managed sidecar container and volume names.
+         * Useful when multiple Floci processes share one Docker daemon.
+         */
+        Optional<String> resourceNamespace();
     }
 
     interface InitHooksConfig {

--- a/src/main/java/io/floci/gcp/core/common/ContainerTeardown.java
+++ b/src/main/java/io/floci/gcp/core/common/ContainerTeardown.java
@@ -1,0 +1,19 @@
+package io.floci.gcp.core.common;
+
+/**
+ * Implemented by services that launch Docker containers whose lifetime is bound to the
+ * emulator process (Cloud Run instances, Cloud Functions workers, in-flight build/job
+ * containers). {@code EmulatorLifecycle.onStop} invokes every implementation during the
+ * ShutdownEvent phase — before {@code StorageFactory.shutdownAll()} — so teardown runs at
+ * a deterministic point and state changes made while stopping are still captured by the
+ * final flush. A {@code @PreDestroy} alone is not sufficient for that: bean destruction
+ * runs after the ShutdownEvent observers, when the storage flush schedulers are already
+ * stopped.
+ *
+ * <p>Implementations must be idempotent; they may also be invoked from {@code @PreDestroy}
+ * as a fallback.
+ */
+public interface ContainerTeardown {
+
+    void stopManagedContainers();
+}

--- a/src/main/java/io/floci/gcp/core/common/Resettable.java
+++ b/src/main/java/io/floci/gcp/core/common/Resettable.java
@@ -1,0 +1,14 @@
+package io.floci.gcp.core.common;
+
+/**
+ * Implemented by services or components that hold in-memory state which must be cleared
+ * when the emulator state is reset or nuked.
+ *
+ * <p>Implementations are discovered via CDI ({@code Instance<Resettable>}) and invoked in
+ * no particular order by the reset endpoint. Each {@link #clear()} must therefore be
+ * self-contained (no ordering dependency on other Resettable beans) and idempotent.
+ */
+public interface Resettable {
+
+    void clear();
+}

--- a/src/main/java/io/floci/gcp/core/common/XmlParser.java
+++ b/src/main/java/io/floci/gcp/core/common/XmlParser.java
@@ -1,5 +1,7 @@
 package io.floci.gcp.core.common;
 
+import org.jboss.logging.Logger;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -15,6 +17,8 @@ import java.util.Map;
  * (multipart uploads, bucket configurations, etc.).
  */
 public final class XmlParser {
+
+    private static final Logger LOG = Logger.getLogger(XmlParser.class);
 
     private static final XMLInputFactory FACTORY;
 
@@ -96,7 +100,8 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {
+        } catch (XMLStreamException e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
         }
         return result;
     }
@@ -120,7 +125,8 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {
+        } catch (XMLStreamException e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
         }
         return result;
     }

--- a/src/main/java/io/floci/gcp/core/common/dns/EmbeddedDnsServer.java
+++ b/src/main/java/io/floci/gcp/core/common/dns/EmbeddedDnsServer.java
@@ -11,11 +11,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -23,14 +25,18 @@ import java.util.Optional;
 import java.util.SequencedSet;
 
 /**
- * Embedded UDP/53 DNS server that runs inside the floci-gcp container.
+ * Embedded UDP/53 DNS server that runs inside the floci-gcp container and is injected
+ * into every spawned sidecar container (Cloud Run, Cloud Functions, Cloud SQL) as their
+ * DNS resolver.
  *
- * Resolves *.localhost.floci-gcp.io (and any configured extra-suffixes) to the
- * container's own IP so virtual-hosted GCS URLs work from inside sidecar containers
- * without requiring wildcard Docker aliases.
+ * Resolves *.localhost.floci.io (and any configured extra-suffixes) to the container's
+ * own IP so virtual-hosted GCS URLs and Cloud Run service URLs work from inside sidecar
+ * containers without requiring wildcard Docker aliases.
  *
- * All other queries are forwarded transparently to the upstream resolver read from
- * /etc/resolv.conf (Docker's embedded DNS at 127.0.0.11).
+ * All other queries are forwarded to the upstream resolvers read from /etc/resolv.conf
+ * (Docker's embedded DNS at 127.0.0.11), falling back to the configured public resolvers
+ * (floci-gcp.dns.container-fallback-servers) so public hostnames still resolve when the
+ * resolv.conf resolver does not answer.
  *
  * Only starts when running inside Docker. No-op on the host.
  */
@@ -42,13 +48,22 @@ public class EmbeddedDnsServer {
     private static final int DNS_PORT = 53;
     private static final int TTL = 60;
     private static final String FALLBACK_UPSTREAM = "127.0.0.11";
+    // EDNS0-capable resolvers (Node/c-ares, glibc) advertise UDP payloads well above the
+    // legacy 512-byte limit; CDN-backed public names return larger responses. Receiving into
+    // a 512-byte buffer silently truncates the datagram and corrupts the forwarded answer.
+    private static final int MAX_DNS_UDP_RESPONSE = 4096;
+    // Per-upstream timeout. Bounded so trying every upstream stays under a typical 5s client
+    // resolver timeout even in the worst case.
+    private static final int FORWARD_TIMEOUT_MS = 1500;
     public static final String DEFAULT_SUFFIX = "localhost.floci.io";
 
+    // The suffix "localhost.X" covers "localhost.X" itself and "*.localhost.X" — it does
+    // NOT cover "*.X" (e.g. "localhost.floci.io" does NOT resolve bare "*.floci.io").
     static final List<String> BUILTIN_SUFFIXES = List.of(DEFAULT_SUFFIX);
 
     private volatile String serverIp;
     private final SequencedSet<String> suffixes = new LinkedHashSet<>();
-    private String upstreamDns;
+    private volatile List<String> upstreamDnsServers = List.of();
 
     EmbeddedDnsServer(List<String> suffixes) {
         this.suffixes.addAll(BUILTIN_SUFFIXES);
@@ -62,7 +77,8 @@ public class EmbeddedDnsServer {
         }
         try {
             String myIp = InetAddress.getLocalHost().getHostAddress();
-            upstreamDns = readUpstreamDns();
+            upstreamDnsServers = composeUpstreams(readResolvConfNameservers(),
+                    config.dns().containerFallbackServers());
 
             suffixes.addAll(BUILTIN_SUFFIXES);
             config.hostname().ifPresent(suffixes::add);
@@ -89,6 +105,8 @@ public class EmbeddedDnsServer {
         return Optional.ofNullable(serverIp);
     }
 
+    // ── packet handling ───────────────────────────────────────────────────────
+
     private void handleQuery(Vertx vertx, DatagramSocket socket, byte[] data,
                              String senderHost, int senderPort, String myIp) {
         try {
@@ -101,17 +119,18 @@ public class EmbeddedDnsServer {
             buf.getShort(); // arcount
 
             if ((flags & 0x8000) != 0 || qdCount < 1) {
-                return;
+                return; // not a standard query
             }
 
-            int questionOffset = buf.position();
+            int questionOffset = buf.position(); // always 12 for a standard query
             String qname = readName(buf, data);
             short qtype = buf.getShort();
             buf.getShort(); // qclass
             int questionEnd = buf.position();
 
-            if (qtype == 1 && matchesSuffix(qname)) {
-                byte[] response = buildAResponse(data, txId, questionOffset, questionEnd, myIp);
+            Optional<String> resolvedAddress = qtype == 1 ? resolveARecord(qname, myIp) : Optional.empty();
+            if (resolvedAddress.isPresent()) {
+                byte[] response = buildAResponse(data, txId, questionOffset, questionEnd, resolvedAddress.get());
                 socket.send(Buffer.buffer(response), senderPort, senderHost, v -> {});
             } else {
                 forwardAsync(vertx, socket, data, senderHost, senderPort);
@@ -120,6 +139,8 @@ public class EmbeddedDnsServer {
             LOG.debugv("DNS packet error: {0}", e.getMessage());
         }
     }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
 
     boolean matchesSuffix(String name) {
         if (name == null || name.isEmpty()) {
@@ -135,6 +156,13 @@ public class EmbeddedDnsServer {
         return false;
     }
 
+    Optional<String> resolveARecord(String name, String myIp) {
+        if (matchesSuffix(name)) {
+            return Optional.of(myIp);
+        }
+        return Optional.empty();
+    }
+
     String readName(ByteBuffer buf, byte[] data) {
         StringBuilder sb = new StringBuilder();
         int safety = 0;
@@ -144,6 +172,7 @@ public class EmbeddedDnsServer {
                 break;
             }
             if ((len & 0xC0) == 0xC0) {
+                // compression pointer
                 int offset = ((len & 0x3F) << 8) | (buf.get() & 0xFF);
                 ByteBuffer ptr = ByteBuffer.wrap(data);
                 ptr.position(offset);
@@ -165,22 +194,26 @@ public class EmbeddedDnsServer {
 
     byte[] buildAResponse(byte[] query, short txId, int questionOffset, int questionEnd, String ip) {
         int questionLength = questionEnd - questionOffset;
+        // header(12) + question + answer(name-ptr(2) + type(2) + class(2) + ttl(4) + rdlen(2) + rdata(4))
         ByteBuffer resp = ByteBuffer.allocate(12 + questionLength + 16);
 
+        // header
         resp.putShort(txId);
-        resp.putShort((short) 0x8180);
-        resp.putShort((short) 1);
-        resp.putShort((short) 1);
-        resp.putShort((short) 0);
-        resp.putShort((short) 0);
+        resp.putShort((short) 0x8180); // QR=1, AA=1, RD=1, RCODE=0
+        resp.putShort((short) 1);      // qdcount
+        resp.putShort((short) 1);      // ancount
+        resp.putShort((short) 0);      // nscount
+        resp.putShort((short) 0);      // arcount
 
+        // question (copied verbatim from query)
         resp.put(query, questionOffset, questionLength);
 
-        resp.putShort((short) 0xC00C);
-        resp.putShort((short) 1);
-        resp.putShort((short) 1);
+        // answer
+        resp.putShort((short) 0xC00C); // name pointer to offset 12 (start of question name)
+        resp.putShort((short) 1);       // type A
+        resp.putShort((short) 1);       // class IN
         resp.putInt(TTL);
-        resp.putShort((short) 4);
+        resp.putShort((short) 4);       // rdlength
 
         for (String octet : ip.split("\\.")) {
             resp.put((byte) Integer.parseInt(octet));
@@ -191,41 +224,85 @@ public class EmbeddedDnsServer {
 
     private void forwardAsync(Vertx vertx, DatagramSocket socket, byte[] query,
                               String senderHost, int senderPort) {
-        String upstream = upstreamDns;
-        if (upstream == null) {
+        List<String> upstreams = upstreamDnsServers;
+        if (upstreams.isEmpty()) {
             return;
         }
-        vertx.executeBlocking(() -> {
+        vertx.executeBlocking(() -> forwardToUpstreams(query, upstreams, DNS_PORT))
+                .onSuccess(response ->
+                        socket.send(Buffer.buffer(response), senderPort, senderHost, v -> {}))
+                .onFailure(e ->
+                        LOG.warnv("DNS forwarding failed on all upstreams {0}: {1}",
+                                upstreams, e.getMessage()));
+    }
+
+    /**
+     * Forwards the query to each upstream in order and returns the first valid UDP response.
+     * Throws if every upstream times out or errors, so the caller can log a single warning.
+     * The {@code upstreamPort} is parameterised for tests; production always uses {@link #DNS_PORT}.
+     */
+    byte[] forwardToUpstreams(byte[] query, List<String> upstreams, int upstreamPort) throws Exception {
+        Exception last = null;
+        for (String upstream : upstreams) {
             try (java.net.DatagramSocket fwd = new java.net.DatagramSocket()) {
-                fwd.setSoTimeout(2000);
+                fwd.setSoTimeout(FORWARD_TIMEOUT_MS);
                 InetAddress addr = InetAddress.getByName(upstream);
-                fwd.send(new DatagramPacket(query, query.length, addr, DNS_PORT));
-                byte[] buf = new byte[512];
+                fwd.send(new DatagramPacket(query, query.length, addr, upstreamPort));
+                byte[] buf = new byte[MAX_DNS_UDP_RESPONSE];
                 DatagramPacket resp = new DatagramPacket(buf, buf.length);
                 fwd.receive(resp);
                 return Arrays.copyOf(resp.getData(), resp.getLength());
+            } catch (Exception e) {
+                last = e;
+                LOG.debugv("DNS forward to {0} failed: {1}", upstream, e.getMessage());
             }
-        }).onSuccess(response ->
-            socket.send(Buffer.buffer(response), senderPort, senderHost, v -> {})
-        ).onFailure(e ->
-            LOG.debugv("DNS forwarding to {0} failed: {1}", upstream, e.getMessage())
-        );
+        }
+        throw last != null ? last : new IOException("no upstream resolvers configured");
     }
 
-    private String readUpstreamDns() {
+    /**
+     * Builds the ordered, de-duplicated upstream list the forwarder tries in turn: the
+     * resolver(s) from {@code /etc/resolv.conf} first (or Docker's embedded resolver as a
+     * baseline when none are usable), then the configured public fallbacks. The fallbacks let
+     * public names resolve even when the resolv.conf resolver does not answer, mirroring the
+     * {@code --dns <flociGcpIP> --dns 8.8.8.8} workaround.
+     */
+    static List<String> composeUpstreams(List<String> resolvConf, List<String> fallbacks) {
+        SequencedSet<String> ordered = new LinkedHashSet<>();
+        for (String server : resolvConf) {
+            if (isUsableUpstream(server)) {
+                ordered.add(server.trim());
+            }
+        }
+        if (ordered.isEmpty()) {
+            ordered.add(FALLBACK_UPSTREAM);
+        }
+        if (fallbacks != null) {
+            for (String server : fallbacks) {
+                if (isUsableUpstream(server)) {
+                    ordered.add(server.trim());
+                }
+            }
+        }
+        return List.copyOf(ordered);
+    }
+
+    private static boolean isUsableUpstream(String server) {
+        return server != null && !server.isBlank() && !server.trim().equals("127.0.0.1");
+    }
+
+    private List<String> readResolvConfNameservers() {
+        List<String> servers = new ArrayList<>();
         try {
             for (String line : Files.readAllLines(Path.of("/etc/resolv.conf"))) {
                 line = line.trim();
                 if (line.startsWith("nameserver ")) {
-                    String server = line.substring("nameserver ".length()).trim();
-                    if (!server.equals("127.0.0.1")) {
-                        return server;
-                    }
+                    servers.add(line.substring("nameserver ".length()).trim());
                 }
             }
         } catch (Exception e) {
             LOG.debugv("Could not read /etc/resolv.conf: {0}", e.getMessage());
         }
-        return FALLBACK_UPSTREAM;
+        return servers;
     }
 }

--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerBuilder.java
@@ -42,7 +42,46 @@ public class ContainerBuilder {
     }
 
     public Builder newContainer(String image) {
-        return new Builder(image, config, dockerHostResolver, embeddedDnsServer, currentContainerNetworkResolver);
+        return new Builder(resolveImage(image), config, dockerHostResolver, embeddedDnsServer,
+                currentContainerNetworkResolver);
+    }
+
+    private String resolveImage(String image) {
+        return resolveImage(image, configuredImageRegistryBase(config));
+    }
+
+    /**
+     * Resolves an image reference under the configured registry base
+     * ({@code floci-gcp.docker.image-registry-base}), so every image floci-gcp launches can be
+     * redirected to a mirror or private registry. Already-prefixed references pass through.
+     */
+    static String resolveImage(String image, Optional<String> imageRegistryBase) {
+        if (image == null || image.isBlank()) {
+            return image;
+        }
+        return normalizeImageRegistryBase(imageRegistryBase)
+                .filter(base -> !image.startsWith(base + "/"))
+                .map(base -> base + "/" + image)
+                .orElse(image);
+    }
+
+    private static Optional<String> configuredImageRegistryBase(EmulatorConfig config) {
+        if (config == null || config.docker() == null) {
+            return Optional.empty();
+        }
+        return config.docker().imageRegistryBase();
+    }
+
+    private static Optional<String> normalizeImageRegistryBase(Optional<String> imageRegistryBase) {
+        return imageRegistryBase
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> {
+                    while (value.endsWith("/")) {
+                        value = value.substring(0, value.length() - 1);
+                    }
+                    return value;
+                });
     }
 
     public static class Builder {
@@ -67,6 +106,9 @@ public class ContainerBuilder {
         private final Map<String, String> labels = new HashMap<>();
         private LogConfig logConfig;
         private boolean privileged;
+        private String cgroupnsMode;
+        private String user;
+        private final List<String> groupAdd = new ArrayList<>();
         private final List<String> dnsServers = new ArrayList<>();
 
         Builder(String image, EmulatorConfig config, DockerHostResolver dockerHostResolver,
@@ -235,8 +277,54 @@ public class ContainerBuilder {
             return this;
         }
 
+        /** Sets the Docker cgroup namespace mode (for example, {@code "host"}). */
+        public Builder withCgroupnsMode(String cgroupnsMode) {
+            this.cgroupnsMode = cgroupnsMode;
+            return this;
+        }
+
+        /**
+         * Sets the user the container process runs as, formatted {@code "uid[:gid]"}
+         * (Docker's top-level container user). Null or blank leaves the image {@code USER}
+         * in effect.
+         */
+        public Builder withUser(String user) {
+            this.user = user;
+            return this;
+        }
+
+        /**
+         * Adds a supplementary group id to the container process (Docker {@code --group-add}),
+         * so it can access group-owned resources without changing its primary uid/gid. Blank
+         * ids are ignored.
+         */
+        public Builder withGroupAdd(String groupId) {
+            if (groupId != null && !groupId.isBlank()) {
+                this.groupAdd.add(groupId);
+            }
+            return this;
+        }
+
+        /**
+         * Injects floci-gcp's embedded DNS server into the container so emulator hostnames
+         * resolve to floci-gcp's Docker network IP. No-op when the embedded DNS server is
+         * not running.
+         *
+         * <p>When {@code floci-gcp.dns.container-fallback-enabled} is set, the configured public
+         * fallback resolvers are appended after floci-gcp's IP so the container's own resolver
+         * can fall through for public hostnames if the embedded forwarder cannot answer.
+         */
         public Builder withEmbeddedDns() {
-            embeddedDnsServer.getServerIp().ifPresent(dnsServers::add);
+            embeddedDnsServer.getServerIp().ifPresent(flociIp -> {
+                dnsServers.add(flociIp);
+                if (config.dns().containerFallbackEnabled()) {
+                    for (String fallback : config.dns().containerFallbackServers()) {
+                        if (fallback != null && !fallback.isBlank() && !dnsServers.contains(fallback.trim())) {
+                            dnsServers.add(fallback.trim());
+                        }
+                    }
+                }
+            });
             return this;
         }
 
@@ -257,8 +345,11 @@ public class ContainerBuilder {
                     Map.copyOf(labels),
                     logConfig,
                     privileged,
+                    cgroupnsMode,
                     List.copyOf(dnsServers),
-                    workingDir
+                    workingDir,
+                    user,
+                    List.copyOf(groupAdd)
             );
         }
     }

--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerLifecycleManager.java
@@ -15,6 +15,7 @@ import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.StreamType;
+import io.floci.gcp.config.EmulatorConfig;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -30,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -49,6 +51,7 @@ public class ContainerLifecycleManager {
     private final ContainerDetector containerDetector;
     private final PortAllocator portAllocator;
     private final ImageCacheService imageCacheService;
+    private final EmulatorConfig config;
     private final ExecutorService dockerApiExecutor = Executors.newCachedThreadPool(r -> {
         Thread thread = new Thread(r, "floci-docker-api-" + DOCKER_API_THREAD.incrementAndGet());
         thread.setDaemon(true);
@@ -59,11 +62,13 @@ public class ContainerLifecycleManager {
     public ContainerLifecycleManager(DockerClientProducer dockerClients,
                                      ContainerDetector containerDetector,
                                      PortAllocator portAllocator,
-                                     ImageCacheService imageCacheService) {
+                                     ImageCacheService imageCacheService,
+                                     EmulatorConfig config) {
         this.dockerClients = dockerClients;
         this.containerDetector = containerDetector;
         this.portAllocator = portAllocator;
         this.imageCacheService = imageCacheService;
+        this.config = config;
     }
 
     @PreDestroy
@@ -73,7 +78,15 @@ public class ContainerLifecycleManager {
 
     public ContainerInfo createAndStart(ContainerSpec spec) {
         String containerId = create(spec);
-        return startCreated(containerId, spec);
+        try {
+            return startCreated(containerId, spec);
+        } catch (Exception e) {
+            // A failed start (e.g. host-port conflict) must not leak the created
+            // container: retrying callers would accumulate Created containers and
+            // fixed-name callers would hit name conflicts on the next attempt.
+            removeIfExists(containerId);
+            throw e;
+        }
     }
 
     public String create(ContainerSpec spec) {
@@ -88,6 +101,9 @@ public class ContainerLifecycleManager {
 
         if (spec.name() != null) {
             createCmd.withName(spec.name());
+        }
+        if (spec.user() != null && !spec.user().isBlank()) {
+            createCmd.withUser(spec.user());
         }
         if (spec.env() != null && !spec.env().isEmpty()) {
             createCmd.withEnv(spec.env());
@@ -107,9 +123,7 @@ public class ContainerLifecycleManager {
                     .toArray(ExposedPort[]::new);
             createCmd.withExposedPorts(exposed);
         }
-        if (spec.labels() != null && !spec.labels().isEmpty()) {
-            createCmd.withLabels(spec.labels());
-        }
+        createCmd.withLabels(mergedLabels(spec.labels()));
 
         CreateContainerResponse response = dockerApi("create container " + spec.name(), createCmd::exec);
         String containerId = response.getId();
@@ -203,18 +217,33 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Creates a named volume if it does not already exist. Idempotent — safe to call on every
+     * container start. Labels the volume {@code floci=true} and
+     * {@code floci_emulator=floci-gcp} so both
+     * {@code docker volume prune --filter label=floci=true} (all emulators) and
+     * {@code --filter label=floci_emulator=floci-gcp} (this emulator only) work.
+     */
     public void ensureVolume(String volumeName) {
         if (!volumeExists(volumeName)) {
             LOG.infov("Creating Docker volume {0}", volumeName);
             dockerApi("create Docker volume " + volumeName, () -> {
                 dockerClient().createVolumeCmd()
                         .withName(volumeName)
-                        .withLabels(Map.of("floci-gcp", "true"))
+                        .withLabels(ContainerStorageHelper.defaultLabels(config))
                         .exec();
                 return null;
             });
             LOG.infov("Created Docker volume {0}", volumeName);
         }
+    }
+
+    private Map<String, String> mergedLabels(Map<String, String> specLabels) {
+        Map<String, String> labels = ContainerStorageHelper.defaultLabels(config);
+        if (specLabels != null) {
+            labels.putAll(specLabels);
+        }
+        return labels;
     }
 
     public void removeVolume(String volumeName) {
@@ -274,11 +303,38 @@ public class ContainerLifecycleManager {
         }
 
         Map<Integer, EndpointInfo> endpoints = new HashMap<>();
+        Map<Integer, Integer> publishedHostPorts = new HashMap<>();
         for (int port : ports) {
             endpoints.put(port, resolveEndpoint(inspect, port));
+            OptionalInt published = readPublishedHostPort(inspect, port);
+            if (published.isPresent()) {
+                publishedHostPorts.put(port, published.getAsInt());
+            }
         }
 
-        return new ContainerInfo(containerId, endpoints);
+        return new ContainerInfo(containerId, endpoints, publishedHostPorts);
+    }
+
+    /**
+     * Reads the host port a container's internal port is published on, independent of
+     * whether floci-gcp itself runs inside a container. Unlike {@link #resolveEndpoint} —
+     * which switches to container-IP + internal port in container mode — this always
+     * reads the port binding, for URIs consumed by the host-side Docker daemon.
+     */
+    private static OptionalInt readPublishedHostPort(InspectContainerResponse inspect, int containerPort) {
+        Ports ports = inspect.getNetworkSettings().getPorts();
+        if (ports != null) {
+            Ports.Binding[] binding = ports.getBindings().get(ExposedPort.tcp(containerPort));
+            if (binding != null && binding.length > 0) {
+                try {
+                    return OptionalInt.of(Integer.parseInt(binding[0].getHostPortSpec()));
+                } catch (NumberFormatException e) {
+                    LOG.debugv("Unparseable host port binding for container port {0}: {1}",
+                            String.valueOf(containerPort), binding[0].getHostPortSpec());
+                }
+            }
+        }
+        return OptionalInt.empty();
     }
 
     public void removeIfExists(String name) {
@@ -361,6 +417,14 @@ public class ContainerLifecycleManager {
 
         if (spec.privileged()) {
             hostConfig.withPrivileged(true);
+        }
+        if (spec.cgroupnsMode() != null && !spec.cgroupnsMode().isBlank()) {
+            hostConfig.withCgroupnsMode(spec.cgroupnsMode());
+        }
+        // Supplementary groups (Docker --group-add), e.g. to give a process access to a
+        // group-shared volume without changing its primary uid/gid.
+        if (spec.groupAdd() != null && !spec.groupAdd().isEmpty()) {
+            hostConfig.withGroupAdd(spec.groupAdd());
         }
         if (spec.hasMemoryLimit()) {
             hostConfig.withMemory(spec.memoryBytes());
@@ -530,12 +594,34 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Information about a created or adopted container.
+     *
+     * @param containerId the Docker container ID
+     * @param endpoints map of container port to resolved endpoint (host:port for connection)
+     * @param publishedHostPorts map of container port to the host port it is published on;
+     *                           a port without a binding is absent
+     */
     public record ContainerInfo(
             String containerId,
-            Map<Integer, EndpointInfo> endpoints
+            Map<Integer, EndpointInfo> endpoints,
+            Map<Integer, Integer> publishedHostPorts
     ) {
+        public ContainerInfo(String containerId, Map<Integer, EndpointInfo> endpoints) {
+            this(containerId, endpoints, Map.of());
+        }
+
         public EndpointInfo getEndpoint(int containerPort) {
             return endpoints.get(containerPort);
+        }
+
+        /**
+         * Gets the host port a container port is published on, regardless of whether
+         * floci-gcp itself runs inside a container. Empty when the port has no binding.
+         */
+        public OptionalInt publishedHostPort(int containerPort) {
+            Integer published = publishedHostPorts.get(containerPort);
+            return published != null ? OptionalInt.of(published) : OptionalInt.empty();
         }
     }
 

--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerSpec.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerSpec.java
@@ -10,6 +10,27 @@ import java.util.Map;
 /**
  * Immutable specification for a Docker container to be created.
  * Use {@link ContainerBuilder} to construct instances of this record.
+ *
+ * @param image Docker image name (required)
+ * @param name Container name (optional, Docker generates one if null)
+ * @param env Environment variables as "KEY=value" strings
+ * @param cmd Command to run (overrides image CMD)
+ * @param entrypoint Entrypoint to use (overrides image ENTRYPOINT)
+ * @param memoryBytes Memory limit in bytes (null = no limit)
+ * @param portBindings Map of container port to host port (0 = dynamic allocation)
+ * @param exposedPorts Ports to expose (required for port bindings)
+ * @param networkMode Docker network name or mode (null = default bridge)
+ * @param mounts Volume mounts (named volumes, bind mounts, tmpfs)
+ * @param binds Legacy bind mounts (prefer mounts for new code)
+ * @param extraHosts Extra /etc/hosts entries as "hostname:ip" strings
+ * @param labels Container labels merged over the default floci-gcp labels
+ * @param logConfig Docker log driver configuration (null = daemon default)
+ * @param privileged Whether to run the container in privileged mode (required for k3s)
+ * @param cgroupnsMode Docker cgroup namespace mode (for example, "host")
+ * @param dnsServers DNS server IPs to inject into the container (e.g. floci-gcp's embedded DNS)
+ * @param workingDir Working directory inside the container (overrides image WORKDIR)
+ * @param user User the container process runs as, formatted "uid[:gid]" (null = image USER)
+ * @param groupAdd Supplementary group IDs added to the container process
  */
 public record ContainerSpec(
         String image,
@@ -27,11 +48,14 @@ public record ContainerSpec(
         Map<String, String> labels,
         LogConfig logConfig,
         boolean privileged,
+        String cgroupnsMode,
         List<String> dnsServers,
-        String workingDir
+        String workingDir,
+        String user,
+        List<String> groupAdd
 ) {
     public ContainerSpec(String image) {
-        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), Map.of(), null, false, List.of(), null);
+        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(), null, null, List.of());
     }
 
     public boolean hasPortBindings() {

--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerStorageHelper.java
@@ -8,11 +8,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Central helper for sidecar container volume management.
+ * Central helper for sidecar container volume management (Kafka/Redpanda, CloudSQL, …).
  *
- * Two modes:
- * - Named-volume (default) — manages per-resource Docker named volumes labelled floci-gcp=true.
- * - Host-path (legacy) — active when storage.host-persistent-path is set to an absolute path.
+ * <p>Two modes:
+ * <ul>
+ *   <li>Named-volume (default) — Floci manages per-resource Docker named volumes labelled
+ *       {@code floci-gcp=true}. Active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH}
+ *       is not set.</li>
+ *   <li>Host-path (legacy) — active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH} is set;
+ *       callers fall through to their existing bind-mount logic.</li>
+ * </ul>
  */
 public final class ContainerStorageHelper {
 
@@ -20,33 +25,103 @@ public final class ContainerStorageHelper {
 
     private ContainerStorageHelper() {}
 
+    /**
+     * Canonical container/volume name for a resource. Uses {@code volumeId} when set;
+     * falls back to {@code fallbackId} (the resource name) for resources created before
+     * this change.
+     */
     public static String resourceName(String service, String volumeId, String fallbackId) {
-        return "floci-gcp-" + service + "-" + (volumeId != null ? volumeId : fallbackId);
+        return resourceName(null, service, volumeId, fallbackId);
     }
 
+    public static String resourceName(EmulatorConfig config, String service, String volumeId, String fallbackId) {
+        return dockerName(config, "floci-gcp-" + service + "-" + (volumeId != null ? volumeId : fallbackId));
+    }
+
+    public static String dockerName(EmulatorConfig config, String baseName) {
+        String namespace = resourceNamespace(config);
+        if (namespace.isBlank()) {
+            return baseName;
+        }
+        if (baseName.startsWith("floci-gcp-")) {
+            return "floci-gcp-" + namespace + "-" + baseName.substring("floci-gcp-".length());
+        }
+        return "floci-gcp-" + namespace + "-" + baseName;
+    }
+
+    public static Path hostResourcePath(EmulatorConfig config, String service, String resourceId) {
+        String namespace = resourceNamespace(config);
+        Path base = Path.of(config.storage().hostPersistentPath());
+        if (namespace.isBlank()) {
+            return base.resolve(service).resolve(resourceId);
+        }
+        return base.resolve(namespace).resolve(service).resolve(resourceId);
+    }
+
+    private static String resourceNamespace(EmulatorConfig config) {
+        if (config == null || config.docker() == null || config.docker().resourceNamespace() == null) {
+            return "";
+        }
+        return sanitizeNamePart(config.docker().resourceNamespace().orElse(""));
+    }
+
+    private static String sanitizeNamePart(String value) {
+        String cleaned = value.trim().replaceAll("[^A-Za-z0-9_.-]+", "-");
+        while (cleaned.startsWith("-")) {
+            cleaned = cleaned.substring(1);
+        }
+        while (cleaned.endsWith("-")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+        if (cleaned.equals(".") || cleaned.equals("..")) {
+            return "";
+        }
+        return cleaned;
+    }
+
+    /**
+     * Returns {@code true} when named-volume mode is active.
+     * Returns {@code false} only when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH} is set to
+     * an absolute path, indicating the caller should use a host bind-mount instead.
+     * Volume names and relative paths are not supported in {@code host-persistent-path} —
+     * they are treated as named-volume mode.
+     */
     public static boolean isNamedVolumeMode(EmulatorConfig config) {
         return !config.storage().hostPersistentPath().startsWith("/");
     }
 
+    /**
+     * Ensures the named volume exists and mounts it to {@code internalMount} in the container.
+     * Must only be called when {@link #isNamedVolumeMode} returns {@code true}.
+     */
     public static void applyStorage(
             ContainerBuilder.Builder builder,
             ContainerLifecycleManager lifecycleManager,
+            EmulatorConfig config,
             String service,
             String volumeId,
             String fallbackId,
             String internalMount) {
-        String volumeName = resourceName(service, volumeId, fallbackId);
+        String volumeName = resourceName(config, service, volumeId, fallbackId);
         lifecycleManager.ensureVolume(volumeName);
         builder.withNamedVolume(volumeName, internalMount);
     }
 
+    /**
+     * Removes the named volume on resource delete, honouring the configured prune policy.
+     *
+     * <ul>
+     *   <li>In {@code memory} storage mode: always removes (data cannot survive a restart anyway).</li>
+     *   <li>In persistent modes: removes only when {@code prune-volumes-on-delete: true}.</li>
+     * </ul>
+     */
     public static void removeStorage(
             EmulatorConfig config,
             ContainerLifecycleManager lifecycleManager,
             String service,
             String volumeId,
             String fallbackId) {
-        String volumeName = resourceName(service, volumeId, fallbackId);
+        String volumeName = resourceName(config, service, volumeId, fallbackId);
         boolean isMemory = "memory".equals(config.storage().mode());
         if (isMemory || config.storage().pruneVolumesOnDelete()) {
             lifecycleManager.removeVolume(volumeName);
@@ -55,6 +130,10 @@ public final class ContainerStorageHelper {
         }
     }
 
+    /**
+     * Ensures the host data directory exists for host-path mode (absolute paths only).
+     * Called by managers in their legacy host-path code paths.
+     */
     public static void ensureHostDir(String hostDataPath) {
         try {
             Files.createDirectories(Path.of(hostDataPath));

--- a/src/main/java/io/floci/gcp/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ContainerStorageHelper.java
@@ -6,49 +6,82 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
- * Central helper for sidecar container volume management (Kafka/Redpanda, CloudSQL, …).
+ * Central helper for Docker resource naming, labelling and sidecar volume management
+ * (Kafka/Redpanda, CloudSQL, …).
  *
- * <p>Two modes:
+ * <p>Naming convention (shared across the Floci emulators): every emulator-created container
+ * and volume is named {@code floci-gcp-[<namespace>-]<service>-<id>} and labelled so it is
+ * attributable to exactly one emulator by name and by label. The prefix is owned here —
+ * call sites pass bare {@code <service>-<id>} tokens, never the prefix.</p>
+ *
+ * <p>Storage modes:</p>
  * <ul>
- *   <li>Named-volume (default) — Floci manages per-resource Docker named volumes labelled
- *       {@code floci-gcp=true}. Active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH}
- *       is not set.</li>
- *   <li>Host-path (legacy) — active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH} is set;
- *       callers fall through to their existing bind-mount logic.</li>
+ *   <li>Named-volume (default) — Floci manages per-resource Docker named volumes.
+ *       Active when {@code FLOCI_GCP_STORAGE_HOST_PERSISTENT_PATH} is not set to an
+ *       absolute path.</li>
+ *   <li>Host-path (legacy) — active when {@code host-persistent-path} is set to an absolute
+ *       path; callers use bind-mounts to the specified directory instead.</li>
  * </ul>
  */
 public final class ContainerStorageHelper {
 
     private static final Logger LOG = Logger.getLogger(ContainerStorageHelper.class);
 
+    static final String CLOUD = "gcp";
+    static final String CONTAINER_PREFIX = "floci-" + CLOUD + "-";
+    static final String LEGACY_PREFIX = "floci-";
+
     private ContainerStorageHelper() {}
 
     /**
      * Canonical container/volume name for a resource. Uses {@code volumeId} when set;
      * falls back to {@code fallbackId} (the resource name) for resources created before
-     * this change.
+     * volume ids were introduced.
      */
-    public static String resourceName(String service, String volumeId, String fallbackId) {
-        return resourceName(null, service, volumeId, fallbackId);
-    }
-
     public static String resourceName(EmulatorConfig config, String service, String volumeId, String fallbackId) {
-        return dockerName(config, "floci-gcp-" + service + "-" + (volumeId != null ? volumeId : fallbackId));
+        return dockerName(config, service + "-" + (volumeId != null ? volumeId : fallbackId));
     }
 
+    /**
+     * Prefixes {@code baseName} with {@code floci-gcp-} and the configured resource namespace.
+     * Accepts already-prefixed names (current or legacy {@code floci-} prefix) and normalises
+     * them, so the namespace always lands between the cloud token and the service token.
+     */
     public static String dockerName(EmulatorConfig config, String baseName) {
+        String base = stripPrefix(baseName);
         String namespace = resourceNamespace(config);
         if (namespace.isBlank()) {
-            return baseName;
+            return CONTAINER_PREFIX + base;
         }
-        if (baseName.startsWith("floci-gcp-")) {
-            return "floci-gcp-" + namespace + "-" + baseName.substring("floci-gcp-".length());
-        }
-        return "floci-gcp-" + namespace + "-" + baseName;
+        return CONTAINER_PREFIX + namespace + "-" + base;
     }
 
+    /**
+     * Labels applied to every emulator-created container and volume:
+     * {@code floci=true} (umbrella across all Floci emulators),
+     * {@code floci_emulator=floci-gcp} (per-emulator discriminator), and
+     * {@code floci_namespace} when a resource namespace is configured.
+     */
+    public static Map<String, String> defaultLabels(EmulatorConfig config) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("floci", "true");
+        labels.put("floci_emulator", "floci-" + CLOUD);
+        String namespace = resourceNamespace(config);
+        if (!namespace.isBlank()) {
+            labels.put("floci_namespace", namespace);
+        }
+        return labels;
+    }
+
+    /**
+     * Host data directory for a resource in host-path mode: the configured
+     * {@code host-persistent-path} plus the resource namespace (when configured),
+     * service token and resource id.
+     */
     public static Path hostResourcePath(EmulatorConfig config, String service, String resourceId) {
         String namespace = resourceNamespace(config);
         Path base = Path.of(config.storage().hostPersistentPath());
@@ -56,6 +89,16 @@ public final class ContainerStorageHelper {
             return base.resolve(service).resolve(resourceId);
         }
         return base.resolve(namespace).resolve(service).resolve(resourceId);
+    }
+
+    private static String stripPrefix(String baseName) {
+        if (baseName.startsWith(CONTAINER_PREFIX)) {
+            return baseName.substring(CONTAINER_PREFIX.length());
+        }
+        if (baseName.startsWith(LEGACY_PREFIX)) {
+            return baseName.substring(LEGACY_PREFIX.length());
+        }
+        return baseName;
     }
 
     private static String resourceNamespace(EmulatorConfig config) {
@@ -93,6 +136,9 @@ public final class ContainerStorageHelper {
     /**
      * Ensures the named volume exists and mounts it to {@code internalMount} in the container.
      * Must only be called when {@link #isNamedVolumeMode} returns {@code true}.
+     *
+     * <p>Prefer the {@code volumeName} overload when the resource has a persisted volume name —
+     * recomputing the name from config would orphan data after a prefix or namespace change.</p>
      */
     public static void applyStorage(
             ContainerBuilder.Builder builder,
@@ -102,7 +148,18 @@ public final class ContainerStorageHelper {
             String volumeId,
             String fallbackId,
             String internalMount) {
-        String volumeName = resourceName(config, service, volumeId, fallbackId);
+        applyStorage(builder, lifecycleManager, resourceName(config, service, volumeId, fallbackId), internalMount);
+    }
+
+    /**
+     * Ensures the named volume exists and mounts it to {@code internalMount} in the container.
+     * Must only be called when {@link #isNamedVolumeMode} returns {@code true}.
+     */
+    public static void applyStorage(
+            ContainerBuilder.Builder builder,
+            ContainerLifecycleManager lifecycleManager,
+            String volumeName,
+            String internalMount) {
         lifecycleManager.ensureVolume(volumeName);
         builder.withNamedVolume(volumeName, internalMount);
     }
@@ -118,10 +175,7 @@ public final class ContainerStorageHelper {
     public static void removeStorage(
             EmulatorConfig config,
             ContainerLifecycleManager lifecycleManager,
-            String service,
-            String volumeId,
-            String fallbackId) {
-        String volumeName = resourceName(config, service, volumeId, fallbackId);
+            String volumeName) {
         boolean isMemory = "memory".equals(config.storage().mode());
         if (isMemory || config.storage().pruneVolumesOnDelete()) {
             lifecycleManager.removeVolume(volumeName);

--- a/src/main/java/io/floci/gcp/core/common/docker/ImageCacheService.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/ImageCacheService.java
@@ -1,26 +1,40 @@
 package io.floci.gcp.core.common.docker;
 
 import com.github.dockerjava.api.command.PullImageResultCallback;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
+import com.github.dockerjava.api.model.AuthConfig;
+import io.floci.gcp.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Ensures each Docker image is pulled only once.
+ * Thread-safe using ConcurrentHashMap for double-checked locking per image.
+ */
 @ApplicationScoped
 public class ImageCacheService {
 
     private static final Logger LOG = Logger.getLogger(ImageCacheService.class);
 
+    static final int MAX_PULL_ATTEMPTS = 3;
+    static final long INITIAL_BACKOFF_MS = 500L;
+
     private final DockerClientProducer dockerClients;
+    private final List<EmulatorConfig.DockerConfig.RegistryCredential> registryCredentials;
     private final Set<String> pulledImages = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String, Object> locks = new ConcurrentHashMap<>();
 
     @Inject
-    public ImageCacheService(DockerClientProducer dockerClients) {
+    public ImageCacheService(DockerClientProducer dockerClients, EmulatorConfig config) {
         this.dockerClients = dockerClients;
+        this.registryCredentials = config.docker().registryCredentials();
     }
 
     public void ensureImageExists(String image) {
@@ -39,9 +53,11 @@ public class ImageCacheService {
             }
             LOG.infov("Pulling image: {0}", image);
             try {
-                dockerClients.client().pullImageCmd(image)
-                        .exec(new PullImageResultCallback())
-                        .awaitCompletion(10, TimeUnit.MINUTES);
+                runWithRetry(image, MAX_PULL_ATTEMPTS, INITIAL_BACKOFF_MS,
+                        () -> dockerClients.client().pullImageCmd(image)
+                                .withAuthConfig(resolveAuth(image))
+                                .exec(new PullImageResultCallback())
+                                .awaitCompletion(10, TimeUnit.MINUTES));
                 pulledImages.add(image);
                 LOG.infov("Image pulled successfully: {0}", image);
             } catch (InterruptedException e) {
@@ -49,6 +65,56 @@ public class ImageCacheService {
                 throw new RuntimeException("Interrupted while pulling image: " + image, e);
             }
         }
+    }
+
+    /**
+     * Runs the given pull attempt, retrying on transient registry failures with exponential
+     * backoff. A failure is considered transient when either:
+     * <ul>
+     *   <li>the docker daemon throws {@link InternalServerErrorException} directly (HTTP 500,
+     *       e.g. a registry's {@code "toomanyrequests: Rate exceeded"}), or</li>
+     *   <li>{@link PullImageResultCallback#awaitCompletion} rewraps a daemon error as
+     *       {@link DockerClientException} with a message starting with
+     *       {@code "Could not pull image: "} (the async-callback path; same root cause, just
+     *       a different exception class).</li>
+     * </ul>
+     * Permanent failures (auth, missing image, malformed request, or any other
+     * {@code DockerClientException} not coming from the pull wrapper) keep surfacing their
+     * original docker-java exception subclass on the first attempt and are not retried.
+     */
+    static void runWithRetry(String image, int maxAttempts, long initialBackoffMs,
+                             PullAttempt attempt) throws InterruptedException {
+        long backoffMs = initialBackoffMs;
+        for (int i = 1; i <= maxAttempts; i++) {
+            try {
+                attempt.run();
+                return;
+            } catch (RuntimeException e) {
+                if (!isTransientPullFailure(e) || i == maxAttempts) {
+                    throw e;
+                }
+                LOG.warnv(e, "Transient image pull failure for {0} (attempt {1}/{2}). "
+                        + "Retrying in {3}ms.", image, i, maxAttempts, backoffMs);
+                Thread.sleep(backoffMs);
+                backoffMs *= 2;
+            }
+        }
+    }
+
+    private static boolean isTransientPullFailure(RuntimeException e) {
+        if (e instanceof InternalServerErrorException) {
+            return true;
+        }
+        if (e instanceof DockerClientException && e.getMessage() != null
+                && e.getMessage().startsWith("Could not pull image: ")) {
+            return true;
+        }
+        return false;
+    }
+
+    @FunctionalInterface
+    interface PullAttempt {
+        void run() throws InterruptedException;
     }
 
     private boolean isLocalImagePresent(String image) {
@@ -61,5 +127,24 @@ public class ImageCacheService {
             LOG.debugv("Could not check local image presence for {0}: {1}", image, e.getMessage());
             return false;
         }
+    }
+
+    private AuthConfig resolveAuth(String image) {
+        String host = extractRegistryHost(image);
+        for (EmulatorConfig.DockerConfig.RegistryCredential cred : registryCredentials) {
+            if (cred.server().equals(host)) {
+                LOG.debugv("Using configured credentials for registry: {0}", host);
+                return new AuthConfig()
+                        .withUsername(cred.username())
+                        .withPassword(cred.password())
+                        .withRegistryAddress(cred.server());
+            }
+        }
+        return new AuthConfig();
+    }
+
+    static String extractRegistryHost(String image) {
+        String firstSegment = image.split("/")[0];
+        return (firstSegment.contains(".") || firstSegment.contains(":")) ? firstSegment : "";
     }
 }

--- a/src/main/java/io/floci/gcp/core/common/docker/PortAllocator.java
+++ b/src/main/java/io/floci/gcp/core/common/docker/PortAllocator.java
@@ -19,16 +19,26 @@ public class PortAllocator {
         for (int port = basePort; port <= maxPort; port++) {
             if (!reserved.contains(port) && isPortFree(port)) {
                 reserved.add(port);
-                LOG.debugv("Allocated port {0} from range {1}-{2}", port, basePort, maxPort);
+                LOG.debugv("Allocated port {0} from range {1}-{2}",
+                        String.valueOf(port), String.valueOf(basePort), String.valueOf(maxPort));
                 return port;
             }
         }
         throw new RuntimeException("No free port available in range " + basePort + "-" + maxPort);
     }
 
+    /**
+     * Marks a port as reserved without probing whether it is free. Used on restart to
+     * re-reserve host ports already held by surviving containers so the allocator does
+     * not hand them out again.
+     */
+    public synchronized void markReserved(int port) {
+        reserved.add(port);
+    }
+
     public void release(int port) {
         if (reserved.remove(port)) {
-            LOG.debugv("Released port {0}", port);
+            LOG.debugv("Released port {0}", String.valueOf(port));
         }
     }
 
@@ -36,7 +46,7 @@ public class PortAllocator {
         try (ServerSocket socket = new ServerSocket(0)) {
             socket.setReuseAddress(true);
             int port = socket.getLocalPort();
-            LOG.debugv("Allocated ephemeral port {0}", port);
+            LOG.debugv("Allocated ephemeral port {0}", String.valueOf(port));
             return port;
         } catch (IOException e) {
             throw new RuntimeException("Could not find a free port", e);

--- a/src/main/java/io/floci/gcp/core/storage/HybridStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/HybridStorage.java
@@ -24,6 +24,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * Hybrid storage: in-memory reads with async flush to disk.
+ * Writes go to memory immediately, then flushed to disk periodically.
+ */
 public class HybridStorage<K, V> implements StorageBackend<K, V> {
 
     private static final Logger LOG = Logger.getLogger(HybridStorage.class);
@@ -89,6 +93,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public void load() {
         if (!Files.exists(filePath)) {
+            LOG.debugv("No persistent file found at {0}, starting with empty store", filePath);
             return;
         }
         try {
@@ -132,6 +137,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
             Path tempFile = filePath.resolveSibling(filePath.getFileName() + ".tmp");
             objectMapper.writeValue(tempFile.toFile(), store);
             Files.move(tempFile, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            LOG.debugv("Flushed {0} entries to {1}", store.size(), filePath);
         } catch (IOException e) {
             LOG.errorv(e, "Failed to persist data to {0}", filePath);
             dirty.set(true);

--- a/src/main/java/io/floci/gcp/core/storage/InMemoryStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/InMemoryStorage.java
@@ -8,6 +8,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
+/**
+ * Thread-safe in-memory storage backed by ConcurrentHashMap.
+ * No persistence — data is lost on shutdown unless explicitly flushed.
+ */
 public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
 
     private final ConcurrentHashMap<K, V> store = new ConcurrentHashMap<>();
@@ -44,10 +48,14 @@ public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void flush() {}
+    public void flush() {
+        // No-op for in-memory storage
+    }
 
     @Override
-    public void load() {}
+    public void load() {
+        // No-op for in-memory storage
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/io/floci/gcp/core/storage/PersistentPathValidator.java
+++ b/src/main/java/io/floci/gcp/core/storage/PersistentPathValidator.java
@@ -1,0 +1,58 @@
+package io.floci.gcp.core.storage;
+
+import io.floci.gcp.config.EmulatorConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Validates at boot that the persistent storage path is usable whenever the emulator runs
+ * with a non-memory storage mode. Without this check the failure surfaces lazily and
+ * confusingly: services silently lose data at flush time instead of failing fast at startup.
+ */
+@ApplicationScoped
+public class PersistentPathValidator {
+
+    private final EmulatorConfig config;
+
+    @Inject
+    public PersistentPathValidator(EmulatorConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * @throws IllegalStateException when persistence is enabled but the path is unusable
+     */
+    public void validateAtBoot() {
+        String mode = config.storage().mode();
+        if ("memory".equals(mode)) {
+            return;
+        }
+
+        Path root = Path.of(config.storage().persistentPath());
+        try {
+            probeWritable(root);
+        } catch (IOException | SecurityException e) {
+            throw new IllegalStateException(
+                    "Persistent storage path '" + root.toAbsolutePath()
+                            + "' is not writable, but non-memory storage is enabled (mode=" + mode
+                            + "). Fix the volume mount permissions (it may be read-only or root-owned),"
+                            + " or point FLOCI_GCP_STORAGE_PERSISTENT_PATH at a writable directory.", e);
+        }
+    }
+
+    static void probeWritable(Path dir) throws IOException {
+        Files.createDirectories(dir);
+        Path probe = Files.createTempFile(dir, ".floci-gcp-write-probe", null);
+        try {
+            Files.deleteIfExists(probe);
+        } catch (IOException e) {
+            // The write itself succeeded, so the path is writable; a failed cleanup
+            // must not abort boot as a false "not writable".
+            probe.toFile().deleteOnExit();
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/core/storage/PersistentStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/PersistentStorage.java
@@ -20,6 +20,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * JSON file-backed persistent storage.
+ * Loads all data into memory on startup for fast reads.
+ * Write-through on every put/delete.
+ * Uses atomic writes (temp file + rename) for safety.
+ */
 public class PersistentStorage<K, V> implements StorageBackend<K, V> {
 
     private static final Logger LOG = Logger.getLogger(PersistentStorage.class);
@@ -76,6 +82,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public void load() {
         if (!Files.exists(filePath)) {
+            LOG.debugv("No persistent file found at {0}, starting with empty store", filePath);
             return;
         }
         try {
@@ -84,7 +91,25 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
             store.putAll(data);
             LOG.infov("Loaded {0} entries from {1}", store.size(), filePath);
         } catch (IOException e) {
-            LOG.errorv(e, "Failed to load data from {0}", filePath);
+            // Starting empty here silently drops all persisted state for this store, which can leave
+            // other services referencing resources that now appear missing. Quarantine the
+            // unreadable file and log loudly so the data loss is detectable rather than
+            // masquerading as an empty store.
+            quarantineUnreadableFile(e);
+        }
+    }
+
+    private void quarantineUnreadableFile(IOException cause) {
+        Path quarantine = filePath.resolveSibling(filePath.getFileName() + ".corrupt");
+        try {
+            Files.move(filePath, quarantine, StandardCopyOption.REPLACE_EXISTING);
+            LOG.errorv(cause, "Failed to load persisted data from {0}; moved the unreadable file to "
+                    + "{1} and started with an empty store. This store's state was lost.",
+                    filePath, quarantine);
+        } catch (IOException moveError) {
+            LOG.errorv(cause, "Failed to load persisted data from {0}; could not quarantine it ({1}). "
+                    + "Starting with an empty store. This store's state was lost.",
+                    filePath, moveError.getMessage());
         }
     }
 

--- a/src/main/java/io/floci/gcp/core/storage/StorageBackend.java
+++ b/src/main/java/io/floci/gcp/core/storage/StorageBackend.java
@@ -5,6 +5,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
+/**
+ * Generic storage abstraction for GCP emulator services.
+ *
+ * @param <K> the key type
+ * @param <V> the value type
+ */
 public interface StorageBackend<K, V> {
 
     void put(K key, V value);
@@ -13,13 +19,21 @@ public interface StorageBackend<K, V> {
 
     void delete(K key);
 
+    /**
+     * Return a new mutable list of values whose keys pass the filter. Callers may sort,
+     * filter, or otherwise mutate the returned list without affecting the underlying store.
+     */
     List<V> scan(Predicate<K> keyFilter);
 
+    /** Return all keys in this store. */
     Set<K> keys();
 
+    /** Persist data to disk if applicable. */
     void flush();
 
+    /** Load data from disk on startup. */
     void load();
 
+    /** Clear all data. */
     void clear();
 }

--- a/src/main/java/io/floci/gcp/core/storage/StorageFactory.java
+++ b/src/main/java/io/floci/gcp/core/storage/StorageFactory.java
@@ -10,13 +10,16 @@ import org.jboss.logging.Logger;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Creates {@link ProjectAwareStorageBackend} instances based on configuration.
- * Every backend is wrapped in a project-aware decorator so resources are automatically
- * namespaced by the calling GCP project ID.
+ * Factory that creates {@link ProjectAwareStorageBackend} instances based on configuration.
+ * Every backend created via {@link #create} is wrapped in a project-aware decorator so
+ * resources are automatically namespaced by the calling GCP project ID; globally
+ * namespaced services (e.g. GCS buckets) use {@link #createGlobal} instead.
+ * Tracks all created backends for lifecycle management.
  */
 @ApplicationScoped
 public class StorageFactory {
@@ -25,6 +28,10 @@ public class StorageFactory {
 
     private final EmulatorConfig config;
     private final List<StorageBackend<?, ?>> allBackends = new ArrayList<>();
+    // A file path identifies one logical store: callers sharing a path are expected to agree on
+    // its value type, storage mode, and scoping (global vs project-aware). The first create wins;
+    // repeat calls reuse that backend.
+    private final Map<Path, StorageBackend<?, ?>> backendsByPath = new HashMap<>();
     private final List<HybridStorage<?, ?>> hybridBackends = new ArrayList<>();
     private final List<WalStorage<?, ?>> walBackends = new ArrayList<>();
 
@@ -37,103 +44,133 @@ public class StorageFactory {
     }
 
     /**
-     * Creates a global (non-project-scoped) backend for services whose resources are
+     * Create a global (non-project-scoped) backend for services whose resources are
      * globally namespaced (e.g. GCS, where bucket names are globally unique).
+     *
+     * @param serviceName   the service name (gcs, pubsub, iam, …)
+     * @param fileName      the JSON file name for persistent storage
+     * @param typeReference Jackson type reference for deserialization
      */
-    public <V> StorageBackend<String, V> createGlobal(String serviceName, String fileName,
+    public synchronized <V> StorageBackend<String, V> createGlobal(String serviceName, String fileName,
                                                        TypeReference<Map<String, V>> typeReference) {
-        return createGlobal(serviceName, fileName, typeReference, config.storage().mode());
-    }
+        String mode = config.storage().mode();
+        Path filePath = Path.of(config.storage().persistentPath()).resolve(fileName);
 
-    public <V> StorageBackend<String, V> createGlobal(String serviceName, String fileName,
-                                                       TypeReference<Map<String, V>> typeReference,
-                                                       String modeOverride) {
-        String mode = modeOverride != null ? modeOverride : config.storage().mode();
-        Path basePath = Path.of(config.storage().persistentPath());
-        Path filePath = basePath.resolve(fileName);
+        StorageBackend<String, V> existing = findExisting(mode, serviceName, filePath);
+        if (existing != null) {
+            return existing;
+        }
 
-        LOG.debugv("Creating {0} global storage for service {1}", mode, serviceName);
+        LOG.debugv("Creating {0} global storage for service {1} (file: {2})", mode, serviceName, filePath);
 
-        StorageBackend<String, V> inner = switch (mode) {
-            case "memory" -> new InMemoryStorage<>();
-            case "persistent" -> new PersistentStorage<>(filePath, typeReference);
-            case "hybrid" -> {
-                var hybrid = new HybridStorage<>(filePath, typeReference, 5000L);
-                hybridBackends.add(hybrid);
-                yield hybrid;
-            }
-            case "wal" -> {
-                Path snapshotPath = basePath.resolve(fileName.replace(".json", "-snapshot.json"));
-                Path walFilePath = basePath.resolve(fileName.replace(".json", ".wal"));
-                long compactionInterval = config.storage().wal().compactionIntervalMs();
-                var wal = new WalStorage<>(snapshotPath, walFilePath, typeReference, compactionInterval);
-                walBackends.add(wal);
-                yield wal;
-            }
-            default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
-        };
-
+        StorageBackend<String, V> inner = createInner(mode, fileName, filePath, typeReference);
         inner.load();
         allBackends.add(inner);
+        backendsByPath.put(filePath, inner);
         return inner;
     }
 
-    public <V> ProjectAwareStorageBackend<V> create(String serviceName, String fileName,
+    /**
+     * Create a project-aware storage backend for the given service.
+     * All keys are automatically prefixed with the current project ID derived from
+     * the request context. Async workers should use the {@code *ForProject} overloads
+     * on {@link ProjectAwareStorageBackend} with the project ID stored on the resource model.
+     *
+     * @param serviceName   the service name (cloudsql, bigquery, monitoring, …)
+     * @param fileName      the JSON file name for persistent storage
+     * @param typeReference Jackson type reference for deserialization
+     */
+    public synchronized <V> StorageBackend<String, V> create(String serviceName, String fileName,
                                                      TypeReference<Map<String, V>> typeReference) {
-        return create(serviceName, fileName, typeReference, config.storage().mode());
-    }
+        String mode = config.storage().mode();
+        Path filePath = Path.of(config.storage().persistentPath()).resolve(fileName);
 
-    public <V> ProjectAwareStorageBackend<V> create(String serviceName, String fileName,
-                                                     TypeReference<Map<String, V>> typeReference,
-                                                     String modeOverride) {
-        String mode = modeOverride != null ? modeOverride : config.storage().mode();
-        Path basePath = Path.of(config.storage().persistentPath());
-        Path filePath = basePath.resolve(fileName);
+        StorageBackend<String, V> existing = findExisting(mode, serviceName, filePath);
+        if (existing != null) {
+            return existing;
+        }
 
-        LOG.debugv("Creating {0} storage for service {1}", mode, serviceName);
+        LOG.debugv("Creating {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
 
-        StorageBackend<String, V> inner = switch (mode) {
-            case "memory" -> new InMemoryStorage<>();
-            case "persistent" -> new PersistentStorage<>(filePath, typeReference);
-            case "hybrid" -> {
-                var hybrid = new HybridStorage<>(filePath, typeReference, 5000L);
-                hybridBackends.add(hybrid);
-                yield hybrid;
-            }
-            case "wal" -> {
-                Path snapshotPath = basePath.resolve(fileName.replace(".json", "-snapshot.json"));
-                Path walFilePath = basePath.resolve(fileName.replace(".json", ".wal"));
-                long compactionInterval = config.storage().wal().compactionIntervalMs();
-                var wal = new WalStorage<>(snapshotPath, walFilePath, typeReference, compactionInterval);
-                walBackends.add(wal);
-                yield wal;
-            }
-            default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
-        };
-
+        StorageBackend<String, V> inner = createInner(mode, fileName, filePath, typeReference);
         inner.load();
 
         ProjectAwareStorageBackend<V> backend = new ProjectAwareStorageBackend<>(
                 inner, requestContextInstance, config.defaultProjectId());
         allBackends.add(backend);
+        backendsByPath.put(filePath, backend);
         return backend;
     }
 
-    public void loadAll() {
+    /**
+     * Reuse an existing backend bound to the same file. Handing out a second backend bound to
+     * the same path creates a duplicate in-memory store; on shutdown the stale duplicate flushes
+     * after the active instance and clobbers persisted state.
+     */
+    private <V> StorageBackend<String, V> findExisting(String mode, String serviceName, Path filePath) {
+        StorageBackend<?, ?> existing = backendsByPath.get(filePath);
+        if (existing == null) {
+            return null;
+        }
+        LOG.debugv("Reusing existing {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
+        @SuppressWarnings("unchecked")
+        StorageBackend<String, V> typed = (StorageBackend<String, V>) existing;
+        return typed;
+    }
+
+    private <V> StorageBackend<String, V> createInner(String mode, String fileName, Path filePath,
+                                                      TypeReference<Map<String, V>> typeReference) {
+        Path basePath = Path.of(config.storage().persistentPath());
+        return switch (mode) {
+            case "memory" -> new InMemoryStorage<>();
+            case "persistent" -> new PersistentStorage<>(filePath, typeReference);
+            case "hybrid" -> {
+                var hybrid = new HybridStorage<>(filePath, typeReference, 5000L);
+                hybridBackends.add(hybrid);
+                yield hybrid;
+            }
+            case "wal" -> {
+                Path snapshotPath = basePath.resolve(fileName.replace(".json", "-snapshot.json"));
+                Path walFilePath = basePath.resolve(fileName.replace(".json", ".wal"));
+                long compactionInterval = config.storage().wal().compactionIntervalMs();
+                var wal = new WalStorage<>(snapshotPath, walFilePath, typeReference, compactionInterval);
+                walBackends.add(wal);
+                yield wal;
+            }
+            default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
+        };
+    }
+
+    /** Load all storage backends from disk. */
+    public synchronized void loadAll() {
         for (StorageBackend<?, ?> backend : allBackends) {
             backend.load();
         }
     }
 
-    public void shutdownAll() {
+    /** Flush all storage backends to disk. */
+    public synchronized void flushAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.flush();
+        }
+    }
+
+    /** Clear all storage backends. */
+    public synchronized void clearAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.clear();
+        }
+        flushAll();
+    }
+
+    /** Shutdown all managed backends (stop schedulers, close connections). */
+    public synchronized void shutdownAll() {
         for (HybridStorage<?, ?> hybrid : hybridBackends) {
             hybrid.shutdown();
         }
         for (WalStorage<?, ?> wal : walBackends) {
             wal.shutdown();
         }
-        for (StorageBackend<?, ?> backend : allBackends) {
-            backend.flush();
-        }
+        flushAll();
     }
 }

--- a/src/main/java/io/floci/gcp/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/gcp/core/storage/WalStorage.java
@@ -25,12 +25,14 @@ import java.util.stream.Collectors;
 /**
  * Write-Ahead Log storage: in-memory reads with append-only binary WAL for durability.
  * Periodic compaction writes a full snapshot and truncates the WAL.
+ * On startup: load snapshot, then replay WAL entries after snapshot.
  *
  * Binary WAL entry format:
  *   PUT:    [0x01] [4-byte key length] [key bytes] [4-byte value length] [value bytes]
  *   DELETE: [0x02] [4-byte key length] [key bytes]
  *
- * Key/value bytes are CBOR-serialized (compact binary). Snapshots use indented JSON.
+ * Key and value bytes are serialized via Jackson CBOR (compact binary format).
+ * Snapshot files use indented JSON for debuggability.
  */
 public class WalStorage<K, V> implements StorageBackend<K, V> {
 
@@ -114,7 +116,9 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void flush() { compact(); }
+    public void flush() {
+        compact();
+    }
 
     @Override
     public void load() {
@@ -128,10 +132,12 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                 LOG.errorv(e, "Failed to load snapshot from {0}", snapshotPath);
             }
         }
+
         if (Files.exists(walPath)) {
             int replayed = replayWal();
             LOG.infov("Replayed {0} WAL entries from {1}", replayed, walPath);
         }
+
         openWalWriter();
     }
 
@@ -175,9 +181,12 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
             snapshotMapper.writeValue(tempFile.toFile(), store);
             Files.move(tempFile, snapshotPath, StandardCopyOption.REPLACE_EXISTING,
                     StandardCopyOption.ATOMIC_MOVE);
+
             closeWalWriter();
             Files.deleteIfExists(walPath);
             openWalWriter();
+
+            LOG.debugv("Compacted {0} entries to snapshot, WAL truncated", store.size());
         } catch (IOException e) {
             LOG.errorv(e, "Failed to compact WAL storage");
         } finally {
@@ -232,14 +241,16 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                 } catch (EOFException e) {
                     break;
                 }
+
                 int keyLen = in.readInt();
                 byte[] keyBytes = in.readNBytes(keyLen);
-                if (keyBytes.length < keyLen) break;
+                if (keyBytes.length < keyLen) break; // truncated entry
 
                 if (op == OP_PUT) {
                     int valueLen = in.readInt();
                     byte[] valueBytes = in.readNBytes(valueLen);
-                    if (valueBytes.length < valueLen) break;
+                    if (valueBytes.length < valueLen) break; // truncated entry
+
                     K key = (K) walMapper.readValue(keyBytes, Object.class);
                     V value = walMapper.readValue(valueBytes,
                             walMapper.constructType(typeReference.getType()).getContentType());
@@ -255,7 +266,8 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                 }
             }
         } catch (IOException e) {
-            LOG.errorv(e, "Failed to replay WAL from {0} (replayed {1} entries)", walPath, replayed);
+            LOG.errorv(e, "Failed to replay WAL from {0} (replayed {1} entries before error)",
+                    walPath, replayed);
         }
         return replayed;
     }
@@ -263,8 +275,8 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     private void openWalWriter() {
         try {
             Files.createDirectories(walPath.getParent());
-            walWriter = new DataOutputStream(new BufferedOutputStream(
-                    Files.newOutputStream(walPath,
+            walWriter = new DataOutputStream(
+                    new BufferedOutputStream(Files.newOutputStream(walPath,
                             java.nio.file.StandardOpenOption.CREATE,
                             java.nio.file.StandardOpenOption.APPEND)));
         } catch (IOException e) {

--- a/src/main/java/io/floci/gcp/lifecycle/EmulatorInfoController.java
+++ b/src/main/java/io/floci/gcp/lifecycle/EmulatorInfoController.java
@@ -1,33 +1,48 @@
 package io.floci.gcp.lifecycle;
 
 import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.Resettable;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.lifecycle.inithook.InitializationHook;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Path("/_floci-gcp")
 @Produces(MediaType.APPLICATION_JSON)
 public class EmulatorInfoController {
 
+    private static final Logger LOG = Logger.getLogger(EmulatorInfoController.class);
+
     private final ServiceRegistry serviceRegistry;
     private final InitLifecycleState initLifecycleState;
     private final EmulatorConfig config;
+    private final StorageFactory storageFactory;
+    private final Instance<Resettable> resettables;
 
     @Inject
     public EmulatorInfoController(ServiceRegistry serviceRegistry,
                                   InitLifecycleState initLifecycleState,
-                                  EmulatorConfig config) {
+                                  EmulatorConfig config,
+                                  StorageFactory storageFactory,
+                                  Instance<Resettable> resettables) {
         this.serviceRegistry = serviceRegistry;
         this.initLifecycleState = initLifecycleState;
         this.config = config;
+        this.storageFactory = storageFactory;
+        this.resettables = resettables;
     }
 
     @GET
@@ -68,4 +83,26 @@ public class EmulatorInfoController {
         body.put("scripts", scripts);
         return Response.ok(body).build();
     }
+
+    @POST
+    @Path("/state/reset")
+    public Response reset() {
+        performReset();
+        return Response.ok(Map.of("status", "OK")).build();
+    }
+
+    @POST
+    @Path("/state/nuke")
+    public Response nuke() {
+        return reset();
+    }
+
+    private void performReset() {
+        for (Resettable r : resettables) {
+            r.clear();
+        }
+        storageFactory.clearAll();
+    }
+
+    /** Deletes everything under the persistent data root, keeping the root directory itself. */
 }

--- a/src/main/java/io/floci/gcp/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/floci/gcp/lifecycle/EmulatorLifecycle.java
@@ -1,7 +1,9 @@
 package io.floci.gcp.lifecycle;
 
 import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.ContainerTeardown;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.storage.PersistentPathValidator;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.lifecycle.inithook.InitializationHook;
 import io.floci.gcp.lifecycle.inithook.InitializationHooksRunner;
@@ -13,6 +15,7 @@ import io.quarkus.vertx.http.HttpServerStart;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -33,16 +36,22 @@ public class EmulatorLifecycle {
     private final EmulatorConfig config;
     private final InitializationHooksRunner hooksRunner;
     private final InitLifecycleState initLifecycleState;
+    private final PersistentPathValidator persistentPathValidator;
+    private final Instance<ContainerTeardown> containerTeardowns;
 
     @Inject
     public EmulatorLifecycle(StorageFactory storageFactory, ServiceRegistry serviceRegistry,
                              EmulatorConfig config, InitializationHooksRunner hooksRunner,
-                             InitLifecycleState initLifecycleState) {
+                             InitLifecycleState initLifecycleState,
+                             PersistentPathValidator persistentPathValidator,
+                             Instance<ContainerTeardown> containerTeardowns) {
         this.storageFactory = storageFactory;
         this.serviceRegistry = serviceRegistry;
         this.config = config;
         this.hooksRunner = hooksRunner;
         this.initLifecycleState = initLifecycleState;
+        this.persistentPathValidator = persistentPathValidator;
+        this.containerTeardowns = containerTeardowns;
     }
 
     void onStart(@Observes StartupEvent ignored) {
@@ -60,6 +69,8 @@ public class EmulatorLifecycle {
             throw new IllegalStateException("Boot hook failed", e);
         }
         initLifecycleState.markBootCompleted();
+
+        persistentPathValidator.validateAtBoot();
 
         storageFactory.loadAll();
 
@@ -116,6 +127,23 @@ public class EmulatorLifecycle {
     }
 
     void onStop(@Observes ShutdownEvent ignored) {
+        // Flush persisted state to disk FIRST, before any slow container teardown below.
+        // Stopping Docker sidecars can block long enough to exhaust the SIGTERM grace window
+        // and trigger SIGKILL; if the flush ran last it would be skipped and in-memory (hybrid)
+        // data would be lost on an otherwise-graceful shutdown. shutdownAll() still runs at the
+        // end to stop the flush schedulers and capture any shutdown-time writes.
+        storageFactory.flushAll();
+        // Centralized teardown for process-bound containers (Cloud Run instances, Cloud
+        // Functions workers, in-flight build/job containers). Runs before shutdownAll() so any
+        // state written while stopping is captured by the final flush.
+        for (ContainerTeardown teardown : containerTeardowns) {
+            try {
+                teardown.stopManagedContainers();
+            } catch (Exception e) {
+                LOG.warnv("Container teardown failed for {0}: {1}",
+                        teardown.getClass().getSimpleName(), e.getMessage());
+            }
+        }
         storageFactory.shutdownAll();
         LOG.info("=== floci-gcp Stopped ===");
     }

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeService.java
@@ -10,6 +10,7 @@ import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.docker.ContainerBuilder;
 import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
 import io.floci.gcp.core.common.docker.ContainerSpec;
+import io.floci.gcp.core.common.docker.ContainerStorageHelper;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.services.cloudrun.model.CloudRunRuntimeInstance;
@@ -232,12 +233,10 @@ public class CloudRunRuntimeService {
                 .withHostDockerInternalOnLinux()
                 .withLogRotation()
                 .withLabels(Map.of(
-                        "floci-gcp", "true",
-                        "floci-gcp.service", "cloudrun",
-                        "floci-gcp.project", project,
-                        "floci-gcp.location", location,
-                        "floci-gcp.cloudrun.service", service.getName(),
-                        "floci-gcp.cloudrun.revision", revision.getName()));
+                        "floci_service", "cloudrun",
+                        "floci_project", project,
+                        "floci_location", location,
+                        "floci_resource", revision.getName()));
 
         builder.withEnv(env.entrySet().stream()
                 .map(e -> e.getKey() + "=" + e.getValue())
@@ -397,8 +396,9 @@ public class CloudRunRuntimeService {
 
     private MaterializedGcsVolume materializeGcsVolume(String bucket, String objectPrefix, boolean readOnly,
                                                        String revisionName, String volumeName) {
-        String dockerVolumeName = "floci-gcp-cloudrun-gcs-" + sanitize(lastSegment(revisionName))
-                + "-" + sanitize(volumeName) + "-" + UUID.randomUUID();
+        String dockerVolumeName = ContainerStorageHelper.dockerName(config,
+                "cloudrun-gcs-" + sanitize(lastSegment(revisionName))
+                        + "-" + sanitize(volumeName) + "-" + UUID.randomUUID());
         try {
             gcsService.getBucket(bucket);
             lifecycleManager.ensureVolume(dockerVolumeName);
@@ -570,7 +570,7 @@ public class CloudRunRuntimeService {
     }
 
     private void withGcsVolumeHelper(String volumeName, VolumeHelperAction action) {
-        String helperName = "floci-cloudrun-gcs-volume-" + UUID.randomUUID();
+        String helperName = ContainerStorageHelper.dockerName(config, "cloudrun-gcs-volume-" + UUID.randomUUID());
         String helperId = null;
         try {
             ContainerSpec helper = containerBuilder.newContainer(GCS_VOLUME_HELPER_IMAGE)
@@ -874,13 +874,12 @@ public class CloudRunRuntimeService {
     }
 
     private String containerName(String serviceName, Revision revision) {
-        String name = config.services().cloudrun().execution().containerNamePrefix()
-                + "-" + sanitize(lastSegment(serviceName))
+        String name = "cloudrun-" + sanitize(lastSegment(serviceName))
                 + "-" + sanitize(lastSegment(revision.getName()));
-        if (revision.getUid().isBlank()) {
-            return name;
+        if (!revision.getUid().isBlank()) {
+            name = name + "-" + sanitize(revision.getUid());
         }
-        return name + "-" + sanitize(revision.getUid());
+        return ContainerStorageHelper.dockerName(config, name);
     }
 
     private static String sanitize(String value) {

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
@@ -32,6 +32,13 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
     private static final String POSTGRES_DATA_PARENT_LEGACY = "/var/lib/postgresql/data";
     private static final SecureRandom RANDOM = new SecureRandom();
 
+    /**
+     * Volume-name prefix used before names were persisted. Pinned for backfill only —
+     * pre-upgrade volumes must keep resolving to this exact prefix regardless of what the
+     * live naming helper produces.
+     */
+    private static final String LEGACY_VOLUME_PREFIX = "floci-gcp-cloudsql-";
+
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
     private final ContainerDetector containerDetector;
@@ -56,6 +63,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
         String volumeId = volumeId(updated, project, instance);
         String containerName = containerName(project, instance);
         String fallbackId = fallbackId(project, instance);
+        String volumeName = resolveVolumeName(updated, volumeId, fallbackId, newVolume);
 
         LOG.infov("Starting Cloud SQL PostgreSQL instance {0}:{1} using image {2}", project, instance, image);
         lifecycleManager.removeIfExists(containerName);
@@ -76,8 +84,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
 
         String internalMountPath = getInternalMountPath(stringValue(updated.get("databaseVersion")));
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
-                    "cloudsql", volumeId, fallbackId, internalMountPath);
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, volumeName, internalMountPath);
         } else {
             String hostDataPath = Path.of(config.storage().hostPersistentPath(), "cloudsql",
                     sanitize(project), sanitize(instance)).toAbsolutePath().toString();
@@ -92,14 +99,14 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
             ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
             EndpointInfo endpoint = info.getEndpoint(POSTGRES_PORT);
             awaitReady(info.containerId(), Duration.ofSeconds(config.services().cloudsql().startupTimeoutSeconds()));
-            applyEndpoint(updated, image, volumeId, info.containerId(), endpoint);
+            applyEndpoint(updated, image, volumeId, volumeName, info.containerId(), endpoint);
             return updated;
         } catch (RuntimeException e) {
             if (containerId != null) {
                 lifecycleManager.stopAndRemove(containerId, null);
             }
             if (newVolume && ContainerStorageHelper.isNamedVolumeMode(config)) {
-                lifecycleManager.removeVolume(ContainerStorageHelper.resourceName(config, "cloudsql", volumeId, fallbackId));
+                lifecycleManager.removeVolume(volumeName);
             }
             throw e;
         }
@@ -112,8 +119,10 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
         if (containerId != null && lifecycleManager.isContainerRunning(containerId)) {
             EndpointInfo endpoint = lifecycleManager.resolveEndpoint(containerId, POSTGRES_PORT);
             Map<String, Object> updated = copy(metadata);
-            applyEndpoint(updated, stringValue(dataPlane.get("image")),
-                    volumeId(updated, project, instance), containerId, endpoint);
+            String volumeId = volumeId(updated, project, instance);
+            applyEndpoint(updated, stringValue(dataPlane.get("image")), volumeId,
+                    resolveVolumeName(updated, volumeId, fallbackId(project, instance), false),
+                    containerId, endpoint);
             return updated;
         }
         return startInstance(project, instance, metadata);
@@ -130,7 +139,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
         if (removeStorage) {
             String volumeId = stringValue(dataPlane(metadata).get("volumeId"));
             ContainerStorageHelper.removeStorage(config, lifecycleManager,
-                    "cloudsql", volumeId, fallbackId(project, instance));
+                    resolveVolumeName(metadata, volumeId, fallbackId(project, instance), false));
         }
     }
 
@@ -259,7 +268,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
     }
 
     private void applyEndpoint(Map<String, Object> metadata, String image, String volumeId,
-                               String containerId, EndpointInfo endpoint) {
+                               String volumeName, String containerId, EndpointInfo endpoint) {
         metadata.put("ipAddresses", List.of(mapOf(
                 "type", "PRIMARY",
                 "ipAddress", endpoint.host(),
@@ -271,6 +280,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
                 "host", endpoint.host(),
                 "port", endpoint.port(),
                 "volumeId", volumeId,
+                "volumeName", volumeName,
                 "status", "RUNNING"));
     }
 
@@ -300,6 +310,23 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
         return Map.of();
     }
 
+    /**
+     * Resolves the Docker volume name for an instance. Pre-upgrade instances persisted only a
+     * {@code volumeId}, so their data lives under the pinned legacy name; the live helper must
+     * never be used to backfill them — a future prefix or namespace change would orphan the data.
+     */
+    private String resolveVolumeName(Map<String, Object> metadata, String volumeId,
+                                     String fallbackId, boolean newVolume) {
+        String persisted = stringValue(dataPlane(metadata).get("volumeName"));
+        if (persisted != null && !persisted.isBlank()) {
+            return persisted;
+        }
+        if (newVolume) {
+            return ContainerStorageHelper.resourceName(config, "cloudsql", volumeId, fallbackId);
+        }
+        return LEGACY_VOLUME_PREFIX + (volumeId != null ? volumeId : fallbackId);
+    }
+
     private String volumeId(Map<String, Object> metadata, String project, String instance) {
         String existing = stringValue(dataPlane(metadata).get("volumeId"));
         if (existing != null && !existing.isBlank()) {
@@ -309,7 +336,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
     }
 
     private String containerName(String project, String instance) {
-        return "floci-cloudsql-" + fallbackId(project, instance);
+        return ContainerStorageHelper.dockerName(config, "cloudsql-" + fallbackId(project, instance));
     }
 
     private String fallbackId(String project, String instance) {

--- a/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
+++ b/src/main/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlane.java
@@ -76,7 +76,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
 
         String internalMountPath = getInternalMountPath(stringValue(updated.get("databaseVersion")));
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "cloudsql", volumeId, fallbackId, internalMountPath);
         } else {
             String hostDataPath = Path.of(config.storage().hostPersistentPath(), "cloudsql",
@@ -99,7 +99,7 @@ public class CloudSqlPostgresDataPlane implements CloudSqlDataPlane {
                 lifecycleManager.stopAndRemove(containerId, null);
             }
             if (newVolume && ContainerStorageHelper.isNamedVolumeMode(config)) {
-                lifecycleManager.removeVolume(ContainerStorageHelper.resourceName("cloudsql", volumeId, fallbackId));
+                lifecycleManager.removeVolume(ContainerStorageHelper.resourceName(config, "cloudsql", volumeId, fallbackId));
             }
             throw e;
         }

--- a/src/main/java/io/floci/gcp/services/gke/GkeClusterManager.java
+++ b/src/main/java/io/floci/gcp/services/gke/GkeClusterManager.java
@@ -9,6 +9,7 @@ import io.floci.gcp.core.common.docker.ContainerDetector;
 import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
 import io.floci.gcp.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.floci.gcp.core.common.docker.ContainerSpec;
+import io.floci.gcp.core.common.docker.ContainerStorageHelper;
 import io.floci.gcp.core.common.docker.DockerHostResolver;
 import io.floci.gcp.core.common.docker.PortAllocator;
 import io.floci.gcp.services.gke.model.StoredCluster;
@@ -38,6 +39,13 @@ public class GkeClusterManager {
     private static final Logger LOG = Logger.getLogger(GkeClusterManager.class);
     private static final int K3S_API_SERVER_PORT = 6443;
     private static final String ENDPOINT_MODE_NETWORK = "network";
+
+    /**
+     * Volume-name prefix used before names were persisted. Pinned for backfill only —
+     * pre-upgrade volumes must keep resolving to this exact prefix regardless of what the
+     * live naming helper produces.
+     */
+    private static final String LEGACY_VOLUME_PREFIX = "floci-gke-";
 
     private static final String WEBHOOK_CONFIG_DIR = "/etc";
     private static final String WEBHOOK_CONFIG_FILE = "gke-token-webhook.yaml";
@@ -72,7 +80,8 @@ public class GkeClusterManager {
      */
     public void startCluster(StoredCluster cluster) {
         String image = config.services().gke().defaultImage();
-        String containerName = "floci-gke-" + cluster.getName();
+        String containerName = ContainerStorageHelper.dockerName(config,
+                "gke-" + cluster.getProject() + "-" + cluster.getName());
 
         LOG.infov("Starting k3s container for GKE cluster {0} using image {1}",
                 cluster.getName(), image);
@@ -87,7 +96,9 @@ public class GkeClusterManager {
         // A named Docker volume (not a host bind mount) for the k3s data dir: bind mounts to a
         // macOS host path make kine's unix socket chmod fail (EINVAL); named volumes live in the
         // Docker VM's Linux filesystem. k3s v1.34+ manages embedded SQLite (kine) internally.
-        String volumeName = "floci-gke-" + cluster.getName();
+        String volumeName = volumeName(cluster);
+        cluster.setVolumeName(volumeName);
+        lifecycleManager.ensureVolume(volumeName);
 
         List<String> serverArgs = new ArrayList<>(List.of(
                 "server", "--disable=traefik", "--tls-san=localhost"));
@@ -192,8 +203,27 @@ public class GkeClusterManager {
             return;
         }
         lifecycleManager.stopAndRemove(cluster.getContainerId(), null);
-        lifecycleManager.removeVolume("floci-gke-" + cluster.getName());
+        lifecycleManager.removeVolume(volumeName(cluster));
         LOG.infov("Stopped k3s container for cluster {0}", cluster.getName());
+    }
+
+    /**
+     * Resolves the k3s data volume name. Pre-upgrade clusters used an unscoped
+     * {@code floci-gke-<cluster>} name; an existing volume under that name is adopted so its
+     * data survives the rename. New volumes are project-scoped, which also keeps clusters with
+     * the same id in different projects apart. Long namespace+project+cluster combinations can
+     * exceed the 63-character DNS label limit for in-network resolution of the container name.
+     */
+    String volumeName(StoredCluster cluster) {
+        if (cluster.getVolumeName() != null && !cluster.getVolumeName().isBlank()) {
+            return cluster.getVolumeName();
+        }
+        String legacy = LEGACY_VOLUME_PREFIX + cluster.getName();
+        if (lifecycleManager.volumeExists(legacy)) {
+            return legacy;
+        }
+        return ContainerStorageHelper.resourceName(config, "gke", null,
+                cluster.getProject() + "-" + cluster.getName());
     }
 
     /** The raw k3s kubeconfig (server URL unmodified), for the internal kubeconfig endpoint. */

--- a/src/main/java/io/floci/gcp/services/gke/model/StoredCluster.java
+++ b/src/main/java/io/floci/gcp/services/gke/model/StoredCluster.java
@@ -34,6 +34,7 @@ public class StoredCluster {
     private String containerId;
     private int hostPort;
     private String internalEndpoint;
+    private String volumeName;
 
     public StoredCluster() {
     }
@@ -164,5 +165,13 @@ public class StoredCluster {
 
     public void setInternalEndpoint(String internalEndpoint) {
         this.internalEndpoint = internalEndpoint;
+    }
+
+    public String getVolumeName() {
+        return volumeName;
+    }
+
+    public void setVolumeName(String volumeName) {
+        this.volumeName = volumeName;
     }
 }

--- a/src/main/java/io/floci/gcp/services/kafka/KafkaService.java
+++ b/src/main/java/io/floci/gcp/services/kafka/KafkaService.java
@@ -6,6 +6,7 @@ import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.ServiceDescriptor;
 import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.core.common.docker.ContainerStorageHelper;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.services.kafka.model.ClusterState;
@@ -88,6 +89,8 @@ public class KafkaService {
 
         StoredCluster cluster = new StoredCluster(name);
         cluster.setVolumeId(String.format("%06x", new SecureRandom().nextInt(0xFFFFFF)));
+        cluster.setVolumeName(ContainerStorageHelper.resourceName(
+                config, "kafka", cluster.getVolumeId(), clusterId));
 
         applyCapacityFromBody(cluster, body);
 

--- a/src/main/java/io/floci/gcp/services/kafka/RedpandaManager.java
+++ b/src/main/java/io/floci/gcp/services/kafka/RedpandaManager.java
@@ -70,7 +70,7 @@ public class RedpandaManager {
         }
 
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "kafka", cluster.getVolumeId(), clusterId(cluster.getName()),
                     "/var/lib/redpanda/data");
         } else {

--- a/src/main/java/io/floci/gcp/services/kafka/RedpandaManager.java
+++ b/src/main/java/io/floci/gcp/services/kafka/RedpandaManager.java
@@ -31,6 +31,13 @@ public class RedpandaManager {
     private static final int ADMIN_PORT = 9644;
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    /**
+     * Volume-name prefix used before names were persisted. Pinned for backfill only —
+     * pre-upgrade volumes must keep resolving to this exact prefix regardless of what the
+     * live naming helper produces.
+     */
+    private static final String LEGACY_VOLUME_PREFIX = "floci-gcp-kafka-";
+
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
     private final ContainerDetector containerDetector;
@@ -70,9 +77,8 @@ public class RedpandaManager {
         }
 
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
-                    "kafka", cluster.getVolumeId(), clusterId(cluster.getName()),
-                    "/var/lib/redpanda/data");
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+                    volumeName(cluster), "/var/lib/redpanda/data");
         } else {
             String hostDataPath = Path.of(config.storage().hostPersistentPath(), "kafka", clusterId(cluster.getName()))
                     .toAbsolutePath().toString();
@@ -206,12 +212,27 @@ public class RedpandaManager {
     }
 
     public void removeClusterStorage(StoredCluster cluster) {
-        ContainerStorageHelper.removeStorage(config, lifecycleManager,
-                "kafka", cluster.getVolumeId(), clusterId(cluster.getName()));
+        ContainerStorageHelper.removeStorage(config, lifecycleManager, volumeName(cluster));
     }
 
-    private static String containerName(StoredCluster cluster) {
-        return "floci-kafka-" + clusterId(cluster.getName());
+    /**
+     * Pre-upgrade clusters persisted only a {@code volumeId}; their data lives under the pinned
+     * legacy name. The backfilled name is written back to the cluster, but persistence is
+     * best-effort (it reaches the store only when the cluster turns ACTIVE) — the resolver is
+     * deterministic, so recomputing on the next start is safe.
+     */
+    private String volumeName(StoredCluster cluster) {
+        if (cluster.getVolumeName() != null && !cluster.getVolumeName().isBlank()) {
+            return cluster.getVolumeName();
+        }
+        String legacy = LEGACY_VOLUME_PREFIX
+                + (cluster.getVolumeId() != null ? cluster.getVolumeId() : clusterId(cluster.getName()));
+        cluster.setVolumeName(legacy);
+        return legacy;
+    }
+
+    private String containerName(StoredCluster cluster) {
+        return ContainerStorageHelper.dockerName(config, "kafka-" + clusterId(cluster.getName()));
     }
 
     private static String clusterId(String name) {

--- a/src/main/java/io/floci/gcp/services/kafka/model/StoredCluster.java
+++ b/src/main/java/io/floci/gcp/services/kafka/model/StoredCluster.java
@@ -19,6 +19,7 @@ public class StoredCluster {
     @JsonIgnore
     private String containerId;
     private String volumeId;
+    private String volumeName;
 
     public StoredCluster() {}
 
@@ -57,4 +58,7 @@ public class StoredCluster {
 
     public String getVolumeId() { return volumeId; }
     public void setVolumeId(String volumeId) { this.volumeId = volumeId; }
+
+    public String getVolumeName() { return volumeName; }
+    public void setVolumeName(String volumeName) { this.volumeName = volumeName; }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,7 @@ floci-gcp:
     log-max-file: "3"
     docker-host: "unix:///var/run/docker.sock"
     api-timeout: 30s
+    resource-namespace: ""          # FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE; scopes sidecar container/volume names
   init-hooks:
     shell-executable: /bin/sh
     shutdown-grace-period-seconds: 2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,7 +84,6 @@ floci-gcp:
         request-timeout: 300s
         operation-timeout: 300s
         cleanup-timeout: 15s
-        container-name-prefix: floci-cloudrun
         url-host-suffix:
     cloudfunctions:
       enabled: true
@@ -115,12 +114,25 @@ floci-gcp:
       enabled: true
   dns:
     extra-suffixes:
+    # Public resolvers appended after floci-gcp's embedded DNS in every spawned container.
+    # Lets Cloud Run/GKE/sidecar containers resolve public hostnames even if the embedded
+    # forwarder cannot answer. Disable in offline/locked-down networks where these
+    # resolvers are blocked.
+    container-fallback-enabled: true              # FLOCI_GCP_DNS_CONTAINER_FALLBACK_ENABLED
+    container-fallback-servers:                   # FLOCI_GCP_DNS_CONTAINER_FALLBACK_SERVERS=1.1.1.1,1.0.0.1
+      - 8.8.8.8
+      - 8.8.4.4
   docker:
     log-max-size: "10m"
     log-max-file: "3"
     docker-host: "unix:///var/run/docker.sock"
     api-timeout: 30s
     resource-namespace: ""          # FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE; scopes sidecar container/volume names
+    # image-registry-base: mirror.example.com     # FLOCI_GCP_DOCKER_IMAGE_REGISTRY_BASE; prefixes every launched image
+    # registry-credentials:                       # explicit credentials for private registries
+    #   - server: myregistry.example.com
+    #     username: user
+    #     password: secret
   init-hooks:
     shell-executable: /bin/sh
     shutdown-grace-period-seconds: 2

--- a/src/test/java/io/floci/gcp/core/common/dns/EmbeddedDnsServerTest.java
+++ b/src/test/java/io/floci/gcp/core/common/dns/EmbeddedDnsServerTest.java
@@ -3,6 +3,9 @@ package io.floci.gcp.core.common.dns;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -135,6 +138,83 @@ class EmbeddedDnsServerTest {
         assertEquals((byte) 19, resp.get());
         assertEquals((byte) 0, resp.get());
         assertEquals((byte) 42, resp.get());
+    }
+
+    // ── composeUpstreams — forwarder upstream ordering ────────────────────────
+
+    @Test
+    void composeUpstreams_resolvConfFirstThenFallbacks() {
+        List<String> upstreams = EmbeddedDnsServer.composeUpstreams(
+                List.of("192.168.65.7"), List.of("8.8.8.8", "8.8.4.4"));
+        assertEquals(List.of("192.168.65.7", "8.8.8.8", "8.8.4.4"), upstreams);
+    }
+
+    @Test
+    void composeUpstreams_usesDockerResolverBaselineWhenResolvConfEmpty() {
+        List<String> upstreams = EmbeddedDnsServer.composeUpstreams(
+                List.of(), List.of("8.8.8.8"));
+        // Docker's embedded resolver is the baseline, then the configured fallback.
+        assertEquals(List.of("127.0.0.11", "8.8.8.8"), upstreams);
+    }
+
+    @Test
+    void composeUpstreams_skipsLoopbackAndBlankEntries() {
+        List<String> upstreams = EmbeddedDnsServer.composeUpstreams(
+                List.of("127.0.0.1", "  ", "10.0.0.2"), List.of("", "8.8.8.8"));
+        assertEquals(List.of("10.0.0.2", "8.8.8.8"), upstreams);
+    }
+
+    @Test
+    void composeUpstreams_dedupesAcrossResolvConfAndFallbacks() {
+        List<String> upstreams = EmbeddedDnsServer.composeUpstreams(
+                List.of("8.8.8.8"), List.of("8.8.8.8", "8.8.4.4"));
+        assertEquals(List.of("8.8.8.8", "8.8.4.4"), upstreams);
+    }
+
+    @Test
+    void composeUpstreams_toleratesNullFallbacks() {
+        List<String> upstreams = EmbeddedDnsServer.composeUpstreams(List.of("10.0.0.2"), null);
+        assertEquals(List.of("10.0.0.2"), upstreams);
+    }
+
+    // ── forwarding — response buffer size regression ──────────────────────────
+
+    @Test
+    void forwardToUpstreams_returnsResponseLargerThan512BytesIntact() throws Exception {
+        // Regression guard: a 512-byte receive buffer silently truncated EDNS0 responses from
+        // CDN-backed public hosts, corrupting the answer forwarded back to sidecar containers.
+        byte[] bigResponse = new byte[1500];
+        for (int i = 0; i < bigResponse.length; i++) {
+            bigResponse[i] = (byte) (i & 0xFF);
+        }
+
+        try (DatagramSocket responder = new DatagramSocket(0, InetAddress.getByName("127.0.0.1"))) {
+            startResponder(responder, bigResponse);
+            byte[] query = buildQuery("storage.googleapis.com", (short) 0x1234);
+
+            byte[] response = dns.forwardToUpstreams(
+                    query, List.of("127.0.0.1"), responder.getLocalPort());
+
+            assertEquals(bigResponse.length, response.length,
+                    "response larger than 512 bytes must be forwarded without truncation");
+            assertArrayEquals(bigResponse, response);
+        }
+    }
+
+    /** Replies to the first datagram received with a fixed payload, on a daemon thread. */
+    private void startResponder(DatagramSocket responder, byte[] responsePayload) {
+        Thread t = new Thread(() -> {
+            try {
+                DatagramPacket req = new DatagramPacket(new byte[4096], 4096);
+                responder.receive(req);
+                responder.send(new DatagramPacket(
+                        responsePayload, responsePayload.length, req.getAddress(), req.getPort()));
+            } catch (Exception ignored) {
+                // socket closed when the test completes
+            }
+        });
+        t.setDaemon(true);
+        t.start();
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/src/test/java/io/floci/gcp/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/floci/gcp/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -1,0 +1,143 @@
+package io.floci.gcp.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.exception.NotFoundException;
+import io.floci.gcp.config.EmulatorConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Asserts the default Docker labels at the single choke point every emulator-created
+ * container and volume passes through. All five container families funnel into
+ * {@link ContainerLifecycleManager#create}, so asserting here covers every service
+ * by construction.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContainerLifecycleManagerLabelsTest {
+
+    @Mock
+    DockerClientProducer dockerClients;
+
+    @Mock
+    DockerClient dockerClient;
+
+    @Mock
+    ContainerDetector containerDetector;
+
+    @Mock
+    PortAllocator portAllocator;
+
+    @Mock
+    ImageCacheService imageCacheService;
+
+    @Mock
+    EmulatorConfig config;
+
+    @Mock
+    EmulatorConfig.DockerConfig dockerConfig;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(config.docker()).thenReturn(dockerConfig);
+        lenient().when(dockerConfig.resourceNamespace()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void createAppliesDefaultLabelsToEveryContainer() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createMergesSpecLabelsOverDefaults() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+        ContainerSpec spec = new ContainerSpec(
+                "busybox:stable", null, List.of(), null, null, null, Map.of(), List.of(), null,
+                List.of(), List.of(), List.of(), Map.of("floci_service", "cloudrun"), null, false,
+                null, List.of(), null, null, List.of());
+
+        manager().create(spec);
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp", "floci_service", "cloudrun"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createIncludesNamespaceLabelWhenConfigured() {
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp", "floci_namespace", "run-one"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void ensureVolumeAppliesTheSameDefaultLabels() {
+        InspectVolumeCmd inspectVolumeCmd = mock(InspectVolumeCmd.class);
+        when(dockerClient.inspectVolumeCmd("volume-1")).thenReturn(inspectVolumeCmd);
+        when(inspectVolumeCmd.exec()).thenThrow(new NotFoundException("missing"));
+        CreateVolumeCmd createVolumeCmd = mock(CreateVolumeCmd.class, RETURNS_SELF);
+        when(dockerClient.createVolumeCmd()).thenReturn(createVolumeCmd);
+
+        manager().ensureVolume("volume-1");
+
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createVolumeCmd).withLabels(labels.capture());
+        assertEquals(Map.of("floci", "true", "floci_emulator", "floci-gcp"), labels.getValue());
+    }
+
+    private ContainerLifecycleManager manager() {
+        when(dockerClients.client()).thenReturn(dockerClient);
+        when(dockerClients.apiTimeout()).thenReturn(Duration.ofSeconds(5));
+        return new ContainerLifecycleManager(dockerClients, containerDetector, portAllocator, imageCacheService, config);
+    }
+
+    private CreateContainerCmd stubCreateContainer() {
+        CreateContainerCmd createCmd = mock(CreateContainerCmd.class, RETURNS_SELF);
+        when(dockerClient.createContainerCmd("busybox:stable")).thenReturn(createCmd);
+        CreateContainerResponse response = mock(CreateContainerResponse.class);
+        when(response.getId()).thenReturn("container-id");
+        when(createCmd.exec()).thenReturn(response);
+        return createCmd;
+    }
+
+    private Map<String, String> capturedLabels(CreateContainerCmd createCmd) {
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createCmd).withLabels(labels.capture());
+        return labels.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ArgumentCaptor<Map<String, String>> labelsCaptor() {
+        return ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+    }
+}

--- a/src/test/java/io/floci/gcp/core/common/docker/ContainerLifecycleManagerTest.java
+++ b/src/test/java/io/floci/gcp/core/common/docker/ContainerLifecycleManagerTest.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.api.command.InspectVolumeCmd;
 import com.github.dockerjava.api.command.RemoveContainerCmd;
 import com.github.dockerjava.api.command.RemoveVolumeCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
+import io.floci.gcp.config.EmulatorConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
@@ -42,6 +43,9 @@ class ContainerLifecycleManagerTest {
 
     @Mock
     ImageCacheService imageCacheService;
+
+    @Mock
+    EmulatorConfig config;
 
     @Mock
     RemoveContainerCmd removeContainerCmd;
@@ -88,7 +92,8 @@ class ContainerLifecycleManagerTest {
         when(inspectVolumeCmd.exec()).thenThrow(new NotFoundException("missing"));
         when(dockerClient.createVolumeCmd()).thenReturn(createVolumeCmd);
         when(createVolumeCmd.withName("volume-1")).thenReturn(createVolumeCmd);
-        when(createVolumeCmd.withLabels(Map.of("floci-gcp", "true"))).thenReturn(createVolumeCmd);
+        when(createVolumeCmd.withLabels(Map.of("floci", "true", "floci_emulator", "floci-gcp")))
+                .thenReturn(createVolumeCmd);
 
         manager().ensureVolume("volume-1");
 
@@ -129,6 +134,6 @@ class ContainerLifecycleManagerTest {
     private ContainerLifecycleManager manager(Duration apiTimeout) {
         when(dockerClients.client()).thenReturn(dockerClient);
         when(dockerClients.apiTimeout()).thenReturn(apiTimeout);
-        return new ContainerLifecycleManager(dockerClients, containerDetector, portAllocator, imageCacheService);
+        return new ContainerLifecycleManager(dockerClients, containerDetector, portAllocator, imageCacheService, config);
     }
 }

--- a/src/test/java/io/floci/gcp/core/common/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/floci/gcp/core/common/docker/ContainerStorageHelperTest.java
@@ -1,0 +1,73 @@
+package io.floci.gcp.core.common.docker;
+
+import io.floci.gcp.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContainerStorageHelperTest {
+
+    @Test
+    void namesCarryTheGcpPrefixWithoutNamespace() {
+        assertEquals("floci-gcp-cloudsql-p-i", ContainerStorageHelper.dockerName(config(""), "cloudsql-p-i"));
+        assertEquals("floci-gcp-cloudsql-p-i", ContainerStorageHelper.resourceName(config(""), "cloudsql", null, "p-i"));
+        assertEquals("floci-gcp-kafka-abc123", ContainerStorageHelper.resourceName(config(""), "kafka", "abc123", "c1"));
+    }
+
+    @Test
+    void nullConfigYieldsDefaultModeNames() {
+        assertEquals("floci-gcp-cloudsql-abc123", ContainerStorageHelper.resourceName(null, "cloudsql", "abc123", "p-i"));
+        assertEquals("floci-gcp-cloudsql-p-i", ContainerStorageHelper.resourceName(null, "cloudsql", null, "p-i"));
+    }
+
+    @Test
+    void namespaceLandsBetweenCloudAndServiceTokens() {
+        assertEquals("floci-gcp-run-one-kafka-abc123",
+                ContainerStorageHelper.resourceName(config(" run/one "), "kafka", "abc123", "c1"));
+        assertEquals("floci-gcp-run-one-gke-p1-c1",
+                ContainerStorageHelper.dockerName(config("run-one"), "gke-p1-c1"));
+    }
+
+    @Test
+    void alreadyPrefixedNamesAreNormalized() {
+        assertEquals("floci-gcp-kafka-x", ContainerStorageHelper.dockerName(config(""), "floci-gcp-kafka-x"));
+        assertEquals("floci-gcp-kafka-x", ContainerStorageHelper.dockerName(config(""), "floci-kafka-x"));
+        assertEquals("floci-gcp-gke-c1", ContainerStorageHelper.dockerName(config(""), "floci-gke-c1"));
+        assertEquals("floci-gcp-run-one-kafka-x", ContainerStorageHelper.dockerName(config("run-one"), "floci-gcp-kafka-x"));
+        assertEquals("floci-gcp-run-one-cloudrun-svc", ContainerStorageHelper.dockerName(config("run-one"), "floci-cloudrun-svc"));
+    }
+
+    @Test
+    void defaultLabelsIdentifyThisEmulator() {
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp"),
+                ContainerStorageHelper.defaultLabels(config("")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp", "floci_namespace", "run-one"),
+                ContainerStorageHelper.defaultLabels(config(" run/one ")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp"),
+                ContainerStorageHelper.defaultLabels(null));
+    }
+
+    @Test
+    void unsafeNamespaceSegmentsAreIgnored() {
+        assertEquals("floci-gcp-kafka-x", ContainerStorageHelper.dockerName(config(".."), "kafka-x"));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-gcp"),
+                ContainerStorageHelper.defaultLabels(config("..")));
+    }
+
+    private static EmulatorConfig config(String namespace) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        when(config.docker()).thenReturn(docker);
+        when(docker.resourceNamespace()).thenReturn(namespace.isBlank() ? Optional.empty() : Optional.of(namespace));
+        return config;
+    }
+}

--- a/src/test/java/io/floci/gcp/lifecycle/EmulatorInfoControllerIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/lifecycle/EmulatorInfoControllerIntegrationTest.java
@@ -1,0 +1,62 @@
+package io.floci.gcp.lifecycle;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class EmulatorInfoControllerIntegrationTest {
+
+    @Test
+    void stateReset_returnsOk() {
+        given()
+                .when().post("/_floci-gcp/state/reset")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("status", equalTo("OK"));
+    }
+
+    @Test
+    void stateNuke_returnsOk() {
+        given()
+                .when().post("/_floci-gcp/state/nuke")
+                .then()
+                .statusCode(200)
+                .contentType("application/json")
+                .body("status", equalTo("OK"));
+    }
+
+    @Test
+    void stateReset_clearsServiceState() {
+        String project = "reset-it";
+        String topicName = "projects/" + project + "/topics/to-be-reset";
+
+        given()
+                .contentType("application/json")
+                .body("{}")
+                .when().put("/v1/projects/" + project + "/topics/to-be-reset")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(topicName));
+
+        given()
+                .when().get("/v1/projects/" + project + "/topics/to-be-reset")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(topicName));
+
+        given()
+                .when().post("/_floci-gcp/state/reset")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("OK"));
+
+        given()
+                .when().get("/v1/projects/" + project + "/topics/to-be-reset")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunRuntimeServiceTest.java
@@ -51,10 +51,10 @@ class CloudRunRuntimeServiceTest {
         when(config.services().cloudrun().execution().defaultPort()).thenReturn(8080);
         when(config.services().cloudrun().execution().startupTimeout()).thenReturn(Duration.ofSeconds(1));
         when(config.services().cloudrun().execution().requestTimeout()).thenReturn(Duration.ofSeconds(300));
-        when(config.services().cloudrun().execution().containerNamePrefix()).thenReturn("floci-cloudrun");
         when(config.effectiveBaseUrl()).thenReturn("http://localhost:4588");
         when(config.docker().logMaxSize()).thenReturn("10m");
         when(config.docker().logMaxFile()).thenReturn("3");
+        when(config.docker().resourceNamespace()).thenReturn(Optional.empty());
 
         DockerHostResolver dockerHostResolver = mock(DockerHostResolver.class);
         when(dockerHostResolver.isLinuxHost()).thenReturn(false);
@@ -96,7 +96,10 @@ class CloudRunRuntimeServiceTest {
         assertFalse(spec.env().contains("PORT=9999"));
         assertTrue(spec.env().contains("K_SERVICE=svc"));
         assertTrue(spec.env().contains("K_REVISION=svc-00001"));
-        assertEquals("cloudrun", spec.labels().get("floci-gcp.service"));
+        assertEquals("cloudrun", spec.labels().get("floci_service"));
+        assertEquals("p1", spec.labels().get("floci_project"));
+        assertEquals("us-central1", spec.labels().get("floci_location"));
+        assertEquals(revision.getName(), spec.labels().get("floci_resource"));
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlaneTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudsql/CloudSqlPostgresDataPlaneTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,6 +51,9 @@ class CloudSqlPostgresDataPlaneTest {
     @Mock
     EmulatorConfig.CloudSqlServiceConfig cloudSqlConfig;
 
+    @Mock
+    EmulatorConfig.DockerConfig dockerConfig;
+
     @Test
     void startInstanceCleansUpCreatedContainerAndNewVolumeWhenStartupFails() {
         ContainerSpec spec = new ContainerSpec("postgres:18.4-alpine");
@@ -62,7 +66,7 @@ class CloudSqlPostgresDataPlaneTest {
         when(cloudSqlConfig.startupTimeoutSeconds()).thenReturn(0);
         when(containerDetector.isRunningInContainer()).thenReturn(false);
         when(containerBuilder.newContainer("postgres:18.4-alpine")).thenReturn(specBuilder);
-        when(specBuilder.withName("floci-cloudsql-project-a-pg-main")).thenReturn(specBuilder);
+        when(specBuilder.withName("floci-gcp-cloudsql-project-a-pg-main")).thenReturn(specBuilder);
         when(specBuilder.withEnv(any(), any())).thenReturn(specBuilder);
         when(specBuilder.withLogRotation()).thenReturn(specBuilder);
         when(specBuilder.withDockerNetwork(Optional.empty())).thenReturn(specBuilder);
@@ -84,5 +88,100 @@ class CloudSqlPostgresDataPlaneTest {
         verify(lifecycleManager).stopAndRemove("container-1", null);
         verify(lifecycleManager).removeVolume(argThat(name -> name.startsWith(
                 "floci-gcp-cloudsql-project-a-pg-main-")));
+    }
+
+    @Test
+    void preUpgradeInstancesMountTheirLegacyVolumeEvenWithNamespaceConfigured() {
+        ContainerSpec spec = new ContainerSpec("postgres:18.4-alpine");
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.hostPersistentPath()).thenReturn("./data");
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.cloudsql()).thenReturn(cloudSqlConfig);
+        when(servicesConfig.dockerNetwork()).thenReturn(Optional.empty());
+        when(cloudSqlConfig.postgres18Image()).thenReturn("postgres:18.4-alpine");
+        when(cloudSqlConfig.startupTimeoutSeconds()).thenReturn(0);
+        when(config.docker()).thenReturn(dockerConfig);
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(containerBuilder.newContainer("postgres:18.4-alpine")).thenReturn(specBuilder);
+        when(specBuilder.withName("floci-gcp-run-one-cloudsql-project-a-pg-main")).thenReturn(specBuilder);
+        when(specBuilder.withEnv(any(), any())).thenReturn(specBuilder);
+        when(specBuilder.withLogRotation()).thenReturn(specBuilder);
+        when(specBuilder.withDockerNetwork(Optional.empty())).thenReturn(specBuilder);
+        when(specBuilder.withDynamicPort(5432)).thenReturn(specBuilder);
+        when(specBuilder.withNamedVolume("floci-gcp-cloudsql-abc123", "/var/lib/postgresql"))
+                .thenReturn(specBuilder);
+        when(specBuilder.build()).thenReturn(spec);
+        when(lifecycleManager.create(spec)).thenReturn("container-1");
+        when(lifecycleManager.startCreated("container-1", spec)).thenReturn(new ContainerInfo(
+                "container-1",
+                Map.of(5432, new EndpointInfo("localhost", 15432))));
+
+        CloudSqlPostgresDataPlane dataPlane = new CloudSqlPostgresDataPlane(
+                containerBuilder, lifecycleManager, containerDetector, config);
+
+        assertThrows(GcpException.class, () -> dataPlane.startInstance(
+                "project-a", "pg-main", Map.of(
+                        "name", "pg-main",
+                        "databaseVersion", "POSTGRES_18",
+                        "flociDataPlane", Map.of("volumeId", "abc123"))));
+
+        verify(specBuilder).withNamedVolume("floci-gcp-cloudsql-abc123", "/var/lib/postgresql");
+        verify(lifecycleManager, never()).removeVolume(any());
+    }
+
+    @Test
+    void freshInstancesGetNamespacedVolumeNamesAndRollbackRemovesTheSameName() {
+        ContainerSpec spec = new ContainerSpec("postgres:18.4-alpine");
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.hostPersistentPath()).thenReturn("./data");
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.cloudsql()).thenReturn(cloudSqlConfig);
+        when(servicesConfig.dockerNetwork()).thenReturn(Optional.empty());
+        when(cloudSqlConfig.postgres18Image()).thenReturn("postgres:18.4-alpine");
+        when(cloudSqlConfig.startupTimeoutSeconds()).thenReturn(0);
+        when(config.docker()).thenReturn(dockerConfig);
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(containerBuilder.newContainer("postgres:18.4-alpine")).thenReturn(specBuilder);
+        when(specBuilder.withName("floci-gcp-run-one-cloudsql-project-a-pg-main")).thenReturn(specBuilder);
+        when(specBuilder.withEnv(any(), any())).thenReturn(specBuilder);
+        when(specBuilder.withLogRotation()).thenReturn(specBuilder);
+        when(specBuilder.withDockerNetwork(Optional.empty())).thenReturn(specBuilder);
+        when(specBuilder.withDynamicPort(5432)).thenReturn(specBuilder);
+        when(specBuilder.withNamedVolume(
+                argThat(name -> name.startsWith("floci-gcp-run-one-cloudsql-project-a-pg-main-")),
+                eq("/var/lib/postgresql"))).thenReturn(specBuilder);
+        when(specBuilder.build()).thenReturn(spec);
+        when(lifecycleManager.create(spec)).thenReturn("container-1");
+        when(lifecycleManager.startCreated("container-1", spec)).thenReturn(new ContainerInfo(
+                "container-1",
+                Map.of(5432, new EndpointInfo("localhost", 15432))));
+
+        CloudSqlPostgresDataPlane dataPlane = new CloudSqlPostgresDataPlane(
+                containerBuilder, lifecycleManager, containerDetector, config);
+
+        assertThrows(GcpException.class, () -> dataPlane.startInstance(
+                "project-a", "pg-main", Map.of("name", "pg-main", "databaseVersion", "POSTGRES_18")));
+
+        verify(lifecycleManager).removeVolume(argThat(name -> name.startsWith(
+                "floci-gcp-run-one-cloudsql-project-a-pg-main-")));
+    }
+
+    @Test
+    void stopInstanceRemovesTheLegacyVolumeForPreUpgradeInstances() {
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.mode()).thenReturn("memory");
+        when(config.docker()).thenReturn(dockerConfig);
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+
+        CloudSqlPostgresDataPlane dataPlane = new CloudSqlPostgresDataPlane(
+                containerBuilder, lifecycleManager, containerDetector, config);
+
+        dataPlane.stopInstance("project-a", "pg-main",
+                Map.of("flociDataPlane", Map.of("volumeId", "abc123")), true);
+
+        verify(lifecycleManager).removeIfExists("floci-gcp-run-one-cloudsql-project-a-pg-main");
+        verify(lifecycleManager).removeVolume("floci-gcp-cloudsql-abc123");
     }
 }

--- a/src/test/java/io/floci/gcp/services/gke/GkeClusterManagerVolumeTest.java
+++ b/src/test/java/io/floci/gcp/services/gke/GkeClusterManagerVolumeTest.java
@@ -1,0 +1,79 @@
+package io.floci.gcp.services.gke;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.docker.ContainerBuilder;
+import io.floci.gcp.core.common.docker.ContainerDetector;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
+import io.floci.gcp.core.common.docker.DockerHostResolver;
+import io.floci.gcp.core.common.docker.PortAllocator;
+import io.floci.gcp.services.gke.model.StoredCluster;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GkeClusterManagerVolumeTest {
+
+    @Mock
+    ContainerBuilder containerBuilder;
+
+    @Mock
+    ContainerLifecycleManager lifecycleManager;
+
+    @Mock
+    ContainerDetector containerDetector;
+
+    @Mock
+    PortAllocator portAllocator;
+
+    @Mock
+    DockerHostResolver dockerHostResolver;
+
+    @Mock
+    EmulatorConfig config;
+
+    @Mock
+    EmulatorConfig.DockerConfig dockerConfig;
+
+    @Test
+    void persistedVolumeNamesAreUsedVerbatim() {
+        StoredCluster cluster = cluster();
+        cluster.setVolumeName("floci-gcp-gke-p1-c1");
+
+        assertEquals("floci-gcp-gke-p1-c1", manager().volumeName(cluster));
+    }
+
+    @Test
+    void existingLegacyVolumesAreAdoptedEvenWithNamespaceConfigured() {
+        when(lifecycleManager.volumeExists("floci-gke-c1")).thenReturn(true);
+
+        assertEquals("floci-gke-c1", manager().volumeName(cluster()));
+    }
+
+    @Test
+    void newVolumesAreProjectScopedAndNamespaced() {
+        when(lifecycleManager.volumeExists("floci-gke-c1")).thenReturn(false);
+        when(config.docker()).thenReturn(dockerConfig);
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+
+        assertEquals("floci-gcp-run-one-gke-p1-c1", manager().volumeName(cluster()));
+    }
+
+    private GkeClusterManager manager() {
+        return new GkeClusterManager(containerBuilder, lifecycleManager, containerDetector,
+                portAllocator, dockerHostResolver, config);
+    }
+
+    private static StoredCluster cluster() {
+        StoredCluster cluster = new StoredCluster();
+        cluster.setName("c1");
+        cluster.setProject("p1");
+        return cluster;
+    }
+}

--- a/src/test/java/io/floci/gcp/services/kafka/RedpandaManagerVolumeMigrationTest.java
+++ b/src/test/java/io/floci/gcp/services/kafka/RedpandaManagerVolumeMigrationTest.java
@@ -1,0 +1,115 @@
+package io.floci.gcp.services.kafka;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.docker.ContainerBuilder;
+import io.floci.gcp.core.common.docker.ContainerDetector;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.floci.gcp.core.common.docker.ContainerLifecycleManager.EndpointInfo;
+import io.floci.gcp.services.kafka.model.StoredCluster;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedpandaManagerVolumeMigrationTest {
+
+    @Mock
+    ContainerBuilder containerBuilder;
+
+    @Mock
+    ContainerLifecycleManager lifecycleManager;
+
+    @Mock
+    ContainerDetector containerDetector;
+
+    @Mock
+    EmulatorConfig config;
+
+    @Mock
+    EmulatorConfig.StorageConfig storageConfig;
+
+    @Mock
+    EmulatorConfig.ServicesConfig servicesConfig;
+
+    @Mock
+    EmulatorConfig.KafkaServiceConfig kafkaConfig;
+
+    @Mock
+    EmulatorConfig.DockerConfig dockerConfig;
+
+    @Test
+    void preUpgradeClustersMountTheirLegacyVolumeEvenWithNamespaceConfigured() {
+        ContainerBuilder.Builder specBuilder = stubStartContainerPath("run-one");
+        StoredCluster cluster = cluster("abc123", null);
+
+        manager().startContainer(cluster);
+
+        verify(specBuilder).withName("floci-gcp-run-one-kafka-c1");
+        verify(lifecycleManager).ensureVolume("floci-gcp-kafka-abc123");
+        verify(specBuilder).withNamedVolume("floci-gcp-kafka-abc123", "/var/lib/redpanda/data");
+        assertEquals("floci-gcp-kafka-abc123", cluster.getVolumeName());
+    }
+
+    @Test
+    void persistedVolumeNamesAreUsedVerbatim() {
+        ContainerBuilder.Builder specBuilder = stubStartContainerPath("run-one");
+        StoredCluster cluster = cluster("abc123", "floci-gcp-run-one-kafka-abc123");
+
+        manager().startContainer(cluster);
+
+        verify(lifecycleManager).ensureVolume("floci-gcp-run-one-kafka-abc123");
+        verify(specBuilder).withNamedVolume("floci-gcp-run-one-kafka-abc123", "/var/lib/redpanda/data");
+    }
+
+    @Test
+    void removeClusterStorageResolvesTheSameLegacyName() {
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.mode()).thenReturn("memory");
+
+        manager().removeClusterStorage(cluster("abc123", null));
+
+        verify(lifecycleManager).removeVolume("floci-gcp-kafka-abc123");
+    }
+
+    private RedpandaManager manager() {
+        return new RedpandaManager(containerBuilder, lifecycleManager, containerDetector, config);
+    }
+
+    private static StoredCluster cluster(String volumeId, String volumeName) {
+        StoredCluster cluster = new StoredCluster("projects/p1/locations/us-central1/clusters/c1");
+        cluster.setVolumeId(volumeId);
+        cluster.setVolumeName(volumeName);
+        return cluster;
+    }
+
+    private ContainerBuilder.Builder stubStartContainerPath(String namespace) {
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.kafka()).thenReturn(kafkaConfig);
+        when(kafkaConfig.defaultImage()).thenReturn("redpanda:test");
+        when(kafkaConfig.dockerNetwork()).thenReturn(Optional.empty());
+        when(config.docker()).thenReturn(dockerConfig);
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of(namespace));
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.hostPersistentPath()).thenReturn("./data");
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        ContainerBuilder.Builder specBuilder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        when(containerBuilder.newContainer("redpanda:test")).thenReturn(specBuilder);
+        lenient().when(specBuilder.build()).thenReturn(null);
+        when(lifecycleManager.createAndStart(any())).thenReturn(new ContainerInfo(
+                "container-1", Map.of(9092, new EndpointInfo("localhost", 19092))));
+        return specBuilder;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,7 +30,6 @@ floci-gcp:
         request-timeout: 300s
         operation-timeout: 300s
         cleanup-timeout: 15s
-        container-name-prefix: floci-cloudrun
         url-host-suffix:
     cloudfunctions:
       enabled: true
@@ -55,3 +54,4 @@ floci-gcp:
       enabled: true
   docker:
     api-timeout: 30s
+    resource-namespace: ""


### PR DESCRIPTION
## Summary

Stacked on #108 (`fix/converge-docker`) — merge that first (the DNS
forwarder uses the `container-fallback-servers` config it introduces).

Converges the dns and runtime clusters on floci-aws baseline 0142dc4.

DNS (floci-aws 2d306414):
- `EmbeddedDnsServer`: raise the UDP response buffer 512 → 4096 so
  EDNS0/CDN responses are no longer truncated; forward through ALL
  resolv.conf nameservers plus the configured fallback chain (127.0.0.11
  baseline when resolv.conf is unusable), 1500ms per-upstream timeout, one
  warning when every upstream fails
- Fix the class javadoc: the canonical suffix is `localhost.floci.io`, not
  `*.localhost.floci-gcp.io` (CloudRunUrlService depends on it)

Runtime:
- State reset surface (f4c7a84d): `Resettable` interface, POST
  `/_floci-gcp/state/reset` clearing all Resettable beans +
  `StorageFactory.clearAll()`, `/state/nuke` as an alias. floci-gcp
  previously had no state reset at all
- `PersistentPathValidator` (fe49bee4): fail fast at boot when the data root
  is not writable
- `EmulatorLifecycle.onStop`: flush persisted state FIRST, before slow
  container teardown, closing the SIGTERM-grace-window data-loss hazard
  (5eec7269); generic `Instance<ContainerTeardown>` teardown loop
- `XmlParser`: log swallowed malformed-XML parse errors at debug

No gcp service implements Resettable/ContainerTeardown yet (follow-up); the
reset endpoint is effective through `clearAll()` alone.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

The reset endpoint lives under the emulator-internal `/_floci-gcp/` prefix —
no GCP API surface is touched. DNS changes affect only the embedded
forwarder for spawned containers. Compatibility suite not re-run for this
segment; behavior converged on floci-aws baseline 0142dc4.

## Checklist

- [x] `./mvnw test` passes locally (468 tests, 0 failures)
- [x] New or updated integration test added (composeUpstreams ordering,
  >512-byte forwarding regression, reset/nuke integration test incl.
  Pub/Sub topic clearing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
