### PR TITLE
docs: sync docs and README with current service and configuration surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ services:
       - "4588:4588"
     volumes:
       - ./data:/app/data
+      # Enables Docker-backed services (Cloud Run, Cloud SQL, Kafka, GKE)
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FLOCI_GCP_HOSTNAME: floci-gcp
       FLOCI_GCP_BASE_URL: http://floci-gcp:4588
+      # Keep state across restarts in the mounted ./data volume
+      FLOCI_GCP_STORAGE_MODE: hybrid
 ```
 
 ```bash
@@ -65,6 +69,7 @@ export FIRESTORE_EMULATOR_HOST=localhost:4588
 export DATASTORE_EMULATOR_HOST=localhost:4588
 export STORAGE_EMULATOR_HOST=http://localhost:4588
 export SECRET_MANAGER_EMULATOR_HOST=localhost:4588
+export FIREBASE_AUTH_EMULATOR_HOST=localhost:4588
 export GOOGLE_CLOUD_PROJECT=floci-local
 ```
 
@@ -146,6 +151,8 @@ GCP's official emulators are fragmented — each service ships its own binary, r
 | Service Usage | ✅ | ❌ |
 | Identity Platform / Firebase Auth | ✅ | ❌ |
 | BigQuery (Phase 1) | ✅ | ❌ |
+| Eventarc | ✅ | ❌ |
+| IAM Service Account Credentials | ✅ | ❌ |
 | Native binary | ✅ | ❌ |
 
 ## Architecture Overview
@@ -162,11 +169,11 @@ flowchart LR
         end
 
         subgraph REST ["REST services"]
-            B["Cloud Storage\nIAM\nDatastore\nCloud Run\nCloud Functions\nCloud SQL\nGKE\nBigQuery"]
+            B["Cloud Storage\nIAM\nIAM Credentials\nDatastore\nCloud Run\nCloud Functions\nCloud SQL\nGKE\nBigQuery\nEventarc\nService Usage\nFirebase Auth"]
         end
 
         subgraph Docker ["Docker-backed"]
-            C["Managed Kafka\n(Redpanda)"]
+            C["Managed Kafka (Redpanda)\nCloud SQL (Postgres)\nCloud Run\nGKE (k3s)"]
         end
 
         Router --> GRPC
@@ -187,31 +194,34 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Category | Services |
 |---|---|
 | Object and document storage | Cloud Storage (GCS), Firestore, Datastore |
-| Messaging | Pub/Sub, Managed Kafka |
-| Security and identity | Secret Manager, Cloud KMS, IAM |
+| Messaging and events | Pub/Sub, Managed Kafka, Eventarc |
+| Security and identity | Secret Manager, Cloud KMS, IAM, IAM Service Account Credentials, Firebase Auth (Identity Platform) |
 | Container orchestration | GKE (Kubernetes Engine) |
 | Serverless control planes | Cloud Run, Cloud Functions |
 | Task scheduling | Cloud Tasks, Cloud Scheduler |
 | Databases | Cloud SQL for PostgreSQL |
 | Analytics | BigQuery (Phase 1) |
 | Observability | Cloud Logging, Cloud Monitoring |
+| API management | Service Usage, Cloud Resource Manager (minimal `projects.get`) |
 
 <details>
 <summary>Detailed service notes</summary>
 
 | Service | Protocol | Notable features |
 |---|---|---|
-| **Cloud Storage (GCS)** | REST XML + REST JSON | Buckets, objects, multipart upload, object compose, ACLs, bucket IAM, conditional requests (preconditions), versioning, lifecycle, CORS, pre-signed URLs (V4) |
-| **Pub/Sub** | gRPC | Topics, subscriptions, publish, pull, streaming pull, push delivery, snapshots, seek, field masks on update |
+| **Cloud Storage (GCS)** | REST XML + REST JSON | Buckets, objects, multipart upload, object compose, ACLs, bucket IAM, conditional requests (preconditions), versioning, lifecycle, CORS, pre-signed URLs (V4), batch API, Pub/Sub object notifications, customer-supplied encryption keys (CSEK) |
+| **Pub/Sub** | gRPC + REST JSON | Topics, subscriptions, publish, pull, streaming pull, push delivery, snapshots, seek, field masks on update, subscription filters (attribute filter language) |
 | **Firestore** | gRPC | Documents, collections, queries (all operators), field transforms, aggregation (COUNT), transactions, batch writes, real-time listeners (`listen` stream) |
 | **Datastore** | HTTP/protobuf | Entities, structured queries, GQL queries, aggregation (COUNT), transactions, GQL named/positional bindings |
 | **Secret Manager** | gRPC | Secrets, versioning, access, `versions/latest` alias, disable/enable/destroy, IAM bindings |
 | **Cloud Logging** | gRPC + REST JSON | Structured log ingestion (`WriteLogEntries`), read-back (`ListLogEntries`) with a practical filter subset (logName, severity, resource.type, timestamp, labels), `ListLogs`, `DeleteLog`; text/JSON payloads |
 | **Cloud KMS** | gRPC + REST JSON | Key rings, crypto keys, key versions, symmetric encrypt/decrypt (AES-256-GCM), asymmetric sign (EC P-256, RSA PKCS1) and decrypt (RSA-OAEP), `GetPublicKey`, `GenerateRandomBytes`, CRC32C integrity fields |
 | **IAM** | REST JSON | Service accounts, RSA-2048 key pairs (JSON key file format), policy bindings, `SignBlob` (V4 signed URLs) |
+| **IAM Service Account Credentials** | REST JSON | `generateAccessToken` (`iamcredentials.googleapis.com` v1) for service-account impersonation with scopes and lifetime; tokens are opaque emulator stubs |
 | **Managed Kafka** | REST JSON | Clusters, topics, consumer groups; Redpanda-backed or mock mode |
 | **GKE (Kubernetes Engine)** | REST JSON | Clusters and operations (`container.googleapis.com` v1); real k3s clusters via Docker (`rancher/k3s`) or mock mode. Reached by SDKs/gcloud through host-based routing (`container.*`) or the `/container/v1` path prefix |
-| **Cloud Run** | REST JSON | Services, IAM policies, revisions, long-running operations; control plane by default, experimental Docker-backed invocation when enabled |
+| **Cloud Run** | REST JSON | Services, IAM policies, revisions, long-running operations; Docker-backed invocation on by default (set `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK=true` for control plane only) |
+| **Eventarc** | REST JSON | Trigger CRUD (`eventarc.googleapis.com` v1); delivers CloudEvents from Pub/Sub publishes and GCS object events to Cloud Run and HTTP endpoint destinations |
 | **Cloud Functions** | REST JSON | Functions, source upload URL generation, long-running operations; control plane only, no runtime invocation |
 | **Cloud SQL for PostgreSQL** | REST JSON | Instances (Postgres), control-plane lifecycle, long-running operations |
 | **Cloud Tasks** | gRPC | Queues (rate limits, retry config, pause/resume/purge), tasks (HTTP and App Engine targets, schedule time), `RunTask`; control plane only, tasks are tracked but not dispatched |
@@ -232,6 +242,7 @@ floci-gcp uses real Docker containers when in-process emulation would reduce fid
 | Managed Kafka | `redpandadata/redpanda:latest` | Kafka-compatible broker via Redpanda | `FLOCI_GCP_SERVICES_KAFKA_MOCK` |
 | Cloud SQL for PostgreSQL | `postgres:15.18-alpine` (15–18) | PostgreSQL engine, JDBC-compatible access | `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` |
 | Cloud Run | User-specified container image | Image-based service execution and request serving | `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK` |
+| GKE (Kubernetes Engine) | `rancher/k3s:latest` | Real k3s Kubernetes clusters reachable via kubectl | `FLOCI_GCP_SERVICES_GKE_MOCK` |
 
 Docker-backed services require the Docker socket:
 
@@ -251,6 +262,7 @@ docker run -d --name floci-gcp \
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES16_IMAGE` | `postgres:16.14-alpine` |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES17_IMAGE` | `postgres:17.10-alpine` |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_POSTGRES18_IMAGE` | `postgres:18.4-alpine` |
+| `FLOCI_GCP_SERVICES_GKE_DEFAULT_IMAGE` | `rancher/k3s:latest` |
 
 ## Persistence and Storage Modes
 
@@ -487,6 +499,8 @@ gcloud secrets versions access latest --secret=my-secret
 
 Use `GenericContainer` to start an isolated floci-gcp instance directly from your tests. This avoids shared state, manual daemon setup, and port conflicts.
 
+The emulator also ships helper endpoints for test harnesses: `GET /health` (readiness, also at `/_floci-gcp/health`), `GET /_floci-gcp/info` (build and service info), and `POST /_floci-gcp/state/reset` (wipe all emulator state between tests without a restart).
+
 <details>
 <summary><strong>Java</strong></summary>
 
@@ -497,7 +511,7 @@ class PubSubIntegrationTest {
     @Container
     static GenericContainer<?> flociGcp = new GenericContainer<>("floci/floci-gcp:latest")
         .withExposedPorts(4588)
-        .waitingFor(Wait.forHttp("/_floci/health").forPort(4588));
+        .waitingFor(Wait.forHttp("/health").forPort(4588));
 
     static TopicAdminClient topicClient;
 
@@ -591,6 +605,7 @@ Google ships a separate emulator per service (`gcloud beta emulators pubsub | fi
 | `gcloud beta emulators datastore start` → `DATASTORE_EMULATOR_HOST=localhost:8081` | `DATASTORE_EMULATOR_HOST=localhost:4588` |
 | _(no official emulator)_ | `STORAGE_EMULATOR_HOST=http://localhost:4588` |
 | _(no official emulator)_ | `SECRET_MANAGER_EMULATOR_HOST=localhost:4588` |
+| Firebase Auth emulator → `FIREBASE_AUTH_EMULATOR_HOST=localhost:9099` | `FIREBASE_AUTH_EMULATOR_HOST=localhost:4588` |
 
 The GCP SDKs skip credential checks automatically when these variables are set, so no code changes are needed — one container replaces the fragmented per-service emulator processes.
 
@@ -612,7 +627,7 @@ Use `latest` for stable releases, a pinned version for reproducible builds, and 
 image: floci/floci-gcp:latest
 
 # Pinned release
-image: floci/floci-gcp:1.0.0
+image: floci/floci-gcp:0.5.0
 
 # Track main
 image: floci/floci-gcp:nightly
@@ -630,6 +645,9 @@ All settings are overridable via environment variables (`FLOCI_GCP_` prefix).
 | `FLOCI_GCP_HOSTNAME` | *(unset)* | Hostname to use in returned URLs when running inside Docker Compose |
 | `FLOCI_GCP_STORAGE_MODE` | `memory` | Storage mode: `memory` · `persistent` · `hybrid` · `wal` |
 | `FLOCI_GCP_STORAGE_PERSISTENT_PATH` | `./data` | Directory for persisted state |
+| `FLOCI_GCP_SERVICES_DOCKER_NETWORK` | *(unset)* | Docker network that spawned sidecar containers join (set to your compose network) |
+| `FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE` | *(empty)* | Name prefix isolating sidecar containers and volumes when multiple instances share one Docker daemon |
+| `FLOCI_GCP_DNS_CONTAINER_FALLBACK_ENABLED` | `true` | Append public DNS resolvers in spawned containers; disable in offline or locked-down networks |
 
 Per-service enable flags (`FLOCI_GCP_SERVICES_<SERVICE>_ENABLED`), mock flags (`*_MOCK`), sidecar images, Docker networking, and DNS suffixes are documented in the full reference.
 
@@ -645,18 +663,35 @@ services:
     image: floci/floci-gcp:latest
     ports:
       - "4588:4588"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FLOCI_GCP_HOSTNAME: floci-gcp
       FLOCI_GCP_BASE_URL: http://floci-gcp:4588
+      # Attach spawned sidecars (Cloud Run, Cloud SQL, Kafka, GKE) to this network
+      FLOCI_GCP_SERVICES_DOCKER_NETWORK: my_project_default
+    networks:
+      my_project_default:
+        aliases:
+          - localhost.floci.io
+          - container.localhost.floci.io
 
   my-app:
     environment:
       PUBSUB_EMULATOR_HOST: floci-gcp:4588
       FIRESTORE_EMULATOR_HOST: floci-gcp:4588
       STORAGE_EMULATOR_HOST: http://floci-gcp:4588
+    networks:
+      - my_project_default
     depends_on:
       - floci-gcp
+
+networks:
+  my_project_default:
+    name: my_project_default
 ```
+
+The network aliases let other containers resolve virtual-hosted URLs (`*.localhost.floci.io`) that the emulator's embedded DNS serves for GCS and Cloud Run.
 
 ## Community
 

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -46,50 +46,29 @@ floci-gcp:
     wal:
       compaction-interval-ms: 30000
 
-  dns:
-    # Extra hostname suffixes resolved to floci-gcp's container IP by the embedded DNS server.
-    # Via env var (comma-separated): FLOCI_GCP_DNS_EXTRA_SUFFIXES=custom.internal,other.domain
-    # extra-suffixes:
-    #   - custom.internal
-
-  docker:
-    log-max-size: "10m"
-    log-max-file: "3"
-    docker-host: unix:///var/run/docker.sock
-    api-timeout: 30s
-    docker-config-path: ""
-    resource-namespace: ""            # Optional; inserted into sidecar container/volume names (floci-gcp-<ns>-...)
-
   services:
     gcs:
       enabled: true
-
     pubsub:
       enabled: true
-
     firestore:
       enabled: true
-
     datastore:
       enabled: true
-
-    secretmanager:
-      enabled: true
-
     iam:
       enabled: true
-
+    iamcredentials:
+      enabled: true
+    secretmanager:
+      enabled: true
     logging:
       enabled: true
-
     kms:
       enabled: true
-
     kafka:
       enabled: true
       mock: false
       default-image: "redpandadata/redpanda:latest"
-
     cloudsql:
       enabled: true
       mock: false
@@ -98,10 +77,8 @@ floci-gcp:
       postgres17-image: "postgres:17.10-alpine"
       postgres18-image: "postgres:18.4-alpine"
       startup-timeout-seconds: 90
-
     cloudtasks:
       enabled: true
-
     cloudrun:
       enabled: true
       mock: false                     # false runs Docker-backed service execution
@@ -112,18 +89,18 @@ floci-gcp:
         operation-timeout: 300s
         cleanup-timeout: 15s
         url-host-suffix:              # Optional; defaults to hostname, then localhost.floci.io
-
     cloudfunctions:
       enabled: true
-
     monitoring:
       enabled: true
-
     scheduler:
       enabled: true
       invocation-enabled: true        # background dispatcher fires due jobs
       tick-interval-seconds: 10
-
+    eventarc:
+      enabled: true
+    bigquery:
+      enabled: true
     gke:
       enabled: true
       mock: false                     # false starts real rancher/k3s clusters
@@ -131,8 +108,44 @@ floci-gcp:
       api-server-base-port: 6550
       api-server-max-port: 6599
       keep-running-on-shutdown: false
-      endpoint-mode: host
+      endpoint-mode: host             # host | network (network for emulator-in-Docker setups)
       docker-network:                 # overrides services.docker-network for k3s sidecars
+    serviceusage:
+      enabled: true
+    resourcemanager:
+      enabled: true
+    firebaseauth:
+      enabled: true
+    # docker-network:                 # shared Docker network for all spawned sidecars (FLOCI_GCP_SERVICES_DOCKER_NETWORK)
+
+  dns:
+    extra-suffixes:
+    # Public resolvers appended after floci-gcp's embedded DNS in every spawned container.
+    # Lets Cloud Run/GKE/sidecar containers resolve public hostnames even if the embedded
+    # forwarder cannot answer. Disable in offline/locked-down networks where these
+    # resolvers are blocked.
+    container-fallback-enabled: true              # FLOCI_GCP_DNS_CONTAINER_FALLBACK_ENABLED
+    container-fallback-servers:                   # FLOCI_GCP_DNS_CONTAINER_FALLBACK_SERVERS=1.1.1.1,1.0.0.1
+      - 8.8.8.8
+      - 8.8.4.4
+
+  docker:
+    log-max-size: "10m"
+    log-max-file: "3"
+    docker-host: "unix:///var/run/docker.sock"
+    api-timeout: 30s
+    # docker-config-path:                         # directory containing Docker's config.json for registry auth
+    resource-namespace: ""          # FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE; scopes sidecar container/volume names
+    # image-registry-base: mirror.example.com     # FLOCI_GCP_DOCKER_IMAGE_REGISTRY_BASE; prefixes every launched image
+    # registry-credentials:                       # explicit credentials for private registries
+    #   - server: myregistry.example.com
+    #     username: user
+    #     password: secret
+
+  init-hooks:
+    shell-executable: /bin/sh
+    shutdown-grace-period-seconds: 2
+    timeout-seconds: 30
 ```
 
 ## Disabling Services

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -5,10 +5,14 @@ floci-gcp is distributed as a Docker image. All configuration is done through en
 ## Quick Start
 
 ```bash
-docker run --rm -p 4588:4588 floci/floci-gcp:latest
+docker run --rm -p 4588:4588 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  floci/floci-gcp:latest
 ```
 
 All GCP services are immediately available at `http://localhost:4588`.
+
+The Docker socket mount lets floci-gcp spawn sidecar containers for the Docker-backed services (Cloud Run execution, Cloud SQL, Managed Kafka, GKE). Omit it if you only need the in-process services, or set the per-service `*_MOCK` flags to `true`.
 
 ## Docker Compose
 
@@ -57,9 +61,17 @@ services:
     image: floci/floci-gcp:latest
     ports:
       - "4588:4588"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FLOCI_GCP_HOSTNAME: floci-gcp       # (1)
       FLOCI_GCP_BASE_URL: http://floci-gcp:4588
+      FLOCI_GCP_SERVICES_DOCKER_NETWORK: my_project_default   # (2)
+    networks:
+      my_project_default:
+        aliases:
+          - localhost.floci.io
+          - container.localhost.floci.io
 
   my-app:
     build: .
@@ -69,11 +81,18 @@ services:
       DATASTORE_EMULATOR_HOST: floci-gcp:4588
       STORAGE_EMULATOR_HOST: http://floci-gcp:4588
       SECRET_MANAGER_EMULATOR_HOST: floci-gcp:4588
+    networks:
+      - my_project_default
     depends_on:
       - floci-gcp
+
+networks:
+  my_project_default:
+    name: my_project_default
 ```
 
 1. Must match the Compose service name so other containers can resolve it by DNS.
+2. Attaches spawned sidecar containers (Cloud Run, Cloud SQL, Kafka, GKE) to the Compose network so both floci-gcp and your app can reach them by name. The `localhost.floci.io` aliases let other containers resolve virtual-hosted URLs served by floci-gcp's embedded DNS.
 
 !!! tip "CI pipelines"
     In GitHub Actions or GitLab CI where both your app and floci-gcp run as `services`, set `FLOCI_GCP_HOSTNAME` to the service name (e.g. `floci-gcp`) and point your GCP SDKs at `floci-gcp:4588`.

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -43,6 +43,8 @@ floci-gcp's embedded DNS server runs inside the container and resolves GCS virtu
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_GCP_DNS_EXTRA_SUFFIXES` | _(none)_ | Comma-separated list of additional hostname suffixes to resolve to floci-gcp's container IP |
+| `FLOCI_GCP_DNS_CONTAINER_FALLBACK_ENABLED` | `true` | Append public resolvers after the embedded DNS in every spawned container so sidecars (Cloud Run, GKE, Kafka) can resolve public hostnames. Disable in offline or locked-down networks where these resolvers are blocked |
+| `FLOCI_GCP_DNS_CONTAINER_FALLBACK_SERVERS` | `8.8.8.8,8.8.4.4` | The fallback resolvers appended when container fallback is enabled |
 
 ---
 
@@ -58,11 +60,14 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_DATASTORE_ENABLED` | `true` | Datastore |
 | `FLOCI_GCP_SERVICES_SECRETMANAGER_ENABLED` | `true` | Secret Manager |
 | `FLOCI_GCP_SERVICES_IAM_ENABLED` | `true` | IAM |
+| `FLOCI_GCP_SERVICES_IAMCREDENTIALS_ENABLED` | `true` | IAM Service Account Credentials (`generateAccessToken`) |
 | `FLOCI_GCP_SERVICES_LOGGING_ENABLED` | `true` | Cloud Logging |
 | `FLOCI_GCP_SERVICES_KMS_ENABLED` | `true` | Cloud KMS |
 | `FLOCI_GCP_SERVICES_MONITORING_ENABLED` | `true` | Cloud Monitoring |
 | `FLOCI_GCP_SERVICES_CLOUDTASKS_ENABLED` | `true` | Cloud Tasks |
 | `FLOCI_GCP_SERVICES_SCHEDULER_ENABLED` | `true` | Cloud Scheduler |
+| `FLOCI_GCP_SERVICES_SCHEDULER_INVOCATION_ENABLED` | `true` | Fire due Scheduler jobs in the background (disable for control plane only) |
+| `FLOCI_GCP_SERVICES_SCHEDULER_TICK_INTERVAL_SECONDS` | `10` | How often the Scheduler background dispatcher checks for due jobs |
 | `FLOCI_GCP_SERVICES_KAFKA_ENABLED` | `true` | Managed Service for Apache Kafka |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_ENABLED` | `true` | Cloud SQL for PostgreSQL |
 | `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` | `false` | Mock mode — no Docker-backed PostgreSQL data-plane instances |
@@ -75,6 +80,12 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_CLEANUP_TIMEOUT` | `15s` | Maximum time to wait for best-effort Docker cleanup after an operation is already resolved |
 | `FLOCI_GCP_SERVICES_CLOUDRUN_EXECUTION_URL_HOST_SUFFIX` | `localhost.floci.io` or `FLOCI_GCP_HOSTNAME` | Host suffix used for generated Cloud Run execution URLs |
 | `FLOCI_GCP_SERVICES_CLOUDFUNCTIONS_ENABLED` | `true` | Cloud Functions |
+| `FLOCI_GCP_SERVICES_GKE_ENABLED` | `true` | GKE (Kubernetes Engine) |
+| `FLOCI_GCP_SERVICES_BIGQUERY_ENABLED` | `true` | BigQuery |
+| `FLOCI_GCP_SERVICES_SERVICEUSAGE_ENABLED` | `true` | Service Usage |
+| `FLOCI_GCP_SERVICES_RESOURCEMANAGER_ENABLED` | `true` | Cloud Resource Manager (minimal `projects.get`) |
+| `FLOCI_GCP_SERVICES_FIREBASEAUTH_ENABLED` | `true` | Firebase Auth (Identity Platform) |
+| `FLOCI_GCP_SERVICES_EVENTARC_ENABLED` | `true` | Eventarc |
 
 ### Sidecar containers
 
@@ -113,7 +124,7 @@ Some services (e.g. Managed Kafka) start real sidecar containers via the host Do
 | `FLOCI_GCP_SERVICES_GKE_API_SERVER_BASE_PORT` | `6550` | Lowest host port assigned to a cluster's Kubernetes API server |
 | `FLOCI_GCP_SERVICES_GKE_API_SERVER_MAX_PORT` | `6599` | Highest host port assigned to a cluster's Kubernetes API server |
 | `FLOCI_GCP_SERVICES_GKE_KEEP_RUNNING_ON_SHUTDOWN` | `false` | When `true`, leave spawned k3s containers running after floci-gcp shuts down |
-| `FLOCI_GCP_SERVICES_GKE_ENDPOINT_MODE` | `host` | How the cluster endpoint is advertised to `kubectl` (`host` for a reachable `host:port`) |
+| `FLOCI_GCP_SERVICES_GKE_ENDPOINT_MODE` | `host` | How the cluster endpoint is advertised to `kubectl`: `host` (a reachable `host:port`) or `network` (the container's network address, for emulator-in-Docker setups) |
 | `FLOCI_GCP_SERVICES_GKE_DOCKER_NETWORK` | _(none)_ | Overrides `FLOCI_GCP_SERVICES_DOCKER_NETWORK` for GKE/k3s sidecars only |
 
 ---
@@ -141,6 +152,9 @@ These variables control the Docker daemon used by floci-gcp's embedded DNS and s
 | `FLOCI_GCP_DOCKER_API_TIMEOUT` | `30s` | Per-call Docker API timeout before floci-gcp resets the Docker client |
 | `FLOCI_GCP_DOCKER_LOG_MAX_SIZE` | `10m` | Log rotation max size for spawned containers |
 | `FLOCI_GCP_DOCKER_LOG_MAX_FILE` | `3` | Number of rotated log files to keep |
+| `FLOCI_GCP_DOCKER_IMAGE_REGISTRY_BASE` | _(none)_ | Registry prefix applied to every sidecar image floci-gcp launches (e.g. an internal mirror like `mirror.example.com`) |
+
+Private-registry credentials (`floci-gcp.docker.registry-credentials`, a list of `server`/`username`/`password` entries) are best set in an `application.yml` — see the [application.yml reference](./advanced/application-yml.md).
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -94,7 +94,11 @@ Quick summary:
 The `./compatibility-tests/` directory contains SDK-based integration tests. Run them before submitting changes that affect GCP protocol behavior:
 
 ```bash
-docker compose -f docker-compose-test.yml up --build
+cd compatibility-tests
+cp env.example .env
+just setup
+just test-all          # SDK suites (Java, Node, Python, Go, gcloud)
+just test-all-iac      # Terraform / OpenTofu
 ```
 
 If the compatibility test suite is unavailable in your environment, state that explicitly in the PR description.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,6 +23,8 @@ docker pull floci/floci-gcp:latest
 | `x.y.z` | Pinned release |
 | `nightly` | Latest nightly build (floating) |
 | `nightly-mmddyyyy` | Pinned nightly |
+| `latest-compat` / `x.y.z-compat` | JVM-based compatibility variant for platforms where the native image is unavailable |
+| `nightly-compat` / `nightly-mmddyyyy-compat` | Nightly compatibility variant |
 
 ## Choosing a tag
 
@@ -62,7 +64,7 @@ java -jar target/quarkus-app/quarkus-run.jar
 
 ```bash
 ./mvnw clean package -Pnative -DskipTests
-./target/floci-gcp-runner
+./target/floci-gcp-*-runner   # e.g. ./target/floci-gcp-0.5.0-runner
 ```
 
 !!! note

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -14,9 +14,13 @@ This guide gets floci-gcp running and verifies that GCP SDK and gcloud CLI comma
           - "4588:4588"
         volumes:
           - ./data:/app/data
+          # Enables Docker-backed services (Cloud Run, Cloud SQL, Kafka, GKE)
+          - /var/run/docker.sock:/var/run/docker.sock
         environment:
           FLOCI_GCP_HOSTNAME: floci-gcp
           FLOCI_GCP_BASE_URL: http://floci-gcp:4588
+          # Keep state across restarts in the mounted ./data volume
+          FLOCI_GCP_STORAGE_MODE: hybrid
     ```
 
     ```bash
@@ -28,8 +32,11 @@ This guide gets floci-gcp running and verifies that GCP SDK and gcloud CLI comma
     ```bash
     docker run -d --name floci-gcp \
       -p 4588:4588 \
+      -v /var/run/docker.sock:/var/run/docker.sock \
       floci/floci-gcp:latest
     ```
+
+    The Docker socket mount enables the Docker-backed services (Cloud Run execution, Cloud SQL, Managed Kafka, GKE); omit it if you only need the in-process services.
 
 === "Build from source"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | Service | Protocol | Notable features |
 |---|---|---|
 | **Cloud Storage (GCS)** | REST XML + REST JSON | Buckets, objects, multipart upload, object compose, ACLs, bucket IAM, conditional requests, versioning, pre-signed URLs |
-| **Pub/Sub** | gRPC | Topics, subscriptions, publish, pull, streaming pull, push delivery, snapshots, seek |
+| **Pub/Sub** | gRPC + REST | Topics, subscriptions, publish, pull, streaming pull, push delivery, snapshots, seek, subscription filters |
 | **Firestore** | gRPC | Documents, collections, queries, field transforms, aggregation, transactions, real-time listeners |
 | **Datastore** | HTTP/protobuf | Entities, structured queries, GQL queries, aggregation, transactions |
 | **Secret Manager** | gRPC | Secrets, versions, access, disable/enable/destroy, IAM bindings |
@@ -23,12 +23,19 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | **Cloud KMS** | gRPC + REST | Key rings, crypto keys, versions, symmetric encrypt/decrypt, asymmetric sign/decrypt, `GenerateRandomBytes` |
 | **IAM** | REST | Service accounts, RSA-2048 keys, policy bindings, SignBlob (V4 signed URLs) |
 | **Managed Kafka** | REST | Clusters, topics, consumer groups (Redpanda-backed or mock mode) |
-| **Cloud Run** | REST | Service create/get/list/delete, IAM policy operations, revisions, LRO polling; control plane by default, experimental Docker-backed invocation and GCS volume mounts when enabled |
+| **Cloud Run** | REST | Service create/get/list/delete, IAM policy operations, revisions, LRO polling; Docker-backed invocation on by default (mock flag for control plane only) |
 | **Cloud Functions** | REST | Function create/get/list/delete, upload URL generation, LRO polling; control plane only |
-| **Cloud SQL for PostgreSQL** | REST | Instance lifecycle (Postgres), LRO polling; control plane only |
+| **Cloud SQL for PostgreSQL** | REST | Instance lifecycle (Postgres), LRO polling; Docker-backed PostgreSQL data plane on by default (mock flag for control plane only) |
 | **Cloud Tasks** | gRPC | Queues (rate limits, retry, pause/resume/purge), tasks (HTTP/App Engine targets), `RunTask`; control plane only |
 | **Cloud Scheduler** | gRPC + REST | Cron jobs (Pub/Sub, HTTP, App Engine targets), `Pause`/`Resume`/`RunJob`, unix-cron + time zones; background dispatcher fires due jobs |
 | **Cloud Monitoring** | gRPC + REST | Metric descriptors, monitored resource descriptors, time series write (`CreateTimeSeries`) and read (`ListTimeSeries`) |
+| **GKE (Kubernetes Engine)** | REST | Cluster and operation APIs (`container.googleapis.com` v1); real k3s clusters via Docker or mock mode |
+| **BigQuery (Phase 1)** | REST | Datasets, tables, `insertAll`/`tabledata.list`, query jobs over a SQL subset |
+| **Service Usage** | REST | Enable/disable/list project services; backs Terraform `google_project_service` |
+| **Firebase Auth (Identity Platform)** | REST | Identity Toolkit v1 sign-up/sign-in, emulator JWTs, admin user CRUD |
+| **Eventarc** | REST | Trigger CRUD; delivers CloudEvents from Pub/Sub and GCS events to Cloud Run and HTTP endpoints |
+| **IAM Credentials** | REST | `generateAccessToken` for service-account impersonation (shape-only stub tokens) |
+| **Resource Manager** | REST | Minimal `projects.get` for provider project lookups |
 
 ## Why floci-gcp?
 
@@ -52,9 +59,13 @@ services:
       - "4588:4588"
     volumes:
       - ./data:/app/data
+      # Enables Docker-backed services (Cloud Run, Cloud SQL, Kafka, GKE)
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FLOCI_GCP_HOSTNAME: floci-gcp
       FLOCI_GCP_BASE_URL: http://floci-gcp:4588
+      # Keep state across restarts in the mounted ./data volume
+      FLOCI_GCP_STORAGE_MODE: hybrid
 ```
 
 ```bash

--- a/docs/services/eventarc.md
+++ b/docs/services/eventarc.md
@@ -1,0 +1,83 @@
+# Eventarc
+
+floci-gcp emulates the [Eventarc](https://cloud.google.com/eventarc) API (`eventarc.googleapis.com` v1) with REST JSON: trigger CRUD plus in-process event delivery. When a Pub/Sub message is published or a GCS object event fires inside the emulator, matching triggers receive a CloudEvents HTTP request at their destination.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_EVENTARC_ENABLED` | `true` | Enable or disable the Eventarc service |
+
+## Endpoint
+
+REST JSON under `/v1/projects/{project}/locations/{location}`:
+
+| Operation | Method and path |
+|---|---|
+| Create trigger | `POST /triggers?triggerId=...` (supports `validateOnly`) |
+| List triggers | `GET /triggers` (with `pageSize`/`pageToken`) |
+| Get trigger | `GET /triggers/{id}` |
+| Update trigger | `PATCH /triggers/{id}` (supports `updateMask`, `allowMissing`, `validateOnly`) |
+| Delete trigger | `DELETE /triggers/{id}` (supports `allowMissing`, `validateOnly`) |
+| List providers | `GET /providers` — returns `storage.googleapis.com` and `pubsub.googleapis.com` |
+| List channels | `GET /channels` — always empty (stub) |
+
+Mutations return completed `google.longrunning.Operation` responses, readable via the shared operations surface at `/v2/projects/{project}/locations/{location}/operations`.
+
+## Event Delivery
+
+Matching triggers receive a CloudEvents **binary-mode** HTTP POST (`ce-id`, `ce-source`, `ce-specversion: 1.0`, `ce-type`, `ce-time` headers):
+
+- **Pub/Sub** — event type `google.cloud.pubsub.topic.v1.messagePublished`, source `//pubsub.googleapis.com/{topic}`, body in push-delivery format (`message` with base64 `data`, `attributes`, `messageId`, `publishTime`).
+- **Cloud Storage** — source `//storage.googleapis.com/projects/_/buckets/{bucket}`, body is the object metadata JSON.
+
+Supported destinations: **Cloud Run services** (resolved through the emulator's Cloud Run URL routing, honoring `path`) and **HTTP endpoints** (`httpEndpoint.uri`).
+
+## Quick Start
+
+=== "Java"
+
+    ```java
+    EventarcClient client = EventarcClient.create(
+        EventarcSettings.newHttpJsonBuilder()
+            .setEndpoint("http://localhost:4588")
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .build());
+
+    client.createTriggerAsync(CreateTriggerRequest.newBuilder()
+            .setParent("projects/my-project/locations/us-central1")
+            .setTriggerId("pubsub-trigger")
+            .setTrigger(Trigger.newBuilder()
+                .addEventFilters(EventFilter.newBuilder()
+                    .setAttribute("type")
+                    .setValue("google.cloud.pubsub.topic.v1.messagePublished"))
+                .setDestination(Destination.newBuilder()
+                    .setCloudRun(CloudRun.newBuilder()
+                        .setService("hello-run").setRegion("us-central1"))))
+            .build())
+        .get();
+    ```
+
+=== "REST"
+
+    ```bash
+    curl -X POST \
+      'http://localhost:4588/v1/projects/my-project/locations/us-central1/triggers?triggerId=gcs-trigger' \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "eventFilters": [
+          {"attribute": "type", "value": "google.cloud.storage.object.v1.finalized"},
+          {"attribute": "bucket", "value": "my-bucket"}
+        ],
+        "destination": {"cloudRun": {"service": "hello-run", "region": "us-central1"}}
+      }'
+    ```
+
+## Not Yet Supported
+
+- GKE, Workflows, and Cloud Functions destinations (logged and dropped)
+- `match-path-pattern` operators — event filters use exact-value matching (with a last-segment fallback for `topic`/`bucket` attributes)
+- Delivery retries and dead-lettering — delivery is fire-and-forget; failures are logged, not surfaced
+- Channels and third-party providers (stubs)
+
+A trigger with no `eventFilters` never matches. A trigger whose `transport.pubsub` topic matches the published topic receives the event even if its filters do not match.

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -199,6 +199,14 @@ The embedded DNS server resolves `*.localhost.floci.io` to floci-gcp's container
 - `PatchObject` (update metadata: `contentType`, `contentDisposition`, `contentEncoding`, `contentLanguage`, custom metadata)
 - `ComposeObject` (concatenate up to 32 source objects)
 - Pre-signed GET/PUT URLs (V4 signature via IAM `SignBlob`)
+- Batch requests (`/batch/storage/v1`)
+- Customer-supplied encryption keys (CSEK)
+
+Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly — the emulator preserves URI-encoded names exactly as real GCS does.
+
+**Pub/Sub notifications (REST JSON):**
+
+- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`) — object changes publish to the configured Pub/Sub topic in the local backend
 
 **Object ACLs (REST JSON):**
 
@@ -210,3 +218,5 @@ The embedded DNS server resolves `*.localhost.floci.io` to floci-gcp's container
 - `ifGenerationMatch` / `ifGenerationNotMatch`
 - `ifMetagenerationMatch` / `ifMetagenerationNotMatch`
 - Returns HTTP 412 on precondition failure
+- Enforced atomically on the write paths (insert, patch/update, resumable finalize) under a per-object lock, with a monotonic generation sequence — concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)
+- Not yet enforced on `delete`, `compose`, `copyTo`, and `rewriteTo` (params are accepted and ignored)

--- a/docs/services/iam-credentials.md
+++ b/docs/services/iam-credentials.md
@@ -1,0 +1,45 @@
+# IAM Service Account Credentials
+
+floci-gcp emulates the [IAM Service Account Credentials](https://cloud.google.com/iam/docs/reference/credentials/rest) API (`iamcredentials.googleapis.com` v1) with REST JSON, supporting `generateAccessToken` for service-account impersonation flows (for example `ImpersonatedCredentials` in the GCP SDKs).
+
+Since the emulator accepts all requests without credential validation, impersonation is **shape-only**: the endpoint returns a wire-compatible response, but the vended token is an opaque stub (`floci-gcp-impersonated-<uuid>`) that no other emulated service validates.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_IAMCREDENTIALS_ENABLED` | `true` | Enable or disable the IAM Credentials service |
+
+## Endpoint
+
+```
+POST /v1/projects/-/serviceAccounts/{serviceAccount}:generateAccessToken
+```
+
+Request body:
+
+| Field | Behavior |
+|---|---|
+| `scope` | Required. Must include `https://www.googleapis.com/auth/cloud-platform` or `https://www.googleapis.com/auth/devstorage.read_write`; other scopes are rejected with `INVALID_ARGUMENT` |
+| `lifetime` | Optional `"<n>s"` duration string. Defaults to `3600s`; values above 3600s are capped; non-positive values are rejected |
+| `delegates` | Accepted and ignored (no delegation chain is enforced) |
+
+Response: `{ "accessToken": "...", "expireTime": "..." }`.
+
+## Quick Start
+
+```java
+ImpersonatedCredentials credentials = ImpersonatedCredentials.newBuilder()
+    .setSourceCredentials(sourceCredentials)
+    .setTargetPrincipal("my-sa@floci-local.iam.gserviceaccount.com")
+    .setScopes(List.of("https://www.googleapis.com/auth/cloud-platform"))
+    .setLifetime(3600)
+    .setIamEndpointOverride("http://localhost:4588")
+    .build();
+```
+
+## Not Yet Supported
+
+- `generateIdToken`, `signBlob`, `signJwt` on this surface (IAM's own `signBlob` lives in the [IAM service](iam.md))
+- Scope-based authorization of the vended token (tokens are never validated)
+- Delegation chains (`delegates` is ignored)

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -106,3 +106,7 @@ URL signedUrl = storage.signUrl(
 - `SetIamPolicy`
 - `TestIamPermissions`
 - `SignBlob`
+
+## Related: Service Account Impersonation
+
+`generateAccessToken` (the `iamcredentials.googleapis.com` API used by `ImpersonatedCredentials`) is provided by the separate [IAM Credentials service](iam-credentials.md), toggled with `FLOCI_GCP_SERVICES_IAMCREDENTIALS_ENABLED`.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -7,13 +7,14 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | Service | Protocol | Endpoint |
 |---|---|---|
 | [Cloud Storage (GCS)](gcs.md) | REST XML (objects) + REST JSON (management) | `/{bucket}/{object}`, `/storage/v1/b/{bucket}` |
-| [Pub/Sub](pubsub.md) | gRPC | `google.pubsub.v1.Publisher`, `google.pubsub.v1.Subscriber` |
+| [Pub/Sub](pubsub.md) | gRPC + REST JSON | `google.pubsub.v1.Publisher`, `google.pubsub.v1.Subscriber`, `/v1/projects/{project}/topics` |
 | [Firestore](firestore.md) | gRPC | `google.firestore.v1.Firestore` |
 | [Datastore](datastore.md) | HTTP/protobuf | `/v1/projects/{project}:{method}` |
 | [Secret Manager](secret-manager.md) | gRPC | `google.cloud.secretmanager.v1.SecretManagerService` |
 | [Cloud Logging](logging.md) | gRPC + REST JSON | `google.logging.v2.LoggingServiceV2`, `/v2/entries:write`, `/v2/entries:list` |
 | [Cloud KMS](kms.md) | gRPC + REST JSON | `google.cloud.kms.v1.KeyManagementService`, `/v1/projects/{project}/locations/{location}/keyRings` |
 | [IAM](iam.md) | REST JSON | `/v1/projects/{project}/serviceAccounts` |
+| [IAM Credentials](iam-credentials.md) | REST JSON | `/v1/projects/-/serviceAccounts/{sa}:generateAccessToken` |
 | [Managed Kafka](managed-kafka.md) | REST JSON | `/v1/projects/{project}/locations/{location}/clusters` |
 | [GKE (Kubernetes Engine)](gke.md) | REST JSON | `container.*` host or `/container/v1/projects/{project}/locations/{location}/clusters` |
 | [Cloud SQL for PostgreSQL](cloud-sql-postgres.md) | REST JSON | `/v1/projects/{project}/instances` |
@@ -22,7 +23,9 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud Tasks](cloud-tasks.md) | gRPC | `google.cloud.tasks.v2.CloudTasks` |
 | [Cloud Scheduler](scheduler.md) | gRPC + REST JSON | `google.cloud.scheduler.v1.CloudScheduler`, `/v1/projects/{project}/locations/{location}/jobs` |
 | [Cloud Monitoring](cloud-monitoring.md) | gRPC + REST JSON | `google.monitoring.v3.MetricService`, `/v3/projects/{project}` |
-| [Service Usage](service-usage.md) | REST JSON | `/v1/projects/{project}/services` (+ minimal Resource Manager `/v1/projects/{projectId}`) |
+| [Service Usage](service-usage.md) | REST JSON | `/v1/projects/{project}/services` |
+| [Resource Manager](service-usage.md#cloud-resource-manager-companion) | REST JSON | `/v1/projects/{projectId}` (minimal `projects.get`) |
+| [Eventarc](eventarc.md) | REST JSON | `/v1/projects/{project}/locations/{location}/triggers` |
 | [Firebase Auth](firebase-auth.md) | REST JSON | `/identitytoolkit.googleapis.com/v1/accounts:*`, `/securetoken.googleapis.com/v1/token` |
 | [BigQuery (Phase 1)](bigquery.md) | REST JSON | `/bigquery/v2/projects/{project}` |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Cloud Logging: services/logging.md
     - Cloud KMS: services/kms.md
     - IAM: services/iam.md
+    - IAM Credentials: services/iam-credentials.md
     - Managed Kafka: services/managed-kafka.md
     - GKE (Kubernetes Engine): services/gke.md
     - Cloud SQL for PostgreSQL: services/cloud-sql-postgres.md
@@ -85,6 +86,7 @@ nav:
     - Cloud Tasks: services/cloud-tasks.md
     - Cloud Scheduler: services/scheduler.md
     - Cloud Monitoring: services/cloud-monitoring.md
+    - Eventarc: services/eventarc.md
     - Service Usage: services/service-usage.md
     - Firebase Auth: services/firebase-auth.md
     - BigQuery: services/bigquery.md


### PR DESCRIPTION
## Summary

Brings the docs site and README in line with the emulator's current capabilities:

- New service pages: **Eventarc** (with Java/REST quick-start examples) and **IAM Credentials** (`generateAccessToken`), with nav and index entries
- Configuration references updated: new env vars (`FLOCI_GCP_SERVICES_DOCKER_NETWORK`, `FLOCI_GCP_DOCKER_RESOURCE_NAMESPACE`, DNS container fallback, registry base/credentials, per-service enable flags), reorganized `application.yml` reference
- Docker/Compose guidance: docker socket mount for Docker-backed services, sidecar network wiring with `localhost.floci.io` aliases
- README/index tables now cover GKE, BigQuery, Service Usage, Firebase Auth, and Resource Manager; GCS page documents batch API, CSEK, Pub/Sub notifications, and precondition enforcement details; contributing page points at the `just`-based compat suite; health endpoint corrected to `/health`

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

Documentation only — no wire-protocol changes.

## Checklist

- [x] `./mvnw test` passes locally — not run; docs-only change, no code touched
- [ ] New or updated integration test added — N/A, docs only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)