### PR TITLE
fix(pubsub): reject subscription filter changes after creation

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
@@ -13,6 +13,7 @@ import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.FieldMask;
 import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.DetachSubscriptionRequest;
 import com.google.pubsub.v1.ProjectSubscriptionName;
@@ -24,6 +25,7 @@ import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.ReceivedMessage;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.UpdateSubscriptionRequest;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.junit.jupiter.api.AfterAll;
@@ -498,6 +500,64 @@ class PubSubTest {
                     .setFilter("this is not a filter (((")
                     .build()))
                     .isInstanceOf(InvalidArgumentException.class);
+        } finally {
+            try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
+            try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
+        }
+    }
+
+    @Test
+    @Order(17)
+    void filterCannotBeModifiedAfterCreation() {
+        String topicId = TestFixtures.uniqueName("immutable-filter-topic");
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, topicId);
+        ProjectSubscriptionName subName =
+                ProjectSubscriptionName.of(PROJECT_ID, TestFixtures.uniqueName("immutable-filter-sub"));
+
+        topicAdminClient.createTopic(topicName);
+        subscriptionAdminClient.createSubscription(Subscription.newBuilder()
+                .setName(subName.toString())
+                .setTopic(topicName.toString())
+                .setAckDeadlineSeconds(10)
+                .setFilter("attributes.event_type = \"a\"")
+                .build());
+
+        try {
+            assertThatThrownBy(() -> subscriptionAdminClient.updateSubscription(
+                    UpdateSubscriptionRequest.newBuilder()
+                            .setSubscription(Subscription.newBuilder()
+                                    .setName(subName.toString())
+                                    .setFilter("attributes.event_type = \"b\"")
+                                    .build())
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("filter").build())
+                            .build()))
+                    .isInstanceOf(InvalidArgumentException.class);
+
+            assertThatThrownBy(() -> subscriptionAdminClient.updateSubscription(
+                    UpdateSubscriptionRequest.newBuilder()
+                            .setSubscription(Subscription.newBuilder()
+                                    .setName(subName.toString())
+                                    .setFilter("attributes.event_type = \"a\"")
+                                    .build())
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("filter").build())
+                            .build()))
+                    .as("GCP rejects filter in the update mask even when the value is unchanged")
+                    .isInstanceOf(InvalidArgumentException.class);
+
+            assertThat(subscriptionAdminClient.getSubscription(subName).getFilter())
+                    .isEqualTo("attributes.event_type = \"a\"");
+
+            Subscription relabelled = subscriptionAdminClient.updateSubscription(
+                    UpdateSubscriptionRequest.newBuilder()
+                            .setSubscription(Subscription.newBuilder()
+                                    .setName(subName.toString())
+                                    .putLabels("env", "local")
+                                    .build())
+                            .setUpdateMask(FieldMask.newBuilder().addPaths("labels").build())
+                            .build());
+
+            assertThat(relabelled.getLabelsMap()).containsEntry("env", "local");
+            assertThat(relabelled.getFilter()).isEqualTo("attributes.event_type = \"a\"");
         } finally {
             try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
             try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}

--- a/docs/services/pubsub.md
+++ b/docs/services/pubsub.md
@@ -207,8 +207,20 @@ Rules that mirror GCP:
   `attributes:"みんな"`. Escapes outside a string literal are invalid.
 - A filter must be at most **256 bytes**.
 
-An unparseable filter, or one over the byte limit, is rejected with `INVALID_ARGUMENT` when the
-subscription is created or updated, rather than being accepted and silently ignored.
+An unparseable filter, or one over the byte limit, is rejected with `INVALID_ARGUMENT` at creation
+time, rather than being accepted and silently ignored.
+
+### The filter is immutable
+
+As in GCP, the filter is a property of the subscription that cannot change after creation. A
+`subscriptions.patch` that names `filter` in its update mask is rejected with `INVALID_ARGUMENT`,
+whatever value it carries — GCP rejects on the presence of the field in the mask, not on whether the
+value differs, so restating the current filter fails too. A patch that does not name `filter` in its
+mask succeeds and leaves the filter untouched, even when the request body carries one — the update
+mask governs, so clients that echo a whole subscription back keep working.
+
+To change a filter, follow the same path as in GCP: snapshot the subscription, create a new one with
+the desired filter, `Seek` to the snapshot, move subscribers over, then delete the old subscription.
 
 ## Push Subscriptions
 

--- a/docs/services/pubsub.md
+++ b/docs/services/pubsub.md
@@ -219,6 +219,11 @@ value differs, so restating the current filter fails too. A patch that does not 
 mask succeeds and leaves the filter untouched, even when the request body carries one — the update
 mask governs, so clients that echo a whole subscription back keep working.
 
+GCP requires an update mask on `subscriptions.patch`; floci-gcp also accepts a patch without one and
+treats it as replacing every field. On that path a body carrying the subscription's current filter is
+accepted and the filter is left alone, a body carrying a different one is rejected, and a body
+omitting it leaves the filter in place rather than clearing it.
+
 To change a filter, follow the same path as in GCP: snapshot the subscription, create a new one with
 the desired filter, `Seek` to the snapshot, move subscribers over, then delete the old subscription.
 

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -302,7 +303,7 @@ public class PubSubService {
         StoredSubscription stored = getSubscription(name);
         boolean replaceAll = updateMaskPaths == null || updateMaskPaths.isEmpty();
 
-        if (replaceAll ? filter != null : masked(updateMaskPaths, "filter")) {
+        if (filterChangeRequested(stored.getFilter(), filter, updateMaskPaths)) {
             throw filterNotMutable(stored.getName());
         }
 
@@ -439,6 +440,16 @@ public class PubSubService {
             }
         }
         return messageIds;
+    }
+
+    // A mask makes "filter" itself the trigger, as in GCP. Without a mask GCP rejects the request
+    // outright, so only a value that actually differs is treated as a change here.
+    private static boolean filterChangeRequested(String current, String requested,
+            List<String> updateMaskPaths) {
+        if (updateMaskPaths != null && !updateMaskPaths.isEmpty()) {
+            return masked(updateMaskPaths, "filter");
+        }
+        return requested != null && !Objects.equals(blankToNull(requested), current);
     }
 
     private static GcpException filterNotMutable(String name) {

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -250,14 +250,13 @@ public class PubSubService {
         LOG.infof("updateSubscription name=%s", subProto.getName());
         StoredSubscription stored = getSubscription(subProto.getName());
         if (updateMask.getPathsList().contains("filter")) {
-            SubscriptionFilter.validate(subProto.getFilter());
+            throw filterNotMutable(stored.getName());
         }
         for (String path : updateMask.getPathsList()) {
             switch (path) {
                 case "ack_deadline_seconds" -> stored.setAckDeadlineSeconds(subProto.getAckDeadlineSeconds());
                 case "labels" -> stored.setLabels(subProto.getLabelsMap().isEmpty() ? null
                         : new java.util.HashMap<>(subProto.getLabelsMap()));
-                case "filter" -> stored.setFilter(subProto.getFilter().isEmpty() ? null : subProto.getFilter());
                 case "retain_acked_messages" -> stored.setRetainAckedMessages(subProto.getRetainAckedMessages());
                 case "message_retention_duration" -> {
                     if (subProto.hasMessageRetentionDuration()) {
@@ -303,8 +302,8 @@ public class PubSubService {
         StoredSubscription stored = getSubscription(name);
         boolean replaceAll = updateMaskPaths == null || updateMaskPaths.isEmpty();
 
-        if (replaceAll || masked(updateMaskPaths, "filter")) {
-            SubscriptionFilter.validate(filter);
+        if (replaceAll ? filter != null : masked(updateMaskPaths, "filter")) {
+            throw filterNotMutable(stored.getName());
         }
 
         if (replaceAll || masked(updateMaskPaths, "ack_deadline_seconds")) {
@@ -322,9 +321,6 @@ public class PubSubService {
         }
         if (replaceAll || masked(updateMaskPaths, "message_retention_duration")) {
             stored.setMessageRetentionDuration(blankToNull(messageRetentionDuration));
-        }
-        if (replaceAll || masked(updateMaskPaths, "filter")) {
-            stored.setFilter(blankToNull(filter));
         }
         if (replaceAll || masked(updateMaskPaths, "push_config")) {
             stored.setPushEndpoint(blankToNull(pushEndpoint));
@@ -443,6 +439,12 @@ public class PubSubService {
             }
         }
         return messageIds;
+    }
+
+    private static GcpException filterNotMutable(String name) {
+        LOG.warnf("updateSubscription rejected: filter is not mutable name=%s", name);
+        return GcpException.invalidArgument("Invalid update_mask provided in the "
+                + "UpdateSubscriptionRequest: the 'filter' field in the Subscription is not mutable.");
     }
 
     private boolean matchesFilter(StoredSubscription sub, Map<String, String> attributes) {

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
@@ -248,6 +248,75 @@ class PubSubRestIntegrationTest {
     }
 
     @Test
+    void patchingTheFilterIsRejectedWithInvalidArgument() {
+        String project = "pubsub-rest-filter-immutable-it";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/events").then().statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "topic": "projects/%s/topics/events",
+                          "filter": "attributes.event_type = \\"a\\""
+                        }
+                        """.formatted(project))
+                .when().put(base + "/subscriptions/immutable")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .queryParam("updateMask", "filter")
+                .body("{\"filter\": \"attributes.event_type = \\\"b\\\"\"}")
+                .when().patch(base + "/subscriptions/immutable")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+
+        given()
+                .contentType("application/json")
+                .queryParam("updateMask", "filter")
+                .body("{\"filter\": \"attributes.event_type = \\\"a\\\"\"}")
+                .when().patch(base + "/subscriptions/immutable")
+                .then()
+                .statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+
+        given()
+                .when().get(base + "/subscriptions/immutable")
+                .then()
+                .statusCode(200)
+                .body("filter", equalTo("attributes.event_type = \"a\""));
+
+        given()
+                .contentType("application/json")
+                .queryParam("updateMask", "labels")
+                .body("{\"labels\": {\"env\": \"local\"}}")
+                .when().patch(base + "/subscriptions/immutable")
+                .then()
+                .statusCode(200)
+                .body("labels.env", equalTo("local"))
+                .body("filter", equalTo("attributes.event_type = \"a\""));
+
+        given()
+                .contentType("application/json")
+                .queryParam("updateMask", "labels")
+                .body("""
+                        {
+                          "labels": {"env": "echoed"},
+                          "filter": "attributes.event_type = \\"ignored\\""
+                        }
+                        """)
+                .when().patch(base + "/subscriptions/immutable")
+                .then()
+                .statusCode(200)
+                .body("labels.env", equalTo("echoed"))
+                .body("filter", equalTo("attributes.event_type = \"a\""));
+    }
+
+    @Test
     void unparseableFilterIsRejectedWithInvalidArgument() {
         String project = "pubsub-rest-filter-invalid-it";
         String base = "/v1/projects/" + project;

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
@@ -266,6 +266,35 @@ class PubSubServiceTest {
     }
 
     @Test
+    void updateSubscriptionWithoutUpdateMaskAcceptsTheExistingFilterInTheBody() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        StoredSubscription updated = service.updateSubscription("projects/p1/subscriptions/s1", 0,
+                Map.of("env", "local"), null, null, "attributes.event_type = \"a\"", null, null, null,
+                null, null, null, null, null, null);
+
+        assertEquals("local", updated.getLabels().get("env"));
+        assertEquals("attributes.event_type = \"a\"", updated.getFilter());
+    }
+
+    @Test
+    void updateSubscriptionWithoutUpdateMaskRejectsADifferentFilterInTheBody() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription("projects/p1/subscriptions/s1", 0, null, null, null,
+                        "attributes.event_type = \"b\"", null, null, null, null, null, null, null, null,
+                        null));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertEquals("attributes.event_type = \"a\"",
+                service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
     void updateSubscriptionWithoutUpdateMaskPreservesTheFilter() {
         service.createTopic("projects/p1/topics/t1");
         createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
@@ -275,6 +304,24 @@ class PubSubServiceTest {
                 Map.of("env", "local"), null, null, null, null, null, null, null, null, null, null, null,
                 null);
 
+        assertEquals("attributes.event_type = \"a\"", updated.getFilter());
+    }
+
+    @Test
+    void updateSubscriptionViaFieldMaskIgnoresAFilterOutsideTheUpdateMask() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        StoredSubscription updated = service.updateSubscription(
+                com.google.pubsub.v1.Subscription.newBuilder()
+                        .setName("projects/p1/subscriptions/s1")
+                        .setFilter("attributes.event_type = \"ignored\"")
+                        .putLabels("env", "local")
+                        .build(),
+                com.google.protobuf.FieldMask.newBuilder().addPaths("labels").build());
+
+        assertEquals("local", updated.getLabels().get("env"));
         assertEquals("attributes.event_type = \"a\"", updated.getFilter());
     }
 

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
@@ -193,32 +193,128 @@ class PubSubServiceTest {
     }
 
     @Test
-    void updateSubscriptionRejectsUnparseableFilter() {
+    void updateSubscriptionRejectsChangingTheFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription("projects/p1/subscriptions/s1", 0, null, null, null,
+                        "attributes.event_type = \"b\"", null, null, null, null, null, null, null, null,
+                        List.of("filter")));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertEquals("attributes.event_type = \"a\"",
+                service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void updateSubscriptionRejectsRemovingTheFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription("projects/p1/subscriptions/s1", 0, null, null, null,
+                        "", null, null, null, null, null, null, null, null, List.of("filter")));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertEquals("attributes.event_type = \"a\"",
+                service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void updateSubscriptionRejectsAddingAFilterToAnUnfilteredSubscription() {
         service.createTopic("projects/p1/topics/t1");
         service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
 
         GcpException ex = assertThrows(GcpException.class,
                 () -> service.updateSubscription("projects/p1/subscriptions/s1", 0, null, null, null,
-                        "attributes.name = ", null, null, null, null, null, null, null, null,
+                        "attributes.event_type = \"a\"", null, null, null, null, null, null, null, null,
                         List.of("filter")));
         assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
         assertNull(service.getSubscription("projects/p1/subscriptions/s1").getFilter());
     }
 
     @Test
-    void updateSubscriptionViaFieldMaskRejectsUnparseableFilter() {
+    void updateSubscriptionRejectsTheFilterInTheMaskEvenWhenTheValueIsUnchanged() {
         service.createTopic("projects/p1/topics/t1");
-        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription("projects/p1/subscriptions/s1", 0,
+                        Map.of("env", "local"), null, null, "attributes.event_type = \"a\"", null, null,
+                        null, null, null, null, null, null, List.of("filter", "labels")));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+
+        StoredSubscription unchanged = service.getSubscription("projects/p1/subscriptions/s1");
+        assertEquals("attributes.event_type = \"a\"", unchanged.getFilter());
+        assertNull(unchanged.getLabels());
+    }
+
+    @Test
+    void updateSubscriptionIgnoresAFilterOutsideTheUpdateMask() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        StoredSubscription updated = service.updateSubscription("projects/p1/subscriptions/s1", 0,
+                Map.of("env", "local"), null, null, "attributes.event_type = \"ignored\"", null, null,
+                null, null, null, null, null, null, List.of("labels"));
+
+        assertEquals("local", updated.getLabels().get("env"));
+        assertEquals("attributes.event_type = \"a\"", updated.getFilter());
+    }
+
+    @Test
+    void updateSubscriptionWithoutUpdateMaskPreservesTheFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        StoredSubscription updated = service.updateSubscription("projects/p1/subscriptions/s1", 0,
+                Map.of("env", "local"), null, null, null, null, null, null, null, null, null, null, null,
+                null);
+
+        assertEquals("attributes.event_type = \"a\"", updated.getFilter());
+    }
+
+    @Test
+    void updateSubscriptionViaFieldMaskRejectsChangingTheFilter() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
 
         GcpException ex = assertThrows(GcpException.class,
                 () -> service.updateSubscription(
                         com.google.pubsub.v1.Subscription.newBuilder()
                                 .setName("projects/p1/subscriptions/s1")
-                                .setFilter("attributes.name = ")
+                                .setFilter("attributes.event_type = \"b\"")
                                 .build(),
                         com.google.protobuf.FieldMask.newBuilder().addPaths("filter").build()));
         assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
-        assertNull(service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+        assertEquals("attributes.event_type = \"a\"",
+                service.getSubscription("projects/p1/subscriptions/s1").getFilter());
+    }
+
+    @Test
+    void updateSubscriptionViaFieldMaskRejectsTheFilterInTheMaskEvenWhenTheValueIsUnchanged() {
+        service.createTopic("projects/p1/topics/t1");
+        createFilteredSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1",
+                "attributes.event_type = \"a\"");
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.updateSubscription(
+                        com.google.pubsub.v1.Subscription.newBuilder()
+                                .setName("projects/p1/subscriptions/s1")
+                                .setFilter("attributes.event_type = \"a\"")
+                                .setAckDeadlineSeconds(30)
+                                .build(),
+                        com.google.protobuf.FieldMask.newBuilder()
+                                .addPaths("filter")
+                                .addPaths("ack_deadline_seconds")
+                                .build()));
+        assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+        assertEquals(10, service.getSubscription("projects/p1/subscriptions/s1").getAckDeadlineSeconds());
     }
 
     @Test
@@ -228,8 +324,8 @@ class PubSubServiceTest {
 
         assertThrows(GcpException.class,
                 () -> service.updateSubscription("projects/p1/subscriptions/s1", 30,
-                        Map.of("env", "local"), null, null, "attributes.name = ", null, null, null,
-                        null, null, null, null, null,
+                        Map.of("env", "local"), null, null, "attributes.event_type = \"a\"", null, null,
+                        null, null, null, null, null, null,
                         List.of("ackDeadlineSeconds", "labels", "filter")));
 
         StoredSubscription unchanged = service.getSubscription("projects/p1/subscriptions/s1");
@@ -249,7 +345,7 @@ class PubSubServiceTest {
                                 .setName("projects/p1/subscriptions/s1")
                                 .setAckDeadlineSeconds(30)
                                 .putLabels("env", "local")
-                                .setFilter("attributes.name = ")
+                                .setFilter("attributes.event_type = \"a\"")
                                 .build(),
                         com.google.protobuf.FieldMask.newBuilder()
                                 .addPaths("ack_deadline_seconds")


### PR DESCRIPTION
Closes #110

Follow-up to #103, as invited [in its merge comment](https://github.com/floci-io/floci-gcp/pull/103#issuecomment-5152381337).

## Problem

The filter is immutable in GCP, but `subscriptions.patch` applied changes to it, and a patch without an update mask cleared it. This was also the one case where publish-time evaluation could diverge from GCP's delivery-time semantics: they are equivalent only while the filter cannot change between enqueue and delivery. That point is @hectorvent's, from the #103 merge comment.

## Behaviour, verified against the live Pub/Sub API

Rather than infer the semantics from the documentation, I checked each case against real Pub/Sub using a throwaway topic and subscription:

| Request | Real Pub/Sub | This PR |
|---|---|---|
| A. mask `filter`, different value | `400 INVALID_ARGUMENT`, *"the 'filter' field in the Subscription is not mutable."* | same |
| B. mask `filter`, **unchanged** value | `400 INVALID_ARGUMENT`, same message | same |
| C. mask `labels` | `200`, filter preserved | same |
| D. **no** update mask | `400`, *"The update_mask … must be set, and must contain a non-empty paths list."* | see below |
| E. mask `filter,labels` | `400`, `labels` unchanged | same |
| F. mask `labels`, body carries the same filter | `200`, filter ignored | same |
| G. mask `labels`, body carries a different filter | `200`, filter ignored | same |
| H. mask `filter`, empty value, subscription has no filter | `400 INVALID_ARGUMENT` | same |
| I. mask `filter`, adding a filter to an unfiltered subscription | `400 INVALID_ARGUMENT` | same |

Three consequences worth calling out, because each is a decision that would otherwise have to be reverse-engineered from the diff:

- **Rejection keys off the presence of `filter` in the update mask, not a comparison against the stored value** (A, B, H, I). Allowing a no-op restatement is the intuitive design, and it is wrong — GCP rejects that too, even when both the stored and the supplied filter are empty.
- **A `filter` in the request body outside the mask is ignored, not rejected** (F, G). The update mask governs. This matters for clients that read-modify-write a whole subscription, such as the Terraform provider.
- **A patch with no update mask at all is handled on its own terms.** GCP rejects those outright for the missing mask (D), so there is no GCP behaviour to mirror; floci-gcp accepting them is a pre-existing deviation I am not changing here. On that path a body carrying the current filter is accepted and the filter left alone, a body carrying a different one is rejected, and a body omitting it leaves the filter in place instead of clearing it — the last of those is a behaviour change, and preserving an immutable field seemed the conservative reading.

The error message is GCP's verbatim. The maskless branch reuses it even though no mask was supplied, since GCP cannot reach that state; a second message for an unreachable case seemed worse than the reuse.

Validating the filter on update is now unreachable — no update can change it — so that call is gone from both overloads. Creation still validates, and after this change `PubSubService.java:219` is the only place in the codebase that writes a subscription filter:

```
$ grep -rn setFilter src/main/java/
  services/pubsub/PubSubService.java:219              # createSubscription, validates
  services/pubsub/model/StoredSubscription.java:50    # model setter
  services/pubsub/PubSubSubscriberController.java:397 # response echo
  core/common/GqlParser.java:56                       # unrelated (Datastore)
```

## Tests

`mvn test` — **578 tests, 0 failures** (Java 25 in a container). New cases cover, on both the `FieldMask` and REST overloads: rejection when changing, clearing, adding and restating a filter; a filter in the request body outside the mask being ignored; a maskless patch that omits, restates or changes the filter; and that a rejected multi-field update leaves the other fields untouched.

Compatibility suites run locally against a JVM build of this branch: `sdk-test-java` `PubSubTest` **17/17** and `sdk-test-python` `test_pubsub` **7/7**, including a new SDK case asserting `InvalidArgumentException` for both a changed and an unchanged filter, and that a labels-only update preserves the filter.

Not run locally: `sdk-test-node`, `sdk-test-go`, `sdk-test-gcloud`, `compat-terraform`, `compat-opentofu` and the native GraalVM build.

## Docs

`docs/services/pubsub.md` gains an immutability subsection under **Subscription Filters**, covering what is rejected, that the update mask governs, the maskless path, and GCP's documented snapshot-and-recreate path for changing a filter.

## Not addressed here

An empty `FieldMask` on the gRPC `UpdateSubscription` is a silent no-op where GCP would reject for a missing mask. That is the same pre-existing deviation as the REST maskless path and predates this change.
