### PR TITLE
fix(firestore): enforce write preconditions and transaction conflicts

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirestoreTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirestoreTest.java
@@ -3,6 +3,7 @@ package io.floci.gcp.test;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Precondition;
 import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
@@ -18,8 +19,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class FirestoreTest {
@@ -170,5 +173,81 @@ class FirestoreTest {
 
         DocumentSnapshot snapshot = docRef.get().get();
         assertThat(snapshot.exists()).isFalse();
+    }
+
+    @Test
+    @Order(7)
+    void createFailsWhenDocumentAlreadyExists() throws ExecutionException, InterruptedException {
+        DocumentReference docRef = firestore.collection(COLLECTION)
+                .document(TestFixtures.uniqueName("precond"));
+        docRef.create(Map.of("name", "Alice")).get();
+        try {
+            assertThatThrownBy(() -> docRef.create(Map.of("name", "Bob")).get())
+                    .isInstanceOf(ExecutionException.class)
+                    .cause()
+                    .hasMessageContaining("already exists");
+
+            DocumentSnapshot snapshot = docRef.get().get();
+            assertThat(snapshot.getString("name")).isEqualTo("Alice");
+        } finally {
+            docRef.delete().get();
+        }
+    }
+
+    @Test
+    @Order(8)
+    void updateFailsWhenDocumentMissing() {
+        DocumentReference docRef = firestore.collection(COLLECTION)
+                .document(TestFixtures.uniqueName("missing"));
+
+        assertThatThrownBy(() -> docRef.update("name", "Alice").get())
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .hasMessageContaining("No document to update");
+    }
+
+    @Test
+    @Order(9)
+    void staleUpdateTimePreconditionFails() throws ExecutionException, InterruptedException {
+        DocumentReference docRef = firestore.collection(COLLECTION)
+                .document(TestFixtures.uniqueName("precond"));
+        WriteResult first = docRef.set(Map.of("version", 1L)).get();
+        WriteResult second = docRef.set(Map.of("version", 2L)).get();
+        try {
+            assertThatThrownBy(() -> docRef.update(
+                    Map.of("version", 3L), Precondition.updatedAt(first.getUpdateTime())).get())
+                    .isInstanceOf(ExecutionException.class);
+
+            // matching precondition succeeds
+            docRef.update(Map.of("version", 3L), Precondition.updatedAt(second.getUpdateTime())).get();
+            assertThat(docRef.get().get().getLong("version")).isEqualTo(3L);
+        } finally {
+            docRef.delete().get();
+        }
+    }
+
+    @Test
+    @Order(10)
+    void transactionRetriesOnConcurrentModification() throws ExecutionException, InterruptedException {
+        DocumentReference docRef = firestore.collection(COLLECTION)
+                .document(TestFixtures.uniqueName("counter"));
+        docRef.set(Map.of("count", 0L)).get();
+        AtomicInteger attempts = new AtomicInteger();
+        try {
+            firestore.runTransaction(transaction -> {
+                long current = transaction.get(docRef).get().getLong("count");
+                if (attempts.incrementAndGet() == 1) {
+                    // out-of-band write invalidates the transaction's read set
+                    docRef.update("count", 100L).get();
+                }
+                transaction.update(docRef, "count", current + 1);
+                return null;
+            }).get();
+
+            assertThat(attempts.get()).isEqualTo(2);
+            assertThat(docRef.get().get().getLong("count")).isEqualTo(101L);
+        } finally {
+            docRef.delete().get();
+        }
     }
 }

--- a/docs/services/firestore.md
+++ b/docs/services/firestore.md
@@ -190,7 +190,10 @@ registration.remove();
   a transaction track only the documents they return, so phantom reads (a
   concurrent write creating a document that would have matched the query) do not
   abort the transaction.
+- `RunAggregationQuery` ignores `transaction` and `newTransaction`; aggregations
+  read outside the transaction and are not part of its read set.
 - Transactions expire after 15 minutes instead of Firestore's shorter
   server-side deadlines.
 - Transaction state is held in memory; transactions do not survive an emulator
-  restart.
+  restart. A commit against an unknown transaction id is applied without conflict
+  validation.

--- a/docs/services/firestore.md
+++ b/docs/services/firestore.md
@@ -117,6 +117,25 @@ db.runTransaction(transaction -> {
 }).get();
 ```
 
+Transactions use optimistic concurrency, matching real Firestore: every document
+read inside a transaction is tracked, and the commit fails with `ABORTED` if any
+of those documents changed after being read. SDK clients retry aborted
+transactions automatically, so concurrent increments like the example above never
+lose updates.
+
+## Preconditions
+
+Write preconditions (`currentDocument`) are enforced on all write paths:
+
+- `create()` fails with `ALREADY_EXISTS` if the document exists
+- `update()` fails with `NOT_FOUND` if the document does not exist
+- `Precondition.updatedAt(...)` fails with `FAILED_PRECONDITION` if the
+  document's update time no longer matches
+
+`Commit` is atomic: if any write's precondition fails, no writes in the request
+are applied. `BatchWrite` is non-atomic and reports a per-write status, matching
+real Firestore.
+
 ## Batch Writes
 
 ```java
@@ -164,3 +183,14 @@ registration.remove();
 - `Write` (streaming)
 - `Listen` (real-time change streams)
 - `ListCollectionIds`
+
+## Deviations from real Firestore
+
+- Transaction conflict detection covers documents actually read. Queries inside
+  a transaction track only the documents they return, so phantom reads (a
+  concurrent write creating a document that would have matched the query) do not
+  abort the transaction.
+- Transactions expire after 15 minutes instead of Firestore's shorter
+  server-side deadlines.
+- Transaction state is held in memory; transactions do not survive an emulator
+  restart.

--- a/src/main/java/io/floci/gcp/core/common/GcpException.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpException.java
@@ -63,6 +63,10 @@ public class GcpException extends RuntimeException {
         return new GcpException(416, "OUT_OF_RANGE", Status.Code.OUT_OF_RANGE, message);
     }
 
+    public static GcpException aborted(String message) {
+        return new GcpException(409, "ABORTED", Status.Code.ABORTED, message);
+    }
+
     public static GcpException failedPrecondition(String message) {
         return new GcpException(400, "FAILED_PRECONDITION", Status.Code.FAILED_PRECONDITION, message);
     }

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreController.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreController.java
@@ -120,35 +120,31 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
         try {
             Instant readTime = Instant.now();
             ByteString txId = request.getTransaction();
-            boolean newTransaction = request.hasNewTransaction();
-            if (newTransaction) {
+            if (request.hasNewTransaction()) {
                 txId = ByteString.copyFrom(service.beginTransaction());
+                // per firestore.proto, the new transaction id is a first response of its own
+                // with no other fields set
+                responseObserver.onNext(RunQueryResponse.newBuilder()
+                        .setTransaction(txId)
+                        .build());
             }
             List<StoredDocument> results = service.runQuery(request.getParent(), request.getStructuredQuery());
 
-            boolean first = true;
             for (StoredDocument doc : results) {
                 if (!txId.isEmpty()) {
                     service.recordTransactionRead(txId.toByteArray(), doc.getName(), doc.getUpdateTime());
                 }
-                RunQueryResponse.Builder resp = RunQueryResponse.newBuilder()
+                responseObserver.onNext(RunQueryResponse.newBuilder()
                         .setDocument(toProto(doc))
-                        .setReadTime(toTimestamp(readTime.toString()));
-                if (newTransaction && first) {
-                    resp.setTransaction(txId);
-                    first = false;
-                }
-                responseObserver.onNext(resp.build());
+                        .setReadTime(toTimestamp(readTime.toString()))
+                        .build());
             }
 
             // terminal message
-            RunQueryResponse.Builder done = RunQueryResponse.newBuilder()
+            responseObserver.onNext(RunQueryResponse.newBuilder()
                     .setReadTime(toTimestamp(readTime.toString()))
-                    .setDone(true);
-            if (newTransaction && first) {
-                done.setTransaction(txId);
-            }
-            responseObserver.onNext(done.build());
+                    .setDone(true)
+                    .build());
             responseObserver.onCompleted();
         } catch (Exception e) {
             LOG.warnf("runQuery failed: %s", e.getMessage());

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreController.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreController.java
@@ -33,8 +33,9 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
             CommitResponse.Builder response = CommitResponse.newBuilder()
                     .setCommitTime(toTimestamp(commitTime.toString()));
 
-            for (Write write : request.getWritesList()) {
-                FirestoreService.WriteCommitResult result = service.applyWrite(write, commitTime);
+            List<FirestoreService.WriteCommitResult> results = service.commit(
+                    request.getWritesList(), request.getTransaction().toByteArray(), commitTime);
+            for (FirestoreService.WriteCommitResult result : results) {
                 WriteResult.Builder wr = WriteResult.newBuilder();
                 if (result.updateTime() != null) {
                     wr.setUpdateTime(toTimestamp(result.updateTime()));
@@ -54,6 +55,9 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
     public void getDocument(GetDocumentRequest request, StreamObserver<Document> responseObserver) {
         LOG.debugf("getDocument name=%s", request.getName());
         try {
+            if (!request.getTransaction().isEmpty()) {
+                service.recordTransactionRead(request.getTransaction().toByteArray(), request.getName());
+            }
             StoredDocument stored = service.getDocument(request.getName())
                     .orElseThrow(() -> io.floci.gcp.core.common.GcpException.notFound(
                             "Document not found: " + request.getName()));
@@ -71,10 +75,23 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
         LOG.debugf("batchGetDocuments database=%s docs=%d", request.getDatabase(), request.getDocumentsCount());
         try {
             Instant readTime = Instant.now();
+            ByteString txId = request.getTransaction();
+            boolean newTransaction = request.hasNewTransaction();
+            if (newTransaction) {
+                txId = ByteString.copyFrom(service.beginTransaction());
+            }
+            boolean first = true;
             for (String docName : request.getDocumentsList()) {
+                if (!txId.isEmpty()) {
+                    service.recordTransactionRead(txId.toByteArray(), docName);
+                }
                 Optional<StoredDocument> stored = service.getDocument(docName);
                 BatchGetDocumentsResponse.Builder resp = BatchGetDocumentsResponse.newBuilder()
                         .setReadTime(toTimestamp(readTime.toString()));
+                if (newTransaction && first) {
+                    resp.setTransaction(txId);
+                    first = false;
+                }
                 if (stored.isPresent()) {
                     resp.setFound(toProto(stored.get()));
                 } else {
@@ -94,20 +111,36 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
         LOG.debugf("runQuery parent=%s", request.getParent());
         try {
             Instant readTime = Instant.now();
+            ByteString txId = request.getTransaction();
+            boolean newTransaction = request.hasNewTransaction();
+            if (newTransaction) {
+                txId = ByteString.copyFrom(service.beginTransaction());
+            }
             List<StoredDocument> results = service.runQuery(request.getParent(), request.getStructuredQuery());
 
+            boolean first = true;
             for (StoredDocument doc : results) {
-                responseObserver.onNext(RunQueryResponse.newBuilder()
+                if (!txId.isEmpty()) {
+                    service.recordTransactionRead(txId.toByteArray(), doc.getName());
+                }
+                RunQueryResponse.Builder resp = RunQueryResponse.newBuilder()
                         .setDocument(toProto(doc))
-                        .setReadTime(toTimestamp(readTime.toString()))
-                        .build());
+                        .setReadTime(toTimestamp(readTime.toString()));
+                if (newTransaction && first) {
+                    resp.setTransaction(txId);
+                    first = false;
+                }
+                responseObserver.onNext(resp.build());
             }
 
             // terminal message
-            responseObserver.onNext(RunQueryResponse.newBuilder()
+            RunQueryResponse.Builder done = RunQueryResponse.newBuilder()
                     .setReadTime(toTimestamp(readTime.toString()))
-                    .setDone(true)
-                    .build());
+                    .setDone(true);
+            if (newTransaction && first) {
+                done.setTransaction(txId);
+            }
+            responseObserver.onNext(done.build());
             responseObserver.onCompleted();
         } catch (Exception e) {
             LOG.warnf("runQuery failed: %s", e.getMessage());
@@ -134,6 +167,7 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
     @Override
     public void rollback(RollbackRequest request, StreamObserver<Empty> responseObserver) {
         LOG.debugf("rollback database=%s", request.getDatabase());
+        service.rollback(request.getTransaction().toByteArray());
         responseObserver.onNext(Empty.getDefaultInstance());
         responseObserver.onCompleted();
     }
@@ -163,11 +197,13 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
     public void updateDocument(UpdateDocumentRequest request, StreamObserver<Document> responseObserver) {
         LOG.debugf("updateDocument name=%s", request.getDocument().getName());
         try {
-            Write write = Write.newBuilder()
+            Write.Builder write = Write.newBuilder()
                     .setUpdate(request.getDocument())
-                    .setUpdateMask(request.getUpdateMask())
-                    .build();
-            service.applyWrite(write, Instant.now());
+                    .setUpdateMask(request.getUpdateMask());
+            if (request.hasCurrentDocument()) {
+                write.setCurrentDocument(request.getCurrentDocument());
+            }
+            service.applyWrite(write.build(), Instant.now());
             StoredDocument stored = service.getDocument(request.getDocument().getName())
                     .orElseThrow();
             responseObserver.onNext(toProto(stored));
@@ -182,8 +218,11 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
     public void deleteDocument(DeleteDocumentRequest request, StreamObserver<Empty> responseObserver) {
         LOG.debugf("deleteDocument name=%s", request.getName());
         try {
-            Write write = Write.newBuilder().setDelete(request.getName()).build();
-            service.applyWrite(write, Instant.now());
+            Write.Builder write = Write.newBuilder().setDelete(request.getName());
+            if (request.hasCurrentDocument()) {
+                write.setCurrentDocument(request.getCurrentDocument());
+            }
+            service.applyWrite(write.build(), Instant.now());
             responseObserver.onNext(Empty.getDefaultInstance());
             responseObserver.onCompleted();
         } catch (Exception e) {
@@ -201,7 +240,10 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
                     : request.getDocumentId();
             String name = request.getParent() + "/" + request.getCollectionId() + "/" + docId;
             Document doc = request.getDocument().toBuilder().setName(name).build();
-            Write write = Write.newBuilder().setUpdate(doc).build();
+            Write write = Write.newBuilder()
+                    .setUpdate(doc)
+                    .setCurrentDocument(Precondition.newBuilder().setExists(false).build())
+                    .build();
             service.applyWrite(write, Instant.now());
             responseObserver.onNext(toProto(service.getDocument(name).orElseThrow()));
             responseObserver.onCompleted();
@@ -232,14 +274,23 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
         try {
             Instant commitTime = Instant.now();
             BatchWriteResponse.Builder resp = BatchWriteResponse.newBuilder();
+            // BatchWrite is non-atomic: each write succeeds or fails independently
             for (Write write : request.getWritesList()) {
-                FirestoreService.WriteCommitResult result = service.applyWrite(write, commitTime);
-                WriteResult.Builder wr = WriteResult.newBuilder();
-                if (result.updateTime() != null) {
-                    wr.setUpdateTime(toTimestamp(result.updateTime()));
+                try {
+                    FirestoreService.WriteCommitResult result = service.applyWrite(write, commitTime);
+                    WriteResult.Builder wr = WriteResult.newBuilder();
+                    if (result.updateTime() != null) {
+                        wr.setUpdateTime(toTimestamp(result.updateTime()));
+                    }
+                    resp.addWriteResults(wr.build());
+                    resp.addStatus(com.google.rpc.Status.newBuilder().setCode(0).build());
+                } catch (io.floci.gcp.core.common.GcpException e) {
+                    resp.addWriteResults(WriteResult.getDefaultInstance());
+                    resp.addStatus(com.google.rpc.Status.newBuilder()
+                            .setCode(e.getGrpcCode().value())
+                            .setMessage(e.getMessage())
+                            .build());
                 }
-                resp.addWriteResults(wr.build());
-                resp.addStatus(com.google.rpc.Status.newBuilder().setCode(0).build());
             }
             responseObserver.onNext(resp.build());
             responseObserver.onCompleted();

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreController.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreController.java
@@ -55,13 +55,14 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
     public void getDocument(GetDocumentRequest request, StreamObserver<Document> responseObserver) {
         LOG.debugf("getDocument name=%s", request.getName());
         try {
+            Optional<StoredDocument> stored = service.getDocument(request.getName());
             if (!request.getTransaction().isEmpty()) {
-                service.recordTransactionRead(request.getTransaction().toByteArray(), request.getName());
+                service.recordTransactionRead(request.getTransaction().toByteArray(), request.getName(),
+                        stored.map(StoredDocument::getUpdateTime).orElse(null));
             }
-            StoredDocument stored = service.getDocument(request.getName())
-                    .orElseThrow(() -> io.floci.gcp.core.common.GcpException.notFound(
-                            "Document not found: " + request.getName()));
-            responseObserver.onNext(toProto(stored));
+            responseObserver.onNext(toProto(stored.orElseThrow(
+                    () -> io.floci.gcp.core.common.GcpException.notFound(
+                            "Document not found: " + request.getName()))));
             responseObserver.onCompleted();
         } catch (Exception e) {
             LOG.warnf("getDocument failed: %s", e.getMessage());
@@ -82,10 +83,11 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
             }
             boolean first = true;
             for (String docName : request.getDocumentsList()) {
-                if (!txId.isEmpty()) {
-                    service.recordTransactionRead(txId.toByteArray(), docName);
-                }
                 Optional<StoredDocument> stored = service.getDocument(docName);
+                if (!txId.isEmpty()) {
+                    service.recordTransactionRead(txId.toByteArray(), docName,
+                            stored.map(StoredDocument::getUpdateTime).orElse(null));
+                }
                 BatchGetDocumentsResponse.Builder resp = BatchGetDocumentsResponse.newBuilder()
                         .setReadTime(toTimestamp(readTime.toString()));
                 if (newTransaction && first) {
@@ -98,6 +100,12 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
                     resp.setMissing(docName);
                 }
                 responseObserver.onNext(resp.build());
+            }
+            if (newTransaction && first) {
+                responseObserver.onNext(BatchGetDocumentsResponse.newBuilder()
+                        .setReadTime(toTimestamp(readTime.toString()))
+                        .setTransaction(txId)
+                        .build());
             }
             responseObserver.onCompleted();
         } catch (Exception e) {
@@ -121,7 +129,7 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
             boolean first = true;
             for (StoredDocument doc : results) {
                 if (!txId.isEmpty()) {
-                    service.recordTransactionRead(txId.toByteArray(), doc.getName());
+                    service.recordTransactionRead(txId.toByteArray(), doc.getName(), doc.getUpdateTime());
                 }
                 RunQueryResponse.Builder resp = RunQueryResponse.newBuilder()
                         .setDocument(toProto(doc))
@@ -283,12 +291,14 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
                         wr.setUpdateTime(toTimestamp(result.updateTime()));
                     }
                     resp.addWriteResults(wr.build());
-                    resp.addStatus(com.google.rpc.Status.newBuilder().setCode(0).build());
-                } catch (io.floci.gcp.core.common.GcpException e) {
+                    resp.addStatus(Status.newBuilder().setCode(0).build());
+                } catch (RuntimeException e) {
+                    io.grpc.Status mapped = GcpGrpcController.grpcException(e).getStatus();
+                    String message = mapped.getDescription();
                     resp.addWriteResults(WriteResult.getDefaultInstance());
-                    resp.addStatus(com.google.rpc.Status.newBuilder()
-                            .setCode(e.getGrpcCode().value())
-                            .setMessage(e.getMessage())
+                    resp.addStatus(Status.newBuilder()
+                            .setCode(mapped.getCode().value())
+                            .setMessage(message == null ? "" : message)
                             .build());
                 }
             }
@@ -345,8 +355,8 @@ public class FirestoreController extends FirestoreGrpc.FirestoreImplBase {
                     WriteResponse.Builder resp = WriteResponse.newBuilder()
                             .setStreamId(req.getStreamId())
                             .setCommitTime(toTimestamp(now.toString()));
-                    for (Write w : req.getWritesList()) {
-                        FirestoreService.WriteCommitResult r = service.applyWrite(w, now);
+                    for (FirestoreService.WriteCommitResult r
+                            : service.commit(req.getWritesList(), null, now)) {
                         WriteResult.Builder wr = WriteResult.newBuilder();
                         if (r.updateTime() != null) {
                             wr.setUpdateTime(toTimestamp(r.updateTime()));

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
@@ -27,9 +27,11 @@ import org.jboss.logging.Logger;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +102,7 @@ public class FirestoreService {
             for (Write write : writes) {
                 results.add(applyWriteUnchecked(write, commitTime));
             }
+            discardTransaction(transactionId);
             return results;
         }
     }
@@ -126,7 +129,7 @@ public class FirestoreService {
             case UPDATE_TIME -> {
                 Instant required = Instant.ofEpochSecond(
                         pre.getUpdateTime().getSeconds(), pre.getUpdateTime().getNanos());
-                Instant actual = existing.map(d -> Instant.parse(d.getUpdateTime())).orElse(null);
+                Instant actual = existing.map(d -> parseUpdateTime(d.getUpdateTime())).orElse(null);
                 if (!required.equals(actual)) {
                     throw GcpException.failedPrecondition("Document " + name
                             + " has changed: required update time " + required
@@ -134,6 +137,18 @@ public class FirestoreService {
                 }
             }
             default -> {}
+        }
+    }
+
+    /** Null for an absent or unparseable stored update time; that then fails any update-time precondition. */
+    private static Instant parseUpdateTime(String storedUpdateTime) {
+        if (storedUpdateTime == null) {
+            return null;
+        }
+        try {
+            return Instant.parse(storedUpdateTime);
+        } catch (DateTimeParseException e) {
+            return null;
         }
     }
 
@@ -455,38 +470,55 @@ public class FirestoreService {
 
     public byte[] beginTransaction() {
         pruneExpiredTransactions();
-        String id = UUID.randomUUID().toString();
-        transactions.put(id, new TransactionState());
-        return id.getBytes(StandardCharsets.UTF_8);
+        byte[] id = UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+        transactions.put(toTransactionKey(id), new TransactionState());
+        return id;
     }
 
     /** Records the version of a document read under a transaction (first read wins). */
     public void recordTransactionRead(byte[] transactionId, String docName) {
+        synchronized (writeLock) {
+            recordTransactionRead(transactionId, docName,
+                    documentStore.get(docName).map(StoredDocument::getUpdateTime).orElse(null));
+        }
+    }
+
+    /**
+     * Records a read against the transaction's read set. Callers must pass the version of the
+     * snapshot they returned to the client, not the store's current version: a write landing
+     * between the read and this call would otherwise go undetected at commit.
+     *
+     * @param updateTime the returned snapshot's update time, or null if the document was absent
+     */
+    public void recordTransactionRead(byte[] transactionId, String docName, String updateTime) {
+        if (transactionId == null || transactionId.length == 0) {
+            return;
+        }
         TransactionState state = transactions.get(toTransactionKey(transactionId));
         if (state == null) {
             return;
         }
         synchronized (writeLock) {
-            state.readVersions.putIfAbsent(docName,
-                    documentStore.get(docName).map(StoredDocument::getUpdateTime));
+            state.readVersions.putIfAbsent(docName, Optional.ofNullable(updateTime));
         }
     }
 
     public void rollback(byte[] transactionId) {
-        transactions.remove(toTransactionKey(transactionId));
+        discardTransaction(transactionId);
     }
 
     /**
      * Optimistic-concurrency check: every document read under the transaction must still
      * be at the version observed at read time, otherwise the commit aborts. Callers must
      * hold {@code writeLock}. Unknown transaction ids pass through unchecked (e.g. state
-     * lost across emulator restart).
+     * lost across emulator restart). The read set is retained on failure so a retried commit
+     * of the same transaction id is validated again.
      */
     private void validateTransaction(byte[] transactionId) {
         if (transactionId == null || transactionId.length == 0) {
             return;
         }
-        TransactionState state = transactions.remove(toTransactionKey(transactionId));
+        TransactionState state = transactions.get(toTransactionKey(transactionId));
         if (state == null) {
             return;
         }
@@ -501,13 +533,21 @@ public class FirestoreService {
         }
     }
 
+    private void discardTransaction(byte[] transactionId) {
+        if (transactionId == null || transactionId.length == 0) {
+            return;
+        }
+        transactions.remove(toTransactionKey(transactionId));
+    }
+
     private void pruneExpiredTransactions() {
         Instant cutoff = Instant.now().minus(TRANSACTION_TTL);
         transactions.values().removeIf(state -> state.startedAt.isBefore(cutoff));
     }
 
+    /** Transaction ids are opaque bytes from the client and need not be valid UTF-8. */
     private static String toTransactionKey(byte[] transactionId) {
-        return new String(transactionId, StandardCharsets.UTF_8);
+        return HexFormat.of().formatHex(transactionId);
     }
 
     // ── Filter evaluation ──────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.firestore.v1.Cursor;
 import com.google.firestore.v1.Document;
 import com.google.firestore.v1.DocumentMask;
+import com.google.firestore.v1.Precondition;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
@@ -23,6 +24,8 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -33,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class FirestoreService {
@@ -76,6 +80,77 @@ public class FirestoreService {
     public record WriteCommitResult(String updateTime) {}
 
     public WriteCommitResult applyWrite(Write write, Instant commitTime) {
+        synchronized (writeLock) {
+            checkPrecondition(write);
+            return applyWriteUnchecked(write, commitTime);
+        }
+    }
+
+    /**
+     * Applies a commit atomically: transaction read-set validation and all write
+     * preconditions are checked against the pre-commit state before any write lands.
+     */
+    public List<WriteCommitResult> commit(List<Write> writes, byte[] transactionId, Instant commitTime) {
+        synchronized (writeLock) {
+            validateTransaction(transactionId);
+            for (Write write : writes) {
+                checkPrecondition(write);
+            }
+            List<WriteCommitResult> results = new ArrayList<>(writes.size());
+            for (Write write : writes) {
+                results.add(applyWriteUnchecked(write, commitTime));
+            }
+            return results;
+        }
+    }
+
+    private void checkPrecondition(Write write) {
+        if (!write.hasCurrentDocument()) {
+            return;
+        }
+        String name = writeTargetName(write);
+        if (name.isEmpty()) {
+            return;
+        }
+        Precondition pre = write.getCurrentDocument();
+        Optional<StoredDocument> existing = documentStore.get(name);
+        switch (pre.getConditionTypeCase()) {
+            case EXISTS -> {
+                if (pre.getExists() && existing.isEmpty()) {
+                    throw GcpException.notFound("No document to update: " + name);
+                }
+                if (!pre.getExists() && existing.isPresent()) {
+                    throw GcpException.alreadyExists("Document already exists: " + name);
+                }
+            }
+            case UPDATE_TIME -> {
+                Instant required = Instant.ofEpochSecond(
+                        pre.getUpdateTime().getSeconds(), pre.getUpdateTime().getNanos());
+                Instant actual = existing.map(d -> Instant.parse(d.getUpdateTime())).orElse(null);
+                if (!required.equals(actual)) {
+                    throw GcpException.failedPrecondition("Document " + name
+                            + " has changed: required update time " + required
+                            + ", actual " + (actual == null ? "(missing)" : actual));
+                }
+            }
+            default -> {}
+        }
+    }
+
+    private static String writeTargetName(Write write) {
+        if (write.hasUpdate()) {
+            return write.getUpdate().getName();
+        }
+        if (!write.getDelete().isEmpty()) {
+            return write.getDelete();
+        }
+        if (write.hasTransform()) {
+            return write.getTransform().getDocument();
+        }
+        return "";
+    }
+
+    private WriteCommitResult applyWriteUnchecked(Write write, Instant commitTime) {
         String now = commitTime.toString();
 
         if (write.hasUpdate()) {
@@ -367,9 +442,72 @@ public class FirestoreService {
 
     // ── Transactions ───────────────────────────────────────────────────────────
 
+    private static final Duration TRANSACTION_TTL = Duration.ofMinutes(15);
+
+    private final Object writeLock = new Object();
+    private final Map<String, TransactionState> transactions = new ConcurrentHashMap<>();
+
+    private static final class TransactionState {
+        final Instant startedAt = Instant.now();
+        // document name -> updateTime at first read; empty Optional = document was absent
+        final Map<String, Optional<String>> readVersions = new HashMap<>();
+    }
+
     public byte[] beginTransaction() {
+        pruneExpiredTransactions();
         String id = UUID.randomUUID().toString();
-        return id.getBytes();
+        transactions.put(id, new TransactionState());
+        return id.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Records the version of a document read under a transaction (first read wins). */
+    public void recordTransactionRead(byte[] transactionId, String docName) {
+        TransactionState state = transactions.get(toTransactionKey(transactionId));
+        if (state == null) {
+            return;
+        }
+        synchronized (writeLock) {
+            state.readVersions.putIfAbsent(docName,
+                    documentStore.get(docName).map(StoredDocument::getUpdateTime));
+        }
+    }
+
+    public void rollback(byte[] transactionId) {
+        transactions.remove(toTransactionKey(transactionId));
+    }
+
+    /**
+     * Optimistic-concurrency check: every document read under the transaction must still
+     * be at the version observed at read time, otherwise the commit aborts. Callers must
+     * hold {@code writeLock}. Unknown transaction ids pass through unchecked (e.g. state
+     * lost across emulator restart).
+     */
+    private void validateTransaction(byte[] transactionId) {
+        if (transactionId == null || transactionId.length == 0) {
+            return;
+        }
+        TransactionState state = transactions.remove(toTransactionKey(transactionId));
+        if (state == null) {
+            return;
+        }
+        for (Map.Entry<String, Optional<String>> read : state.readVersions.entrySet()) {
+            Optional<String> current = documentStore.get(read.getKey())
+                    .map(StoredDocument::getUpdateTime);
+            if (!current.equals(read.getValue())) {
+                throw GcpException.aborted(
+                        "Transaction aborted: document " + read.getKey()
+                                + " was modified after it was read. Retry the transaction.");
+            }
+        }
+    }
+
+    private void pruneExpiredTransactions() {
+        Instant cutoff = Instant.now().minus(TRANSACTION_TTL);
+        transactions.values().removeIf(state -> state.startedAt.isBefore(cutoff));
+    }
+
+    private static String toTransactionKey(byte[] transactionId) {
+        return new String(transactionId, StandardCharsets.UTF_8);
     }
 
     // ── Filter evaluation ──────────────────────────────────────────────────────

--- a/src/test/java/io/floci/gcp/services/firestore/FirestoreControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/firestore/FirestoreControllerTest.java
@@ -1,0 +1,119 @@
+package io.floci.gcp.services.firestore;
+
+import com.google.firestore.v1.Document;
+import com.google.firestore.v1.RunQueryRequest;
+import com.google.firestore.v1.RunQueryResponse;
+import com.google.firestore.v1.StructuredQuery;
+import com.google.firestore.v1.TransactionOptions;
+import com.google.firestore.v1.Write;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.firestore.model.StoredDocument;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FirestoreControllerTest {
+
+    private FirestoreService service;
+    private FirestoreController controller;
+    private static final String DB = "projects/p1/databases/(default)";
+    private static final String PARENT = DB + "/documents";
+
+    @BeforeEach
+    void setUp() {
+        service = new FirestoreService(new InMemoryStorage<String, StoredDocument>());
+        controller = new FirestoreController(service);
+    }
+
+    private static final class CapturingObserver<T> implements StreamObserver<T> {
+        final List<T> messages = new ArrayList<>();
+        Throwable error;
+        boolean completed;
+
+        public void onNext(T value) { messages.add(value); }
+        public void onError(Throwable t) { error = t; }
+        public void onCompleted() { completed = true; }
+    }
+
+    private void seedDocument(String name) {
+        Document doc = Document.newBuilder().setName(name).build();
+        service.applyWrite(Write.newBuilder().setUpdate(doc).build(), Instant.now());
+    }
+
+    private static RunQueryRequest.Builder queryRequest(String collectionId) {
+        return RunQueryRequest.newBuilder()
+                .setParent(PARENT)
+                .setStructuredQuery(StructuredQuery.newBuilder()
+                        .addFrom(StructuredQuery.CollectionSelector.newBuilder()
+                                .setCollectionId(collectionId)
+                                .build()));
+    }
+
+    @Test
+    void newTransactionQueryReturnsTransactionInDedicatedFirstResponse() {
+        seedDocument(PARENT + "/col/doc1");
+        seedDocument(PARENT + "/col/doc2");
+        CapturingObserver<RunQueryResponse> observer = new CapturingObserver<>();
+
+        controller.runQuery(queryRequest("col")
+                .setNewTransaction(TransactionOptions.getDefaultInstance())
+                .build(), observer);
+
+        assertNull(observer.error);
+        assertTrue(observer.completed);
+        assertEquals(4, observer.messages.size());
+
+        RunQueryResponse first = observer.messages.get(0);
+        assertFalse(first.getTransaction().isEmpty());
+        assertFalse(first.hasDocument());
+        assertFalse(first.hasReadTime());
+        assertFalse(first.getDone());
+
+        for (RunQueryResponse later : observer.messages.subList(1, observer.messages.size())) {
+            assertTrue(later.getTransaction().isEmpty());
+        }
+        assertTrue(observer.messages.get(1).hasDocument());
+        assertTrue(observer.messages.get(3).getDone());
+    }
+
+    @Test
+    void newTransactionQueryWithNoResultsStillReturnsTransactionFirst() {
+        CapturingObserver<RunQueryResponse> observer = new CapturingObserver<>();
+
+        controller.runQuery(queryRequest("empty")
+                .setNewTransaction(TransactionOptions.getDefaultInstance())
+                .build(), observer);
+
+        assertNull(observer.error);
+        assertEquals(2, observer.messages.size());
+
+        RunQueryResponse first = observer.messages.get(0);
+        assertFalse(first.getTransaction().isEmpty());
+        assertFalse(first.hasDocument());
+        assertFalse(first.hasReadTime());
+        assertFalse(first.getDone());
+
+        assertTrue(observer.messages.get(1).getDone());
+        assertTrue(observer.messages.get(1).getTransaction().isEmpty());
+    }
+
+    @Test
+    void queryWithoutNewTransactionNeverSetsTransaction() {
+        seedDocument(PARENT + "/col/doc1");
+        CapturingObserver<RunQueryResponse> observer = new CapturingObserver<>();
+
+        controller.runQuery(queryRequest("col").build(), observer);
+
+        assertNull(observer.error);
+        assertEquals(2, observer.messages.size());
+        for (RunQueryResponse resp : observer.messages) {
+            assertTrue(resp.getTransaction().isEmpty());
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
@@ -2,14 +2,14 @@ package io.floci.gcp.services.firestore;
 
 import com.google.firestore.v1.Document;
 import com.google.firestore.v1.Precondition;
-import com.google.protobuf.Timestamp;
-import io.floci.gcp.core.common.GcpException;
-import io.grpc.Status;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
+import com.google.protobuf.Timestamp;
+import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.storage.InMemoryStorage;
 import io.floci.gcp.services.firestore.model.StoredDocument;
+import io.grpc.Status;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,12 +22,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class FirestoreServiceTest {
 
     private FirestoreService service;
+    private InMemoryStorage<String, StoredDocument> storage;
     private static final String DB = "projects/p1/databases/(default)";
     private static final String DOC_NAME = DB + "/documents/users/alice";
 
     @BeforeEach
     void setUp() {
-        service = new FirestoreService(new InMemoryStorage<>());
+        storage = new InMemoryStorage<>();
+        service = new FirestoreService(storage);
     }
 
     @Test
@@ -234,6 +236,49 @@ class FirestoreServiceTest {
         GcpException ex = assertThrows(GcpException.class, () -> service.commit(
                 List.of(upsert(DOC_NAME, "a", "2")), tx, Instant.now()));
         assertEquals(Status.Code.ABORTED, ex.getGrpcCode());
+    }
+
+    @Test
+    void recordedSnapshotVersionDetectsWriteRacingTheRead() {
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.parse("2026-01-01T00:00:00Z"));
+        byte[] tx = service.beginTransaction();
+        String snapshotVersion = service.getDocument(DOC_NAME).orElseThrow().getUpdateTime();
+
+        // write lands between the read and the read being recorded
+        service.applyWrite(upsert(DOC_NAME, "a", "2"), Instant.parse("2026-01-02T00:00:00Z"));
+        service.recordTransactionRead(tx, DOC_NAME, snapshotVersion);
+
+        GcpException ex = assertThrows(GcpException.class, () -> service.commit(
+                List.of(upsert(DOC_NAME, "a", "3")), tx, Instant.now()));
+        assertEquals(Status.Code.ABORTED, ex.getGrpcCode());
+    }
+
+    @Test
+    void retriedCommitOfAbortedTransactionStillAborts() {
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.now());
+        byte[] tx = service.beginTransaction();
+        service.recordTransactionRead(tx, DOC_NAME);
+        service.applyWrite(upsert(DOC_NAME, "a", "2"), Instant.now().plusSeconds(1));
+
+        List<Write> writes = List.of(upsert(DOC_NAME, "a", "3"));
+        assertThrows(GcpException.class, () -> service.commit(writes, tx, Instant.now()));
+        GcpException retry = assertThrows(GcpException.class,
+                () -> service.commit(writes, tx, Instant.now()));
+        assertEquals(Status.Code.ABORTED, retry.getGrpcCode());
+    }
+
+    @Test
+    void unparseableStoredUpdateTimeFailsPreconditionInsteadOfCrashing() {
+        storage.put(DOC_NAME, new StoredDocument(DOC_NAME, "not-a-timestamp", "not-a-timestamp", null));
+
+        Write update = upsert(DOC_NAME, "a", "1").toBuilder()
+                .setCurrentDocument(Precondition.newBuilder()
+                        .setUpdateTime(Timestamp.newBuilder().setSeconds(1).build())
+                        .build())
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.applyWrite(update, Instant.now()));
+        assertEquals(Status.Code.FAILED_PRECONDITION, ex.getGrpcCode());
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
@@ -1,6 +1,10 @@
 package io.floci.gcp.services.firestore;
 
 import com.google.firestore.v1.Document;
+import com.google.firestore.v1.Precondition;
+import com.google.protobuf.Timestamp;
+import io.floci.gcp.core.common.GcpException;
+import io.grpc.Status;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
 import com.google.firestore.v1.Write;
@@ -109,5 +113,139 @@ class FirestoreServiceTest {
         byte[] txn = service.beginTransaction();
         assertNotNull(txn);
         assertTrue(txn.length > 0);
+    }
+
+    private Write upsert(String name, String field, String value) {
+        return Write.newBuilder()
+                .setUpdate(Document.newBuilder()
+                        .setName(name)
+                        .putFields(field, Value.newBuilder().setStringValue(value).build())
+                        .build())
+                .build();
+    }
+
+    @Test
+    void createPreconditionFailsWhenDocumentExists() {
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.now());
+
+        Write create = upsert(DOC_NAME, "a", "2").toBuilder()
+                .setCurrentDocument(Precondition.newBuilder().setExists(false).build())
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.applyWrite(create, Instant.now()));
+        assertEquals(Status.Code.ALREADY_EXISTS, ex.getGrpcCode());
+    }
+
+    @Test
+    void updatePreconditionFailsWhenDocumentMissing() {
+        Write update = upsert(DOC_NAME, "a", "1").toBuilder()
+                .setCurrentDocument(Precondition.newBuilder().setExists(true).build())
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.applyWrite(update, Instant.now()));
+        assertEquals(Status.Code.NOT_FOUND, ex.getGrpcCode());
+    }
+
+    @Test
+    void staleUpdateTimePreconditionFails() {
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.parse("2026-01-01T00:00:00Z"));
+
+        Write update = upsert(DOC_NAME, "a", "2").toBuilder()
+                .setCurrentDocument(Precondition.newBuilder()
+                        .setUpdateTime(Timestamp.newBuilder()
+                                .setSeconds(Instant.parse("2025-01-01T00:00:00Z").getEpochSecond())
+                                .build())
+                        .build())
+                .build();
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.applyWrite(update, Instant.now()));
+        assertEquals(Status.Code.FAILED_PRECONDITION, ex.getGrpcCode());
+        assertEquals("1", service.getDocument(DOC_NAME).orElseThrow()
+                .getFields().get("a").getStringValue());
+    }
+
+    @Test
+    void matchingUpdateTimePreconditionSucceeds() {
+        Instant written = Instant.parse("2026-01-01T00:00:00.123456789Z");
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), written);
+
+        Write update = upsert(DOC_NAME, "a", "2").toBuilder()
+                .setCurrentDocument(Precondition.newBuilder()
+                        .setUpdateTime(Timestamp.newBuilder()
+                                .setSeconds(written.getEpochSecond())
+                                .setNanos(written.getNano())
+                                .build())
+                        .build())
+                .build();
+        service.applyWrite(update, Instant.now());
+        assertEquals("2", service.getDocument(DOC_NAME).orElseThrow()
+                .getFields().get("a").getStringValue());
+    }
+
+    @Test
+    void commitAppliesNothingWhenAnyPreconditionFails() {
+        String other = DB + "/documents/users/bob";
+        Write failing = upsert(DOC_NAME, "a", "1").toBuilder()
+                .setCurrentDocument(Precondition.newBuilder().setExists(true).build())
+                .build();
+
+        assertThrows(GcpException.class, () -> service.commit(
+                List.of(upsert(other, "b", "1"), failing), new byte[0], Instant.now()));
+        assertTrue(service.getDocument(other).isEmpty());
+    }
+
+    @Test
+    void conflictingTransactionAborts() {
+        service.applyWrite(upsert(DOC_NAME, "counter", "0"), Instant.now());
+
+        byte[] tx1 = service.beginTransaction();
+        byte[] tx2 = service.beginTransaction();
+        service.recordTransactionRead(tx1, DOC_NAME);
+        service.recordTransactionRead(tx2, DOC_NAME);
+
+        service.commit(List.of(upsert(DOC_NAME, "counter", "1")), tx1, Instant.now());
+
+        GcpException ex = assertThrows(GcpException.class, () -> service.commit(
+                List.of(upsert(DOC_NAME, "counter", "1")), tx2, Instant.now()));
+        assertEquals(Status.Code.ABORTED, ex.getGrpcCode());
+        assertEquals("1", service.getDocument(DOC_NAME).orElseThrow()
+                .getFields().get("counter").getStringValue());
+    }
+
+    @Test
+    void nonConflictingTransactionCommits() {
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.now());
+
+        byte[] tx = service.beginTransaction();
+        service.recordTransactionRead(tx, DOC_NAME);
+        service.commit(List.of(upsert(DOC_NAME, "a", "2")), tx, Instant.now());
+
+        assertEquals("2", service.getDocument(DOC_NAME).orElseThrow()
+                .getFields().get("a").getStringValue());
+    }
+
+    @Test
+    void transactionReadOfMissingDocumentDetectsCreation() {
+        byte[] tx = service.beginTransaction();
+        service.recordTransactionRead(tx, DOC_NAME);
+
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.now());
+
+        GcpException ex = assertThrows(GcpException.class, () -> service.commit(
+                List.of(upsert(DOC_NAME, "a", "2")), tx, Instant.now()));
+        assertEquals(Status.Code.ABORTED, ex.getGrpcCode());
+    }
+
+    @Test
+    void rollbackDiscardsTransactionState() {
+        byte[] tx = service.beginTransaction();
+        service.recordTransactionRead(tx, DOC_NAME);
+        service.rollback(tx);
+
+        service.applyWrite(upsert(DOC_NAME, "a", "1"), Instant.now());
+        // committing a rolled-back (unknown) transaction skips validation
+        service.commit(List.of(upsert(DOC_NAME, "a", "2")), tx, Instant.now());
+        assertEquals("2", service.getDocument(DOC_NAME).orElseThrow()
+                .getFields().get("a").getStringValue());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #113

The Firestore emulator applied every write unconditionally: `Write.current_document` preconditions were ignored and `Commit` never validated its transaction, so double-creates succeeded, stale preconditions passed silently, and conflicting transactions all committed (losing updates).

- fix(firestore): enforce `current_document` preconditions on all write paths — `exists=false` → `ALREADY_EXISTS`, `exists=true` → `NOT_FOUND`, stale `update_time` → `FAILED_PRECONDITION`; `CreateDocument`/`UpdateDocument`/`DeleteDocument` pass their preconditions through
- fix(firestore): transaction conflict detection — `BeginTransaction` registers server-side state, transactional reads (`GetDocument`, `BatchGetDocuments`, `RunQuery`, incl. `new_transaction`) record the returned snapshot's version, and `Commit` aborts with `ABORTED` if any read document changed; `Rollback` discards state
- fix(firestore): `Commit` and the `Write` stream are atomic per request (preconditions validated before any write lands); `BatchWrite` is non-atomic with per-write `status`, matching real Firestore
- feat(core): add `GcpException.aborted()` (gRPC `ABORTED`, HTTP 409)

Intentional deviations (documented in `docs/services/firestore.md`): query read sets cover returned documents only (no phantom-read detection), `RunAggregationQuery` ignores transactions, transaction state is in-memory with a 15-minute TTL.

Validated with the Java SDK against a running emulator: create/update precondition failures surface as SDK exceptions, and a transaction with a conflicting concurrent write is aborted and retried by the SDK exactly once with no lost update.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
