### PR TITLE
feat(sts): add downscoped token exchange

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -109,6 +109,10 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-iamcredentials</artifactId>
         </dependency>
+		<dependency>
+			<groupId>com.google.auth</groupId>
+			<artifactId>google-auth-library-oauth2-http</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.google.firebase</groupId>
             <artifactId>firebase-admin</artifactId>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/StsTokenExchangeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/StsTokenExchangeTest.java
@@ -1,0 +1,61 @@
+package io.floci.gcp.test;
+
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.CredentialAccessBoundary;
+import com.google.auth.oauth2.DownscopedCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.junit.jupiter.api.Test;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StsTokenExchangeTest {
+
+	@Test
+	void downscopedCredentialsExchangeTokenWithCustomStsTransport() throws Exception {
+		GoogleCredentials sourceCredentials = GoogleCredentials.create(new AccessToken(
+				"source-token",
+				Date.from(Instant.now().plusSeconds(3600))));
+		CredentialAccessBoundary cab = CredentialAccessBoundary.newBuilder()
+				.addRule(CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+						.setAvailableResource("//storage.googleapis.com/projects/_/buckets/compat-bucket")
+						.setAvailablePermissions(List.of("inRole:roles/storage.legacyObjectReader"))
+						.setAvailabilityCondition(
+								CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
+										.setExpression("resource.name.startsWith("
+												+ "'projects/_/buckets/compat-bucket/objects/allowed/')")
+										.build())
+						.build())
+				.build();
+
+		DownscopedCredentials credentials = DownscopedCredentials.newBuilder()
+				.setSourceCredential(sourceCredentials)
+				.setCredentialAccessBoundary(cab)
+				.setHttpTransportFactory(stsTransportFactory())
+				.build();
+
+		AccessToken accessToken = credentials.refreshAccessToken();
+
+		assertThat(accessToken.getTokenValue()).startsWith("floci-gcp-downscoped-");
+		assertThat(accessToken.getExpirationTime()).isAfter(Date.from(Instant.now()));
+	}
+
+	private static HttpTransportFactory stsTransportFactory() {
+		return () -> new NetHttpTransport.Builder()
+				.setConnectionFactory(url -> {
+					if ("sts.googleapis.com".equals(url.getHost())) {
+						URL rewritten = new URL(TestFixtures.endpoint() + url.getFile());
+						return (HttpURLConnection) rewritten.openConnection();
+					}
+					return (HttpURLConnection) url.openConnection();
+				})
+				.build();
+	}
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/StsTokenExchangeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/StsTokenExchangeTest.java
@@ -20,9 +20,6 @@ class StsTokenExchangeTest {
 
 	@Test
 	void downscopedCredentialsExchangeTokenWithCustomStsTransport() throws Exception {
-		GoogleCredentials sourceCredentials = GoogleCredentials.create(new AccessToken(
-				"source-token",
-				Date.from(Instant.now().plusSeconds(3600))));
 		CredentialAccessBoundary cab = CredentialAccessBoundary.newBuilder()
 				.addRule(CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
 						.setAvailableResource("//storage.googleapis.com/projects/_/buckets/compat-bucket")
@@ -30,10 +27,28 @@ class StsTokenExchangeTest {
 						.setAvailabilityCondition(
 								CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
 										.setExpression("resource.name.startsWith("
-												+ "'projects/_/buckets/compat-bucket/objects/allowed/')")
-										.build())
+											+ "'projects/_/buckets/compat-bucket/objects/allowed/')")
+									.build())
+							.build())
+					.build();
+		assertCanExchange(cab);
+	}
+
+	@Test
+	void downscopedCredentialsExchangeBucketWideRuleWithoutCondition() throws Exception {
+		CredentialAccessBoundary cab = CredentialAccessBoundary.newBuilder()
+				.addRule(CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+						.setAvailableResource("//storage.googleapis.com/projects/_/buckets/compat-bucket")
+						.setAvailablePermissions(List.of("inRole:roles/storage.objectViewer"))
 						.build())
 				.build();
+		assertCanExchange(cab);
+	}
+
+	private static void assertCanExchange(CredentialAccessBoundary cab) throws Exception {
+		GoogleCredentials sourceCredentials = GoogleCredentials.create(new AccessToken(
+				"source-token",
+				Date.from(Instant.now().plusSeconds(3600))));
 
 		DownscopedCredentials credentials = DownscopedCredentials.newBuilder()
 				.setSourceCredential(sourceCredentials)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -61,6 +61,7 @@ Each service can be toggled independently. All are enabled by default.
 | `FLOCI_GCP_SERVICES_SECRETMANAGER_ENABLED` | `true` | Secret Manager |
 | `FLOCI_GCP_SERVICES_IAM_ENABLED` | `true` | IAM |
 | `FLOCI_GCP_SERVICES_IAMCREDENTIALS_ENABLED` | `true` | IAM Service Account Credentials (`generateAccessToken`) |
+| `FLOCI_GCP_SERVICES_STS_ENABLED` | `true` | Security Token Service (STS) |
 | `FLOCI_GCP_SERVICES_LOGGING_ENABLED` | `true` | Cloud Logging |
 | `FLOCI_GCP_SERVICES_KMS_ENABLED` | `true` | Cloud KMS |
 | `FLOCI_GCP_SERVICES_MONITORING_ENABLED` | `true` | Cloud Monitoring |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | **Cloud Logging** | gRPC + REST | Structured log ingestion (`WriteLogEntries`), read-back (`ListLogEntries`) with filter subset, `ListLogs`, `DeleteLog` |
 | **Cloud KMS** | gRPC + REST | Key rings, crypto keys, versions, symmetric encrypt/decrypt, asymmetric sign/decrypt, `GenerateRandomBytes` |
 | **IAM** | REST | Service accounts, RSA-2048 keys, policy bindings, SignBlob (V4 signed URLs) |
+| **Security Token Service (STS)** | REST | OAuth 2.0 token exchange for GCS Credential Access Boundaries |
 | **Managed Kafka** | REST | Clusters, topics, consumer groups (Redpanda-backed or mock mode) |
 | **Cloud Run** | REST | Service create/get/list/delete, IAM policy operations, revisions, LRO polling; Docker-backed invocation on by default (mock flag for control plane only) |
 | **Cloud Functions** | REST | Function create/get/list/delete, upload URL generation, LRO polling; control plane only |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -15,6 +15,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud KMS](kms.md) | gRPC + REST JSON | `google.cloud.kms.v1.KeyManagementService`, `/v1/projects/{project}/locations/{location}/keyRings` |
 | [IAM](iam.md) | REST JSON | `/v1/projects/{project}/serviceAccounts` |
 | [IAM Credentials](iam-credentials.md) | REST JSON | `/v1/projects/-/serviceAccounts/{sa}:generateAccessToken` |
+| [Security Token Service (STS)](sts.md) | REST JSON | `/v1/token` |
 | [Managed Kafka](managed-kafka.md) | REST JSON | `/v1/projects/{project}/locations/{location}/clusters` |
 | [GKE (Kubernetes Engine)](gke.md) | REST JSON | `container.*` host or `/container/v1/projects/{project}/locations/{location}/clusters` |
 | [Cloud SQL for PostgreSQL](cloud-sql-postgres.md) | REST JSON | `/v1/projects/{project}/instances` |

--- a/docs/services/sts.md
+++ b/docs/services/sts.md
@@ -1,0 +1,61 @@
+# Security Token Service (STS)
+
+floci-gcp implements the OAuth 2.0 token-exchange endpoint used by Google
+`DownscopedCredentials`. The endpoint accepts a source access token and a
+Credential Access Boundary (CAB), then returns an emulator-managed downscoped
+access token.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_GCP_SERVICES_STS_ENABLED` | `true` | Enable/disable STS token exchange |
+
+## Endpoint
+
+| Method | Path | Content type |
+|---|---|---|
+| `POST` | `/v1/token` | `application/x-www-form-urlencoded` |
+
+The supported exchange requires these form fields:
+
+| Field | Required value |
+|---|---|
+| `grant_type` | `urn:ietf:params:oauth:grant-type:token-exchange` |
+| `subject_token_type` | `urn:ietf:params:oauth:token-type:access_token` |
+| `requested_token_type` | `urn:ietf:params:oauth:token-type:access_token` |
+| `subject_token` | The source access token |
+| `options` | A JSON-encoded GCS Credential Access Boundary |
+
+Validation failures use the OAuth error fields `error` and
+`error_description`.
+
+## Credential Access Boundary support
+
+The CAB parser supports Cloud Storage bucket resources and these permissions:
+
+- `inRole:roles/storage.legacyObjectReader`
+- `inRole:roles/storage.objectViewer`
+- `inRole:roles/storage.legacyBucketWriter`
+
+`availabilityCondition` is optional. Without it, the rule applies to the whole
+bucket. When present, the condition can restrict access to one object prefix
+using `resource.name.startsWith(...)`,
+`api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith(...)`,
+or both expressions joined with `||`. Both expressions must identify the same
+prefix.
+
+## Token lifetime
+
+Tokens exchanged from arbitrary external source credentials have a one-hour
+lifetime. When the source is an unexpired impersonated or downscoped token
+issued by floci-gcp, the new token cannot outlive that source token. Unknown or
+expired floci-gcp source tokens are rejected with `invalid_grant`.
+
+## Scope and deviations
+
+- Only access-token-to-access-token exchange is implemented.
+- Only the documented GCS CAB resource, permission, and prefix-expression
+  subset is accepted.
+- Non-floci source credentials are not validated, matching the emulator's
+  general credential-bypass behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Cloud KMS: services/kms.md
     - IAM: services/iam.md
     - IAM Credentials: services/iam-credentials.md
+    - Security Token Service (STS): services/sts.md
     - Managed Kafka: services/managed-kafka.md
     - GKE (Kubernetes Engine): services/gke.md
     - Cloud SQL for PostgreSQL: services/cloud-sql-postgres.md

--- a/src/main/java/io/floci/gcp/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/gcp/config/EmulatorConfig.java
@@ -110,6 +110,8 @@ public interface EmulatorConfig {
 
         IamCredentialsServiceConfig iamcredentials();
 
+		StsServiceConfig sts();
+
         SecretManagerServiceConfig secretmanager();
 
         LoggingServiceConfig logging();
@@ -217,6 +219,11 @@ public interface EmulatorConfig {
         @WithDefault("true")
         boolean enabled();
     }
+
+	interface StsServiceConfig {
+		@WithDefault("true")
+		boolean enabled();
+	}
 
     interface SecretManagerServiceConfig {
         @WithDefault("true")

--- a/src/main/java/io/floci/gcp/core/common/GcpException.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpException.java
@@ -71,6 +71,10 @@ public class GcpException extends RuntimeException {
         return new GcpException(403, "PERMISSION_DENIED", Status.Code.PERMISSION_DENIED, message);
     }
 
+	public static GcpException unauthenticated(String message) {
+		return new GcpException(401, "UNAUTHENTICATED", Status.Code.UNAUTHENTICATED, message);
+	}
+
     public static GcpException resourceExhausted(String message) {
         return new GcpException(429, "RESOURCE_EXHAUSTED", Status.Code.RESOURCE_EXHAUSTED, message);
     }

--- a/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
@@ -42,6 +42,7 @@ public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
             case "FAILED_PRECONDITION" -> "failedPrecondition";
             case "CONDITION_NOT_MET" -> "conditionNotMet";
             case "PERMISSION_DENIED" -> "forbidden";
+			case "UNAUTHENTICATED" -> "authError";
             case "RESOURCE_EXHAUSTED" -> "rateLimitExceeded";
             case "UNIMPLEMENTED" -> "notImplemented";
             case "DEADLINE_EXCEEDED" -> "deadlineExceeded";

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParser.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParser.java
@@ -1,0 +1,231 @@
+package io.floci.gcp.services.credentials;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.gcp.core.common.GcpException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class CredentialAccessBoundaryParser {
+
+	static final String LEGACY_OBJECT_READER = "inRole:roles/storage.legacyObjectReader";
+	static final String OBJECT_VIEWER = "inRole:roles/storage.objectViewer";
+	static final String LEGACY_BUCKET_WRITER = "inRole:roles/storage.legacyBucketWriter";
+
+	private static final Set<String> SUPPORTED_PERMISSIONS = Set.of(
+			LEGACY_OBJECT_READER,
+			OBJECT_VIEWER,
+			LEGACY_BUCKET_WRITER);
+	private static final Pattern RESOURCE_PATTERN =
+			Pattern.compile("^//storage\\.googleapis\\.com/projects/_/buckets/([^/]+)$");
+	private static final Pattern RESOURCE_NAME_PREFIX_PATTERN =
+			Pattern.compile("^resource\\.name\\.startsWith\\((.+)\\)$");
+	private static final Pattern LIST_PREFIX_PATTERN =
+			Pattern.compile("^api\\.getAttribute\\((.+),\\s*(.+)\\)\\.startsWith\\((.+)\\)$");
+
+	private final ObjectMapper objectMapper;
+
+	@Inject
+	public CredentialAccessBoundaryParser(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	public List<CredentialAccessBoundaryRule> parse(String options) {
+		if (options == null || options.isBlank()) {
+			throw invalidGrant("options is required");
+		}
+
+		JsonNode root;
+		try {
+			root = objectMapper.readTree(options);
+		} catch (IOException e) {
+			throw invalidGrant("options must be valid Credential Access Boundary JSON");
+		}
+
+		JsonNode rulesNode = root.path("accessBoundary").path("accessBoundaryRules");
+		if (!rulesNode.isArray() || rulesNode.isEmpty()) {
+			throw invalidGrant("accessBoundaryRules is required");
+		}
+
+		List<CredentialAccessBoundaryRule> rules = new ArrayList<>();
+		for (JsonNode ruleNode : rulesNode) {
+			String bucket = parseBucket(requiredText(ruleNode, "availableResource"));
+			List<String> permissions = parsePermissions(ruleNode.path("availablePermissions"));
+			String expression = ruleNode.path("availabilityCondition").path("expression").asText(null);
+			if (expression == null || expression.isBlank()) {
+				throw invalidGrant("availabilityCondition.expression is required");
+			}
+			String prefix = parsePrefixExpression(bucket, expression);
+			rules.add(new CredentialAccessBoundaryRule(bucket, prefix, permissions));
+		}
+		return rules;
+	}
+
+	private static String requiredText(JsonNode node, String field) {
+		JsonNode value = node.get(field);
+		if (value == null || !value.isTextual() || value.asText().isBlank()) {
+			throw invalidGrant(field + " is required");
+		}
+		return value.asText();
+	}
+
+	private static String parseBucket(String availableResource) {
+		Matcher matcher = RESOURCE_PATTERN.matcher(availableResource);
+		if (!matcher.matches() || matcher.group(1).isBlank()) {
+			throw invalidGrant("unsupported availableResource");
+		}
+		return matcher.group(1);
+	}
+
+	private static List<String> parsePermissions(JsonNode permissionsNode) {
+		if (!permissionsNode.isArray() || permissionsNode.isEmpty()) {
+			throw invalidGrant("availablePermissions is required");
+		}
+		List<String> permissions = new ArrayList<>();
+		for (JsonNode permissionNode : permissionsNode) {
+			if (!permissionNode.isTextual()) {
+				throw invalidGrant("availablePermissions entries must be strings");
+			}
+			String permission = permissionNode.asText();
+			if (!SUPPORTED_PERMISSIONS.contains(permission)) {
+				throw invalidGrant("unsupported availablePermission");
+			}
+			permissions.add(permission);
+		}
+		return permissions;
+	}
+
+	private static String parsePrefixExpression(String bucket, String expression) {
+		Set<String> prefixes = new LinkedHashSet<>();
+		for (String part : splitOrExpression(expression)) {
+			prefixes.add(parseSingleExpression(bucket, part.trim()));
+		}
+		if (prefixes.size() != 1) {
+			throw invalidGrant("all supported expressions must use the same object prefix");
+		}
+		return prefixes.iterator().next();
+	}
+
+	private static List<String> splitOrExpression(String expression) {
+		List<String> parts = new ArrayList<>();
+		int start = 0;
+		Character quote = null;
+		boolean escaped = false;
+		for (int i = 0; i < expression.length(); i++) {
+			char ch = expression.charAt(i);
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (quote != null) {
+				if (ch == '\\') {
+					escaped = true;
+				} else if (ch == quote) {
+					quote = null;
+				}
+				continue;
+			}
+			if (ch == '\'' || ch == '"') {
+				quote = ch;
+			} else if (ch == '|' && i + 1 < expression.length() && expression.charAt(i + 1) == '|') {
+				parts.add(expression.substring(start, i));
+				start = i + 2;
+				i++;
+			}
+		}
+		if (quote != null) {
+			throw invalidGrant("unterminated string literal in expression");
+		}
+		parts.add(expression.substring(start));
+		return parts;
+	}
+
+	private static String parseSingleExpression(String bucket, String expression) {
+		Matcher resourceMatcher = RESOURCE_NAME_PREFIX_PATTERN.matcher(expression);
+		if (resourceMatcher.matches()) {
+			String resourcePrefix = parseOnlyStringArgument(resourceMatcher.group(1));
+			String expectedStart = "projects/_/buckets/" + bucket + "/objects/";
+			if (!resourcePrefix.startsWith(expectedStart)) {
+				throw invalidGrant("resource.name prefix does not match availableResource bucket");
+			}
+			return normalizePrefix(resourcePrefix.substring(expectedStart.length()));
+		}
+
+		Matcher listMatcher = LIST_PREFIX_PATTERN.matcher(expression);
+		if (listMatcher.matches()) {
+			String attribute = parseOnlyStringArgument(listMatcher.group(1));
+			String defaultValue = parseOnlyStringArgument(listMatcher.group(2));
+			String objectPrefix = parseOnlyStringArgument(listMatcher.group(3));
+			if (!"storage.googleapis.com/objectListPrefix".equals(attribute) || !defaultValue.isEmpty()) {
+				throw invalidGrant("unsupported api.getAttribute expression");
+			}
+			return normalizePrefix(objectPrefix);
+		}
+
+		throw invalidGrant("unsupported availabilityCondition expression");
+	}
+
+	private static String parseOnlyStringArgument(String argument) {
+		String trimmed = argument.trim();
+		if (trimmed.length() < 2) {
+			throw invalidGrant("expected string literal");
+		}
+		char quote = trimmed.charAt(0);
+		if ((quote != '\'' && quote != '"') || trimmed.charAt(trimmed.length() - 1) != quote) {
+			throw invalidGrant("expected string literal");
+		}
+		return decodeCelString(trimmed.substring(1, trimmed.length() - 1));
+	}
+
+	private static String decodeCelString(String value) {
+		StringBuilder decoded = new StringBuilder(value.length());
+		boolean escaped = false;
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			if (!escaped) {
+				if (ch == '\\') {
+					escaped = true;
+				} else {
+					decoded.append(ch);
+				}
+				continue;
+			}
+			switch (ch) {
+				case '\\' -> decoded.append('\\');
+				case '\'' -> decoded.append('\'');
+				case '"' -> decoded.append('"');
+				case 'n' -> decoded.append('\n');
+				case 'r' -> decoded.append('\r');
+				case 't' -> decoded.append('\t');
+				case 'b' -> decoded.append('\b');
+				case 'f' -> decoded.append('\f');
+				default -> throw invalidGrant("unsupported string escape");
+			}
+			escaped = false;
+		}
+		if (escaped) {
+			throw invalidGrant("unterminated string escape");
+		}
+		return decoded.toString();
+	}
+
+	private static String normalizePrefix(String prefix) {
+		if (prefix == null || prefix.isBlank()) {
+			throw invalidGrant("object prefix is required");
+		}
+		return prefix.endsWith("/") ? prefix : prefix + "/";
+	}
+
+	private static GcpException invalidGrant(String message) {
+		return GcpException.invalidArgument(message).withReason("invalid_grant");
+	}
+}

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParser.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParser.java
@@ -60,11 +60,15 @@ public class CredentialAccessBoundaryParser {
 		for (JsonNode ruleNode : rulesNode) {
 			String bucket = parseBucket(requiredText(ruleNode, "availableResource"));
 			List<String> permissions = parsePermissions(ruleNode.path("availablePermissions"));
-			String expression = ruleNode.path("availabilityCondition").path("expression").asText(null);
-			if (expression == null || expression.isBlank()) {
-				throw invalidGrant("availabilityCondition.expression is required");
+			JsonNode conditionNode = ruleNode.get("availabilityCondition");
+			String prefix = "";
+			if (conditionNode != null && !conditionNode.isNull()) {
+				String expression = conditionNode.path("expression").asText(null);
+				if (expression == null || expression.isBlank()) {
+					throw invalidGrant("availabilityCondition.expression is required");
+				}
+				prefix = parsePrefixExpression(bucket, expression);
 			}
-			String prefix = parsePrefixExpression(bucket, expression);
 			rules.add(new CredentialAccessBoundaryRule(bucket, prefix, permissions));
 		}
 		return rules;

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryRule.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryRule.java
@@ -1,0 +1,49 @@
+package io.floci.gcp.services.credentials;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+public class CredentialAccessBoundaryRule {
+
+	private String bucket;
+	private String objectPrefix;
+	private List<String> availablePermissions = new ArrayList<>();
+
+	public CredentialAccessBoundaryRule() {
+	}
+
+	public CredentialAccessBoundaryRule(String bucket, String objectPrefix, List<String> availablePermissions) {
+		this.bucket = bucket;
+		this.objectPrefix = objectPrefix;
+		this.availablePermissions = new ArrayList<>(availablePermissions);
+	}
+
+	public String getBucket() {
+		return bucket;
+	}
+
+	public void setBucket(String bucket) {
+		this.bucket = bucket;
+	}
+
+	public String getObjectPrefix() {
+		return objectPrefix;
+	}
+
+	public void setObjectPrefix(String objectPrefix) {
+		this.objectPrefix = objectPrefix;
+	}
+
+	public List<String> getAvailablePermissions() {
+		return availablePermissions;
+	}
+
+	public void setAvailablePermissions(List<String> availablePermissions) {
+		this.availablePermissions = availablePermissions == null
+				? new ArrayList<>()
+				: new ArrayList<>(availablePermissions);
+	}
+}

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
@@ -1,0 +1,98 @@
+package io.floci.gcp.services.credentials;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@ApplicationScoped
+public class CredentialTokenService {
+
+	public static final String FLOCI_TOKEN_PREFIX = "floci-gcp-";
+	public static final String IMPERSONATED_TOKEN_PREFIX = "floci-gcp-impersonated-";
+	public static final String DOWNSCOPED_TOKEN_PREFIX = "floci-gcp-downscoped-";
+	public static final long DEFAULT_LIFETIME_SECONDS = 3600;
+
+	private final StorageBackend<String, StoredCredentialToken> tokenStore;
+	private final Clock clock;
+
+	@Inject
+	public CredentialTokenService(StorageFactory storageFactory) {
+		this(storageFactory.createGlobal("credential-tokens", "credential-tokens.json",
+				new TypeReference<Map<String, StoredCredentialToken>>() {}),
+				Clock.systemUTC());
+	}
+
+	public CredentialTokenService(StorageBackend<String, StoredCredentialToken> tokenStore, Clock clock) {
+		this.tokenStore = tokenStore;
+		this.clock = clock;
+	}
+
+	public StoredCredentialToken mintImpersonatedToken(String principal, Instant expireTime) {
+		if (principal == null || principal.isBlank()) {
+			throw GcpException.invalidArgument("service account is required");
+		}
+		if (expireTime == null || !expireTime.isAfter(clock.instant())) {
+			throw GcpException.invalidArgument("expireTime must be in the future");
+		}
+
+		String tokenValue = IMPERSONATED_TOKEN_PREFIX + UUID.randomUUID();
+		StoredCredentialToken token = new StoredCredentialToken(
+				tokenValue,
+				StoredCredentialToken.TokenKind.IMPERSONATED,
+				expireTime,
+				null,
+				principal,
+				List.of());
+		tokenStore.put(tokenValue, token);
+		return token;
+	}
+
+	public StoredCredentialToken mintDownscopedToken(String sourceToken,
+			List<CredentialAccessBoundaryRule> gcsRules) {
+		if (sourceToken == null || sourceToken.isBlank()) {
+			throw GcpException.invalidArgument("subject_token is required");
+		}
+		if (gcsRules == null || gcsRules.isEmpty()) {
+			throw GcpException.invalidArgument("credential access boundary rules are required");
+		}
+
+		String tokenValue = DOWNSCOPED_TOKEN_PREFIX + UUID.randomUUID();
+		StoredCredentialToken token = new StoredCredentialToken(
+				tokenValue,
+				StoredCredentialToken.TokenKind.DOWNSCOPED,
+				clock.instant().plusSeconds(DEFAULT_LIFETIME_SECONDS),
+				null,
+				null,
+				gcsRules);
+		tokenStore.put(tokenValue, token);
+		return token;
+	}
+
+	public Optional<StoredCredentialToken> lookupBearerToken(String bearerToken) {
+		if (bearerToken == null || bearerToken.isBlank() || !bearerToken.startsWith(FLOCI_TOKEN_PREFIX)) {
+			return Optional.empty();
+		}
+
+		StoredCredentialToken token = tokenStore.get(bearerToken)
+				.orElseThrow(() -> GcpException.unauthenticated("Unknown Floci credential token"));
+		if (token.getExpireTime() == null || !token.getExpireTime().isAfter(clock.instant())) {
+			tokenStore.delete(bearerToken);
+			throw GcpException.unauthenticated("Expired Floci credential token");
+		}
+		return Optional.of(token);
+	}
+
+	public void clear() {
+		tokenStore.clear();
+	}
+}

--- a/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
+++ b/src/main/java/io/floci/gcp/services/credentials/CredentialTokenService.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class CredentialTokenService {
 		return token;
 	}
 
-	public StoredCredentialToken mintDownscopedToken(String sourceToken,
+	public MintedDownscopedToken mintDownscopedToken(String sourceToken,
 			List<CredentialAccessBoundaryRule> gcsRules) {
 		if (sourceToken == null || sourceToken.isBlank()) {
 			throw GcpException.invalidArgument("subject_token is required");
@@ -66,26 +67,37 @@ public class CredentialTokenService {
 			throw GcpException.invalidArgument("credential access boundary rules are required");
 		}
 
+		Instant now = clock.instant();
+		Instant expireTime = now.plusSeconds(DEFAULT_LIFETIME_SECONDS);
+		Optional<StoredCredentialToken> storedSource = lookupBearerToken(sourceToken, now);
+		if (storedSource.isPresent() && storedSource.get().getExpireTime().isBefore(expireTime)) {
+			expireTime = storedSource.get().getExpireTime();
+		}
+
 		String tokenValue = DOWNSCOPED_TOKEN_PREFIX + UUID.randomUUID();
 		StoredCredentialToken token = new StoredCredentialToken(
 				tokenValue,
 				StoredCredentialToken.TokenKind.DOWNSCOPED,
-				clock.instant().plusSeconds(DEFAULT_LIFETIME_SECONDS),
+				expireTime,
 				null,
 				null,
 				gcsRules);
 		tokenStore.put(tokenValue, token);
-		return token;
+		return new MintedDownscopedToken(token, Duration.between(now, expireTime).toSeconds());
 	}
 
 	public Optional<StoredCredentialToken> lookupBearerToken(String bearerToken) {
+		return lookupBearerToken(bearerToken, clock.instant());
+	}
+
+	private Optional<StoredCredentialToken> lookupBearerToken(String bearerToken, Instant now) {
 		if (bearerToken == null || bearerToken.isBlank() || !bearerToken.startsWith(FLOCI_TOKEN_PREFIX)) {
 			return Optional.empty();
 		}
 
 		StoredCredentialToken token = tokenStore.get(bearerToken)
 				.orElseThrow(() -> GcpException.unauthenticated("Unknown Floci credential token"));
-		if (token.getExpireTime() == null || !token.getExpireTime().isAfter(clock.instant())) {
+		if (token.getExpireTime() == null || !token.getExpireTime().isAfter(now)) {
 			tokenStore.delete(bearerToken);
 			throw GcpException.unauthenticated("Expired Floci credential token");
 		}
@@ -94,5 +106,8 @@ public class CredentialTokenService {
 
 	public void clear() {
 		tokenStore.clear();
+	}
+
+	public record MintedDownscopedToken(StoredCredentialToken token, long expiresInSeconds) {
 	}
 }

--- a/src/main/java/io/floci/gcp/services/credentials/StoredCredentialToken.java
+++ b/src/main/java/io/floci/gcp/services/credentials/StoredCredentialToken.java
@@ -1,0 +1,84 @@
+package io.floci.gcp.services.credentials;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+public class StoredCredentialToken {
+
+	public enum TokenKind {
+		IMPERSONATED,
+		DOWNSCOPED
+	}
+
+	private String tokenValue;
+	private TokenKind tokenKind;
+	private Instant expireTime;
+	private String sourceToken;
+	private String principal;
+	private List<CredentialAccessBoundaryRule> gcsRules = new ArrayList<>();
+
+	public StoredCredentialToken() {
+	}
+
+	public StoredCredentialToken(String tokenValue, TokenKind tokenKind, Instant expireTime,
+			String sourceToken, String principal, List<CredentialAccessBoundaryRule> gcsRules) {
+		this.tokenValue = tokenValue;
+		this.tokenKind = tokenKind;
+		this.expireTime = expireTime;
+		this.sourceToken = sourceToken;
+		this.principal = principal;
+		this.gcsRules = new ArrayList<>(gcsRules);
+	}
+
+	public String getTokenValue() {
+		return tokenValue;
+	}
+
+	public void setTokenValue(String tokenValue) {
+		this.tokenValue = tokenValue;
+	}
+
+	public TokenKind getTokenKind() {
+		return tokenKind;
+	}
+
+	public void setTokenKind(TokenKind tokenKind) {
+		this.tokenKind = tokenKind;
+	}
+
+	public Instant getExpireTime() {
+		return expireTime;
+	}
+
+	public void setExpireTime(Instant expireTime) {
+		this.expireTime = expireTime;
+	}
+
+	public String getSourceToken() {
+		return sourceToken;
+	}
+
+	public void setSourceToken(String sourceToken) {
+		this.sourceToken = sourceToken;
+	}
+
+	public String getPrincipal() {
+		return principal;
+	}
+
+	public void setPrincipal(String principal) {
+		this.principal = principal;
+	}
+
+	public List<CredentialAccessBoundaryRule> getGcsRules() {
+		return gcsRules;
+	}
+
+	public void setGcsRules(List<CredentialAccessBoundaryRule> gcsRules) {
+		this.gcsRules = gcsRules == null ? new ArrayList<>() : new ArrayList<>(gcsRules);
+	}
+}

--- a/src/main/java/io/floci/gcp/services/iamcredentials/IamCredentialsService.java
+++ b/src/main/java/io/floci/gcp/services/iamcredentials/IamCredentialsService.java
@@ -5,6 +5,8 @@ import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.ServiceDescriptor;
 import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import io.floci.gcp.services.credentials.StoredCredentialToken;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -14,34 +16,37 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 @ApplicationScoped
 public class IamCredentialsService {
 
     static final String DEVSTORAGE_READ_WRITE_SCOPE = "https://www.googleapis.com/auth/devstorage.read_write";
     static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
-    static final String TOKEN_PREFIX = "floci-gcp-impersonated-";
+    static final String TOKEN_PREFIX = CredentialTokenService.IMPERSONATED_TOKEN_PREFIX;
     static final long DEFAULT_LIFETIME_SECONDS = 3600;
     static final long MAX_LIFETIME_SECONDS = 3600;
     private static final Set<String> SUPPORTED_SCOPES = Set.of(DEVSTORAGE_READ_WRITE_SCOPE, CLOUD_PLATFORM_SCOPE);
 
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
+    private final CredentialTokenService tokenService;
     private final Clock clock;
 
     @Inject
-    public IamCredentialsService(ServiceRegistry serviceRegistry, EmulatorConfig config) {
-        this(serviceRegistry, config, Clock.systemUTC());
+    public IamCredentialsService(ServiceRegistry serviceRegistry, EmulatorConfig config,
+            CredentialTokenService tokenService) {
+        this(serviceRegistry, config, tokenService, Clock.systemUTC());
     }
 
-    IamCredentialsService(Clock clock) {
-        this(null, null, clock);
+    IamCredentialsService(CredentialTokenService tokenService, Clock clock) {
+        this(null, null, tokenService, clock);
     }
 
-    private IamCredentialsService(ServiceRegistry serviceRegistry, EmulatorConfig config, Clock clock) {
+    private IamCredentialsService(ServiceRegistry serviceRegistry, EmulatorConfig config,
+            CredentialTokenService tokenService, Clock clock) {
         this.serviceRegistry = serviceRegistry;
         this.config = config;
+        this.tokenService = tokenService;
         this.clock = clock;
     }
 
@@ -62,7 +67,8 @@ public class IamCredentialsService {
 
         long lifetimeSeconds = parseLifetimeSeconds(lifetime);
         Instant expireTime = clock.instant().plusSeconds(lifetimeSeconds);
-        return new GeneratedAccessToken(TOKEN_PREFIX + UUID.randomUUID(), expireTime);
+        StoredCredentialToken token = tokenService.mintImpersonatedToken(serviceAccount, expireTime);
+        return new GeneratedAccessToken(token.getTokenValue(), expireTime);
     }
 
     private static void validateScopes(List<?> scopes) {

--- a/src/main/java/io/floci/gcp/services/sts/StsController.java
+++ b/src/main/java/io/floci/gcp/services/sts/StsController.java
@@ -1,0 +1,42 @@
+package io.floci.gcp.services.sts;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Path("/v1")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class StsController {
+
+	@Inject
+	StsService service;
+
+	@POST
+	@Path("/token")
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+	public Response token(@FormParam("grant_type") String grantType,
+			@FormParam("subject_token_type") String subjectTokenType,
+			@FormParam("subject_token") String subjectToken,
+			@FormParam("requested_token_type") String requestedTokenType,
+			@FormParam("options") String options) {
+		try {
+			return Response.ok(service.exchangeToken(
+					grantType, subjectTokenType, subjectToken, requestedTokenType, options)).build();
+		} catch (StsException e) {
+			Map<String, Object> error = new LinkedHashMap<>();
+			error.put("error", e.error());
+			error.put("error_description", e.getMessage());
+			return Response.status(400).type(MediaType.APPLICATION_JSON).entity(error).build();
+		}
+	}
+}

--- a/src/main/java/io/floci/gcp/services/sts/StsException.java
+++ b/src/main/java/io/floci/gcp/services/sts/StsException.java
@@ -1,0 +1,15 @@
+package io.floci.gcp.services.sts;
+
+class StsException extends RuntimeException {
+
+	private final String error;
+
+	StsException(String error, String message) {
+		super(message);
+		this.error = error;
+	}
+
+	String error() {
+		return error;
+	}
+}

--- a/src/main/java/io/floci/gcp/services/sts/StsService.java
+++ b/src/main/java/io/floci/gcp/services/sts/StsService.java
@@ -1,0 +1,96 @@
+package io.floci.gcp.services.sts;
+
+import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.ServiceDescriptor;
+import io.floci.gcp.core.common.ServiceProtocol;
+import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.services.credentials.CredentialAccessBoundaryParser;
+import io.floci.gcp.services.credentials.CredentialAccessBoundaryRule;
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import io.floci.gcp.services.credentials.StoredCredentialToken;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class StsService {
+
+	static final String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+	static final String ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+	static final String BEARER_TOKEN_TYPE = "Bearer";
+
+	private final ServiceRegistry serviceRegistry;
+	private final EmulatorConfig config;
+	private final CredentialAccessBoundaryParser cabParser;
+	private final CredentialTokenService tokenService;
+
+	@Inject
+	public StsService(ServiceRegistry serviceRegistry, EmulatorConfig config,
+			CredentialAccessBoundaryParser cabParser, CredentialTokenService tokenService) {
+		this.serviceRegistry = serviceRegistry;
+		this.config = config;
+		this.cabParser = cabParser;
+		this.tokenService = tokenService;
+	}
+
+	StsService(CredentialAccessBoundaryParser cabParser, CredentialTokenService tokenService) {
+		this(null, null, cabParser, tokenService);
+	}
+
+	void onStart(@Observes StartupEvent ev) {
+		serviceRegistry.register(ServiceDescriptor.builder("sts")
+				.enabled(config.services().sts().enabled())
+				.storageKey("credential-tokens")
+				.protocol(ServiceProtocol.REST)
+				.resourceClasses(StsController.class)
+				.build());
+	}
+
+	public Map<String, Object> exchangeToken(String grantType, String subjectTokenType,
+			String subjectToken, String requestedTokenType, String options) {
+		requireEquals("grant_type", grantType, TOKEN_EXCHANGE_GRANT_TYPE);
+		requireEquals("subject_token_type", subjectTokenType, ACCESS_TOKEN_TYPE);
+		requireEquals("requested_token_type", requestedTokenType, ACCESS_TOKEN_TYPE);
+		if (subjectToken == null || subjectToken.isBlank()) {
+			throw invalidRequest("subject_token is required");
+		}
+		if (options == null || options.isBlank()) {
+			throw invalidRequest("options is required");
+		}
+
+		List<CredentialAccessBoundaryRule> rules;
+		try {
+			rules = cabParser.parse(options);
+		} catch (GcpException e) {
+			throw invalidGrant(e.getMessage());
+		}
+
+		StoredCredentialToken token = tokenService.mintDownscopedToken(subjectToken, rules);
+		Map<String, Object> response = new LinkedHashMap<>();
+		response.put("access_token", token.getTokenValue());
+		response.put("issued_token_type", ACCESS_TOKEN_TYPE);
+		response.put("token_type", BEARER_TOKEN_TYPE);
+		response.put("expires_in", CredentialTokenService.DEFAULT_LIFETIME_SECONDS);
+		return response;
+	}
+
+	private static void requireEquals(String field, String actual, String expected) {
+		if (!expected.equals(actual)) {
+			throw invalidRequest(field + " must be " + expected);
+		}
+	}
+
+	private static StsException invalidRequest(String message) {
+		return new StsException("invalid_request", message);
+	}
+
+	private static StsException invalidGrant(String message) {
+		return new StsException("invalid_grant", message);
+	}
+}

--- a/src/main/java/io/floci/gcp/services/sts/StsService.java
+++ b/src/main/java/io/floci/gcp/services/sts/StsService.java
@@ -64,19 +64,20 @@ public class StsService {
 			throw invalidRequest("options is required");
 		}
 
-		List<CredentialAccessBoundaryRule> rules;
+		CredentialTokenService.MintedDownscopedToken mintedToken;
 		try {
-			rules = cabParser.parse(options);
+			List<CredentialAccessBoundaryRule> rules = cabParser.parse(options);
+			mintedToken = tokenService.mintDownscopedToken(subjectToken, rules);
 		} catch (GcpException e) {
 			throw invalidGrant(e.getMessage());
 		}
 
-		StoredCredentialToken token = tokenService.mintDownscopedToken(subjectToken, rules);
+		StoredCredentialToken token = mintedToken.token();
 		Map<String, Object> response = new LinkedHashMap<>();
 		response.put("access_token", token.getTokenValue());
 		response.put("issued_token_type", ACCESS_TOKEN_TYPE);
 		response.put("token_type", BEARER_TOKEN_TYPE);
-		response.put("expires_in", CredentialTokenService.DEFAULT_LIFETIME_SECONDS);
+		response.put("expires_in", mintedToken.expiresInSeconds());
 		return response;
 	}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,8 @@ floci-gcp:
       enabled: true
     iamcredentials:
       enabled: true
+    sts:
+      enabled: true
     secretmanager:
       enabled: true
     logging:

--- a/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
+++ b/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
@@ -84,6 +84,8 @@ class GcpExceptionMapperTest {
                 GcpExceptionMapper.ErrorDetail.of(409, "x", "ALREADY_EXISTS").errors().get(0).reason());
         assertEquals("conditionNotMet",
                 GcpExceptionMapper.ErrorDetail.of(412, "x", "CONDITION_NOT_MET").errors().get(0).reason());
+		assertEquals("authError",
+				GcpExceptionMapper.ErrorDetail.of(401, "x", "UNAUTHENTICATED").errors().get(0).reason());
         assertEquals("forbidden",
                 GcpExceptionMapper.ErrorDetail.of(403, "x", "PERMISSION_DENIED").errors().get(0).reason());
         assertEquals("backendError",

--- a/src/test/java/io/floci/gcp/core/common/GcpExceptionTest.java
+++ b/src/test/java/io/floci/gcp/core/common/GcpExceptionTest.java
@@ -48,6 +48,14 @@ class GcpExceptionTest {
         assertEquals(Status.Code.PERMISSION_DENIED, ex.getGrpcCode());
     }
 
+	@Test
+	void unauthenticated() {
+		GcpException ex = GcpException.unauthenticated("bad token");
+		assertEquals(401, ex.getHttpStatus());
+		assertEquals("UNAUTHENTICATED", ex.getGcpStatus());
+		assertEquals(Status.Code.UNAUTHENTICATED, ex.getGrpcCode());
+	}
+
     @Test
     void resourceExhausted() {
         GcpException ex = GcpException.resourceExhausted("quota exceeded");

--- a/src/test/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParserTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParserTest.java
@@ -1,0 +1,147 @@
+package io.floci.gcp.services.credentials;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.gcp.core.common.GcpException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CredentialAccessBoundaryParserTest {
+
+	private final CredentialAccessBoundaryParser parser = new CredentialAccessBoundaryParser(new ObjectMapper());
+
+	@Test
+	void parsesReadRuleWithLegacyObjectReader() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.LEGACY_OBJECT_READER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/data/')"));
+
+		assertEquals(1, rules.size());
+		assertEquals("bucket", rules.getFirst().getBucket());
+		assertEquals("data/", rules.getFirst().getObjectPrefix());
+		assertEquals(List.of(CredentialAccessBoundaryParser.LEGACY_OBJECT_READER),
+				rules.getFirst().getAvailablePermissions());
+	}
+
+	@Test
+	void parsesListRuleWithObjectViewer() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.OBJECT_VIEWER,
+				"api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('data/')"));
+
+		assertEquals("data/", rules.getFirst().getObjectPrefix());
+		assertEquals(List.of(CredentialAccessBoundaryParser.OBJECT_VIEWER),
+				rules.getFirst().getAvailablePermissions());
+	}
+
+	@Test
+	void parsesWriteRuleWithLegacyBucketWriter() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.LEGACY_BUCKET_WRITER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/out')"));
+
+		assertEquals("out/", rules.getFirst().getObjectPrefix());
+	}
+
+	@Test
+	void parsesOrExpressionWithSamePrefix() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.OBJECT_VIEWER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/data/')"
+						+ " || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('data/')"));
+
+		assertEquals("data/", rules.getFirst().getObjectPrefix());
+	}
+
+	@Test
+	void preservesPrefixBoundaries() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.LEGACY_OBJECT_READER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/data')"));
+
+		assertEquals("data/", rules.getFirst().getObjectPrefix());
+	}
+
+	@Test
+	void decodesEscapedStrings() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.LEGACY_OBJECT_READER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/dir\\\\quoted\\'/')"));
+
+		assertEquals("dir\\quoted'/", rules.getFirst().getObjectPrefix());
+	}
+
+	@Test
+	void rejectsUnsupportedResource() {
+		assertInvalidGrant(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.LEGACY_OBJECT_READER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/data/')")
+				.replace("storage.googleapis.com", "pubsub.googleapis.com"));
+	}
+
+	@Test
+	void rejectsUnsupportedPermission() {
+		assertInvalidGrant(cab(
+				"bucket",
+				"inRole:roles/storage.admin",
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/data/')"));
+	}
+
+	@Test
+	void rejectsUnsupportedExpression() {
+		assertInvalidGrant(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.LEGACY_OBJECT_READER,
+				"resource.name == 'projects/_/buckets/bucket/objects/data/file'"));
+	}
+
+	@Test
+	void rejectsMalformedJson() {
+		assertInvalidGrant("{not-json");
+	}
+
+	@Test
+	void rejectsExpressionsWithDifferentPrefixes() {
+		assertInvalidGrant(cab(
+				"bucket",
+				CredentialAccessBoundaryParser.OBJECT_VIEWER,
+				"resource.name.startsWith('projects/_/buckets/bucket/objects/data/')"
+						+ " || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('other/')"));
+	}
+
+	private static void assertInvalidGrant(String options) {
+		GcpException ex = assertThrows(GcpException.class,
+				() -> new CredentialAccessBoundaryParser(new ObjectMapper()).parse(options));
+
+		assertEquals("INVALID_ARGUMENT", ex.getGcpStatus());
+		assertEquals("invalid_grant", ex.getReason());
+	}
+
+	static String cab(String bucket, String permission, String expression) {
+		return """
+				{
+				  "accessBoundary": {
+					"accessBoundaryRules": [
+					  {
+						"availableResource": "//storage.googleapis.com/projects/_/buckets/%s",
+						"availablePermissions": ["%s"],
+						"availabilityCondition": {
+						  "expression": "%s"
+						}
+					  }
+					]
+				  }
+				}
+				""".formatted(bucket, permission, expression.replace("\\", "\\\\").replace("\"", "\\\""));
+	}
+}

--- a/src/test/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParserTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/CredentialAccessBoundaryParserTest.java
@@ -61,6 +61,17 @@ class CredentialAccessBoundaryParserTest {
 	}
 
 	@Test
+	void parsesBucketWideRuleWithoutAvailabilityCondition() {
+		List<CredentialAccessBoundaryRule> rules = parser.parse(cabWithoutCondition(
+				"bucket", CredentialAccessBoundaryParser.OBJECT_VIEWER));
+
+		assertEquals("bucket", rules.getFirst().getBucket());
+		assertEquals("", rules.getFirst().getObjectPrefix());
+		assertEquals(List.of(CredentialAccessBoundaryParser.OBJECT_VIEWER),
+				rules.getFirst().getAvailablePermissions());
+	}
+
+	@Test
 	void preservesPrefixBoundaries() {
 		List<CredentialAccessBoundaryRule> rules = parser.parse(cab(
 				"bucket",
@@ -106,6 +117,14 @@ class CredentialAccessBoundaryParserTest {
 	}
 
 	@Test
+	void rejectsAvailabilityConditionWithoutExpression() {
+		assertInvalidGrant(cabWithoutCondition(
+				"bucket", CredentialAccessBoundaryParser.OBJECT_VIEWER)
+				.replace("\"availablePermissions\"", "\"availabilityCondition\": {},\n"
+						+ "        \"availablePermissions\""));
+	}
+
+	@Test
 	void rejectsMalformedJson() {
 		assertInvalidGrant("{not-json");
 	}
@@ -143,5 +162,20 @@ class CredentialAccessBoundaryParserTest {
 				  }
 				}
 				""".formatted(bucket, permission, expression.replace("\\", "\\\\").replace("\"", "\\\""));
+	}
+
+	private static String cabWithoutCondition(String bucket, String permission) {
+		return """
+				{
+				  "accessBoundary": {
+					"accessBoundaryRules": [
+					  {
+						"availableResource": "//storage.googleapis.com/projects/_/buckets/%s",
+						"availablePermissions": ["%s"]
+					  }
+					]
+				  }
+				}
+				""".formatted(bucket, permission);
 	}
 }

--- a/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
@@ -1,0 +1,92 @@
+package io.floci.gcp.services.credentials;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CredentialTokenServiceTest {
+
+	private static final Instant NOW = Instant.parse("2026-07-15T12:00:00Z");
+	private final InMemoryStorage<String, StoredCredentialToken> store = new InMemoryStorage<>();
+	private final CredentialTokenService service =
+			new CredentialTokenService(store, Clock.fixed(NOW, ZoneOffset.UTC));
+
+	@Test
+	void storesAndRetrievesDownscopedToken() {
+		StoredCredentialToken token = service.mintDownscopedToken("source-token", rules());
+
+		Optional<StoredCredentialToken> resolved = service.lookupBearerToken(token.getTokenValue());
+
+		assertTrue(resolved.isPresent());
+		assertEquals(StoredCredentialToken.TokenKind.DOWNSCOPED, resolved.get().getTokenKind());
+		assertEquals(NOW.plusSeconds(CredentialTokenService.DEFAULT_LIFETIME_SECONDS),
+				resolved.get().getExpireTime());
+		assertNull(resolved.get().getSourceToken());
+		assertEquals("bucket", resolved.get().getGcsRules().getFirst().getBucket());
+	}
+
+	@Test
+	void storesAndRetrievesImpersonatedTokenWithoutAccessRules() {
+		StoredCredentialToken token = service.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com", NOW.plusSeconds(1200));
+
+		Optional<StoredCredentialToken> resolved = service.lookupBearerToken(token.getTokenValue());
+
+		assertTrue(resolved.isPresent());
+		assertEquals(StoredCredentialToken.TokenKind.IMPERSONATED, resolved.get().getTokenKind());
+		assertEquals(NOW.plusSeconds(1200), resolved.get().getExpireTime());
+		assertEquals("test@test-project.iam.gserviceaccount.com", resolved.get().getPrincipal());
+		assertTrue(resolved.get().getGcsRules().isEmpty());
+	}
+
+	@Test
+	void expiredTokenIsRejectedAndRemoved() {
+		StoredCredentialToken expired = new StoredCredentialToken(
+				CredentialTokenService.DOWNSCOPED_TOKEN_PREFIX + "expired",
+				StoredCredentialToken.TokenKind.DOWNSCOPED,
+				NOW.minusSeconds(1),
+				"source-token",
+				null,
+				rules());
+		store.put(expired.getTokenValue(), expired);
+
+		GcpException ex = assertThrows(GcpException.class,
+				() -> service.lookupBearerToken(expired.getTokenValue()));
+
+		assertEquals("UNAUTHENTICATED", ex.getGcpStatus());
+		assertFalse(store.get(expired.getTokenValue()).isPresent());
+	}
+
+	@Test
+	void unknownFlociTokenIsRejected() {
+		GcpException ex = assertThrows(GcpException.class,
+				() -> service.lookupBearerToken(CredentialTokenService.DOWNSCOPED_TOKEN_PREFIX + "missing"));
+
+		assertEquals("UNAUTHENTICATED", ex.getGcpStatus());
+	}
+
+	@Test
+	void nonFlociTokenReturnsEmptyLookupForLaterBypassContract() {
+		assertTrue(service.lookupBearerToken("external-token").isEmpty());
+		assertTrue(service.lookupBearerToken(null).isEmpty());
+	}
+
+	private static List<CredentialAccessBoundaryRule> rules() {
+		return List.of(new CredentialAccessBoundaryRule(
+				"bucket",
+				"data/",
+				List.of(CredentialAccessBoundaryParser.LEGACY_OBJECT_READER)));
+	}
+}

--- a/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/credentials/CredentialTokenServiceTest.java
@@ -25,16 +25,32 @@ class CredentialTokenServiceTest {
 
 	@Test
 	void storesAndRetrievesDownscopedToken() {
-		StoredCredentialToken token = service.mintDownscopedToken("source-token", rules());
+		CredentialTokenService.MintedDownscopedToken minted =
+				service.mintDownscopedToken("source-token", rules());
+		StoredCredentialToken token = minted.token();
 
 		Optional<StoredCredentialToken> resolved = service.lookupBearerToken(token.getTokenValue());
 
+		assertEquals(CredentialTokenService.DEFAULT_LIFETIME_SECONDS, minted.expiresInSeconds());
 		assertTrue(resolved.isPresent());
 		assertEquals(StoredCredentialToken.TokenKind.DOWNSCOPED, resolved.get().getTokenKind());
 		assertEquals(NOW.plusSeconds(CredentialTokenService.DEFAULT_LIFETIME_SECONDS),
 				resolved.get().getExpireTime());
 		assertNull(resolved.get().getSourceToken());
 		assertEquals("bucket", resolved.get().getGcsRules().getFirst().getBucket());
+	}
+
+	@Test
+	void capsDownscopedTokenLifetimeToStoredSourceExpiration() {
+		StoredCredentialToken source = service.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com", NOW.plusSeconds(1200));
+
+		CredentialTokenService.MintedDownscopedToken minted =
+				service.mintDownscopedToken(source.getTokenValue(), rules());
+
+		assertEquals(1200, minted.expiresInSeconds());
+		assertEquals(source.getExpireTime(), minted.token().getExpireTime());
+		assertNull(minted.token().getSourceToken());
 	}
 
 	@Test

--- a/src/test/java/io/floci/gcp/services/iamcredentials/IamCredentialsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/iamcredentials/IamCredentialsServiceTest.java
@@ -1,12 +1,16 @@
 package io.floci.gcp.services.iamcredentials;
 
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import io.floci.gcp.services.credentials.StoredCredentialToken;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,11 +18,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IamCredentialsServiceTest {
 
-    private static final Instant NOW = Instant.parse("2026-07-15T12:00:00Z");
-    private static final String SERVICE_ACCOUNT = "test@test-project.iam.gserviceaccount.com";
+	private static final Instant NOW = Instant.parse("2026-07-15T12:00:00Z");
+	private static final String SERVICE_ACCOUNT = "test@test-project.iam.gserviceaccount.com";
 
-    private final IamCredentialsService service =
-            new IamCredentialsService(Clock.fixed(NOW, ZoneOffset.UTC));
+	private final InMemoryStorage<String, StoredCredentialToken> tokenStore = new InMemoryStorage<>();
+	private final CredentialTokenService tokenService =
+			new CredentialTokenService(tokenStore, Clock.fixed(NOW, ZoneOffset.UTC));
+	private final IamCredentialsService service =
+			new IamCredentialsService(tokenService, Clock.fixed(NOW, ZoneOffset.UTC));
 
     @Test
     void generatesTokenAndExpiryForNormalRequest() {
@@ -27,9 +34,13 @@ class IamCredentialsServiceTest {
                 List.of(IamCredentialsService.DEVSTORAGE_READ_WRITE_SCOPE),
                 "1200s");
 
-        assertTrue(token.accessToken().startsWith(IamCredentialsService.TOKEN_PREFIX));
-        assertEquals(NOW.plusSeconds(1200), token.expireTime());
-    }
+		assertTrue(token.accessToken().startsWith(IamCredentialsService.TOKEN_PREFIX));
+		assertEquals(NOW.plusSeconds(1200), token.expireTime());
+		Optional<StoredCredentialToken> stored = tokenService.lookupBearerToken(token.accessToken());
+		assertTrue(stored.isPresent());
+		assertEquals(StoredCredentialToken.TokenKind.IMPERSONATED, stored.get().getTokenKind());
+		assertEquals(SERVICE_ACCOUNT, stored.get().getPrincipal());
+	}
 
     @Test
     void defaultsLifetimeWhenAbsent() {

--- a/src/test/java/io/floci/gcp/services/sts/StsDisabledRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/sts/StsDisabledRestIntegrationTest.java
@@ -1,0 +1,39 @@
+package io.floci.gcp.services.sts;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(StsDisabledRestIntegrationTest.DisabledStsProfile.class)
+class StsDisabledRestIntegrationTest {
+
+	@Test
+	void disabledStsReturnsUnavailableWrapper() {
+		given()
+				.contentType("application/x-www-form-urlencoded")
+				.formParam("grant_type", StsService.TOKEN_EXCHANGE_GRANT_TYPE)
+				.formParam("subject_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("subject_token", "source-token")
+				.formParam("requested_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("options", StsServiceTest.cab())
+				.when().post("/v1/token")
+				.then()
+				.statusCode(503)
+				.body("error.status", equalTo("UNAVAILABLE"))
+				.body("error.message", equalTo("Service sts is not enabled."));
+	}
+
+	public static class DisabledStsProfile implements QuarkusTestProfile {
+		@Override
+		public Map<String, String> getConfigOverrides() {
+			return Map.of("floci-gcp.services.sts.enabled", "false");
+		}
+	}
+}

--- a/src/test/java/io/floci/gcp/services/sts/StsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/sts/StsRestIntegrationTest.java
@@ -1,0 +1,76 @@
+package io.floci.gcp.services.sts;
+
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+class StsRestIntegrationTest {
+
+	@Test
+	void validFormExchangeReturnsRequiredFields() {
+		given()
+				.contentType("application/x-www-form-urlencoded")
+				.formParam("grant_type", StsService.TOKEN_EXCHANGE_GRANT_TYPE)
+				.formParam("subject_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("subject_token", "source-token")
+				.formParam("requested_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("options", StsServiceTest.cab())
+				.when().post("/v1/token")
+				.then()
+				.statusCode(200)
+				.body("access_token", startsWith(CredentialTokenService.DOWNSCOPED_TOKEN_PREFIX))
+				.body("issued_token_type", equalTo(StsService.ACCESS_TOKEN_TYPE))
+				.body("token_type", equalTo(StsService.BEARER_TOKEN_TYPE))
+				.body("expires_in", equalTo((int) CredentialTokenService.DEFAULT_LIFETIME_SECONDS));
+	}
+
+	@Test
+	void missingOptionsReturnsOauthError() {
+		given()
+				.contentType("application/x-www-form-urlencoded")
+				.formParam("grant_type", StsService.TOKEN_EXCHANGE_GRANT_TYPE)
+				.formParam("subject_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("subject_token", "source-token")
+				.formParam("requested_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.when().post("/v1/token")
+				.then()
+				.statusCode(400)
+				.body("error", equalTo("invalid_request"));
+	}
+
+	@Test
+	void unsupportedCabReturnsInvalidGrant() {
+		given()
+				.contentType("application/x-www-form-urlencoded")
+				.formParam("grant_type", StsService.TOKEN_EXCHANGE_GRANT_TYPE)
+				.formParam("subject_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("subject_token", "source-token")
+				.formParam("requested_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("options", StsServiceTest.cab().replace(
+						"inRole:roles/storage.legacyObjectReader", "inRole:roles/storage.admin"))
+				.when().post("/v1/token")
+				.then()
+				.statusCode(400)
+				.body("error", equalTo("invalid_grant"));
+	}
+
+	@Test
+	void wrongGrantTypeReturnsInvalidRequest() {
+		given()
+				.contentType("application/x-www-form-urlencoded")
+				.formParam("grant_type", "bad")
+				.formParam("subject_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("subject_token", "source-token")
+				.formParam("requested_token_type", StsService.ACCESS_TOKEN_TYPE)
+				.formParam("options", StsServiceTest.cab())
+				.when().post("/v1/token")
+				.then()
+				.statusCode(400)
+				.body("error", equalTo("invalid_request"));
+	}
+}

--- a/src/test/java/io/floci/gcp/services/sts/StsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/sts/StsServiceTest.java
@@ -1,0 +1,85 @@
+package io.floci.gcp.services.sts;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.credentials.CredentialAccessBoundaryParser;
+import io.floci.gcp.services.credentials.StoredCredentialToken;
+import io.floci.gcp.services.credentials.CredentialTokenService;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StsServiceTest {
+
+	private final InMemoryStorage<String, StoredCredentialToken> store = new InMemoryStorage<>();
+	private final CredentialTokenService tokenService =
+			new CredentialTokenService(store, Clock.fixed(Instant.parse("2026-07-15T12:00:00Z"), ZoneOffset.UTC));
+	private final StsService service = new StsService(
+			new CredentialAccessBoundaryParser(new ObjectMapper()),
+			tokenService);
+
+	@Test
+	void exchangesSupportedCabForStoredDownscopedToken() {
+		Map<String, Object> response = validExchange();
+
+		String accessToken = (String) response.get("access_token");
+		assertTrue(accessToken.startsWith(CredentialTokenService.DOWNSCOPED_TOKEN_PREFIX));
+		assertEquals(StsService.ACCESS_TOKEN_TYPE, response.get("issued_token_type"));
+		assertEquals(StsService.BEARER_TOKEN_TYPE, response.get("token_type"));
+		assertEquals(CredentialTokenService.DEFAULT_LIFETIME_SECONDS, response.get("expires_in"));
+		assertTrue(store.get(accessToken).isPresent());
+	}
+
+	@Test
+	void rejectsWrongGrantTypeAsInvalidRequest() {
+		StsException ex = assertThrows(StsException.class,
+				() -> service.exchangeToken("bad", StsService.ACCESS_TOKEN_TYPE, "source-token",
+						StsService.ACCESS_TOKEN_TYPE, cab()));
+
+		assertEquals("invalid_request", ex.error());
+	}
+
+	@Test
+	void rejectsUnsupportedCabAsInvalidGrant() {
+		StsException ex = assertThrows(StsException.class,
+				() -> service.exchangeToken(StsService.TOKEN_EXCHANGE_GRANT_TYPE, StsService.ACCESS_TOKEN_TYPE,
+						"source-token", StsService.ACCESS_TOKEN_TYPE, cab().replace(
+								"inRole:roles/storage.legacyObjectReader", "inRole:roles/storage.admin")));
+
+		assertEquals("invalid_grant", ex.error());
+	}
+
+	private Map<String, Object> validExchange() {
+		return service.exchangeToken(
+				StsService.TOKEN_EXCHANGE_GRANT_TYPE,
+				StsService.ACCESS_TOKEN_TYPE,
+				"source-token",
+				StsService.ACCESS_TOKEN_TYPE,
+				cab());
+	}
+
+	static String cab() {
+		return """
+				{
+				  "accessBoundary": {
+					"accessBoundaryRules": [
+					  {
+						"availableResource": "//storage.googleapis.com/projects/_/buckets/bucket",
+						"availablePermissions": ["%s"],
+						"availabilityCondition": {
+						  "expression": "resource.name.startsWith('projects/_/buckets/bucket/objects/data/')"
+						}
+					  }
+					]
+				  }
+				}
+				""".formatted("inRole:roles/storage.legacyObjectReader");
+	}
+}

--- a/src/test/java/io/floci/gcp/services/sts/StsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/sts/StsServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +55,60 @@ class StsServiceTest {
 								"inRole:roles/storage.legacyObjectReader", "inRole:roles/storage.admin")));
 
 		assertEquals("invalid_grant", ex.error());
+	}
+
+	@Test
+	void capsExpiryToStoredImpersonatedSubjectToken() {
+		StoredCredentialToken source = tokenService.mintImpersonatedToken(
+				"test@test-project.iam.gserviceaccount.com",
+				Instant.parse("2026-07-15T12:20:00Z"));
+
+		Map<String, Object> response = service.exchangeToken(
+				StsService.TOKEN_EXCHANGE_GRANT_TYPE,
+				StsService.ACCESS_TOKEN_TYPE,
+				source.getTokenValue(),
+				StsService.ACCESS_TOKEN_TYPE,
+				cab());
+
+		assertEquals(1200L, response.get("expires_in"));
+		StoredCredentialToken downscoped = store.get((String) response.get("access_token")).orElseThrow();
+		assertEquals(source.getExpireTime(), downscoped.getExpireTime());
+	}
+
+	@Test
+	void rejectsUnknownFlociSubjectTokenAsInvalidGrant() {
+		StsException ex = assertThrows(StsException.class,
+				() -> service.exchangeToken(
+						StsService.TOKEN_EXCHANGE_GRANT_TYPE,
+						StsService.ACCESS_TOKEN_TYPE,
+						CredentialTokenService.IMPERSONATED_TOKEN_PREFIX + "missing",
+						StsService.ACCESS_TOKEN_TYPE,
+						cab()));
+
+		assertEquals("invalid_grant", ex.error());
+	}
+
+	@Test
+	void rejectsExpiredFlociSubjectTokenAsInvalidGrant() {
+		StoredCredentialToken expired = new StoredCredentialToken(
+				CredentialTokenService.IMPERSONATED_TOKEN_PREFIX + "expired",
+				StoredCredentialToken.TokenKind.IMPERSONATED,
+				Instant.parse("2026-07-15T11:59:59Z"),
+				null,
+				"test@test-project.iam.gserviceaccount.com",
+				List.of());
+		store.put(expired.getTokenValue(), expired);
+
+		StsException ex = assertThrows(StsException.class,
+				() -> service.exchangeToken(
+						StsService.TOKEN_EXCHANGE_GRANT_TYPE,
+						StsService.ACCESS_TOKEN_TYPE,
+						expired.getTokenValue(),
+						StsService.ACCESS_TOKEN_TYPE,
+						cab()));
+
+		assertEquals("invalid_grant", ex.error());
+		assertTrue(store.get(expired.getTokenValue()).isEmpty());
 	}
 
 	private Map<String, Object> validExchange() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,6 +13,8 @@ floci-gcp:
   services:
     iamcredentials:
       enabled: true
+    sts:
+      enabled: true
     datastore:
       enabled: true
     kafka:


### PR DESCRIPTION
## Summary

Adds the STS token-exchange endpoint used by Google Java DownscopedCredentials, a deliberately limited GCS CAB parser, global Floci credential token storage, and stored impersonated-token handling for later GCS enforcement.

Implements the STS v1 form token-exchange contract needed by the Google Java auth-library downscoping flow. Verified with STS REST tests, CAB parser tests, token-store tests, disablement coverage, and compatibility-tests/sdk-test-java StsTokenExchangeTest against a running emulator.

## Type of change

- [x] New feature (`feat:`)

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
