### PR TITLE
perf(docker): stop duplicating the native binary into a second image layer

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Stage native binary for packaging
         run: |
           mkdir -p native/arm64
-          cp target/*-runner native/arm64/
+          cp target/*-runner native/arm64/application
           cp target/*.so native/arm64/ 2>/dev/null || true
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,8 +127,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - name: Set created timestamp
         id: created

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,8 +114,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -63,10 +63,8 @@ ARG VERSION=latest
 ENV FLOCI_GCP_VERSION=${VERSION}
 ENV FLOCI_GCP_STORAGE_PERSISTENT_PATH=/app/data
 
-COPY --from=build /app/target/*-runner /app/application
+COPY --chmod=755 --from=build /app/target/*-runner /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
-RUN chmod +x /app/application
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -34,8 +34,7 @@ RUN mkdir -p /app/data \
 
 VOLUME /app/data
 
-COPY --chown=1001:root native/${TARGETARCH}/ /app/
-RUN mv /app/*-runner /app/application && chmod +x /app/application
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 


### PR DESCRIPTION
## Summary

The native Dockerfiles ran `RUN mv`/`chmod` on the binary right after `COPY`, which rewrites the whole ~196 MB file into a second image layer — the published image carried two full copies of the binary. This sets the executable bit at `COPY --chmod=755` time instead and moves the rename into CI staging (`native/<arch>/application` before `docker build`). Dockerfile and workflow changes land together by necessity: once the Dockerfile stops renaming, `compatibility.yml`/`nightly.yml`/`release.yml` must stage the fixed name in the same commit. Ports the equivalent floci-aws fix, which cut that image from 521 MB to 325 MB uncompressed (168 → 104 MB compressed).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

No wire-protocol changes — image packaging and CI staging only. The runtime binary and its entrypoint are unchanged.

## Checklist

- [ ] `./mvnw test` passes locally — not run; no Java sources touched (Dockerfile + workflow YAML only)
- [ ] New or updated integration test added — N/A; validated in floci-aws by the published image size dropping 521 → 325 MB
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)