### PR TITLE
chore(logging): log health endpoint requests at debug level

### DIFF
--- a/src/main/java/io/floci/gcp/lifecycle/GrpcServerManager.java
+++ b/src/main/java/io/floci/gcp/lifecycle/GrpcServerManager.java
@@ -38,11 +38,15 @@ public class GrpcServerManager {
             String method = ctx.request().method().name();
             String uri = ctx.request().uri();
             String contentType = ctx.request().getHeader("Content-Type");
-            LOG.infof("Incoming request: %s %s, content-type=%s", method, uri, contentType);
+            String path = ctx.request().path();
+            if ("/health".equals(path) || "/_floci-gcp/health".equals(path)) {
+                LOG.debugf("Incoming request: %s %s, content-type=%s", method, uri, contentType);
+            } else {
+                LOG.infof("Incoming request: %s %s, content-type=%s", method, uri, contentType);
+            }
             String ct = ctx.request().getHeader("Content-Type");
             if (ct != null && ct.startsWith("application/grpc")) {
                 long start = System.currentTimeMillis();
-                String path = ctx.request().path();
                 String remoteAddr = ctx.request().remoteAddress() != null ? ctx.request().remoteAddress().host() : "-";
                 ctx.request().response().endHandler(v ->
                         LOG.infof("%s gRPC %s %dms", remoteAddr, path, System.currentTimeMillis() - start));


### PR DESCRIPTION
## Summary

Docker healthchecks poll `/health` and `/_floci-gcp/health` every few seconds, flooding the default log output with `Incoming request` INFO lines. The request log in `GrpcServerManager` now emits those two paths at debug level; all other requests stay at INFO.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

No wire-protocol changes — log level only. Request routing and responses are untouched.

## Checklist

- [ ] `./mvnw test` passes locally — compile verified; full suite not run for a log-level-only change
- [ ] New or updated integration test added — N/A; no behavior change beyond log verbosity
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)