### PR TITLE
fix(gcs): persist custom object metadata on upload paths

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -70,6 +71,7 @@ class GcsTest {
         BlobId blobId = BlobId.of(BUCKET_NAME, OBJECT_NAME);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
                 .setContentType("text/plain")
+                .setMetadata(Map.of("originalname", "test.txt"))
                 .build();
 
         Blob blob = storage.create(blobInfo, OBJECT_CONTENT.getBytes(StandardCharsets.UTF_8));
@@ -78,6 +80,7 @@ class GcsTest {
         assertThat(blob.getBucket()).isEqualTo(BUCKET_NAME);
         assertThat(blob.getContentType()).isEqualTo("text/plain");
         assertThat(blob.getSize()).isEqualTo(OBJECT_CONTENT.getBytes(StandardCharsets.UTF_8).length);
+        assertThat(blob.getMetadata()).isEqualTo(Map.of("originalname", "test.txt"));
     }
 
     @Test
@@ -87,6 +90,7 @@ class GcsTest {
         assertThat(blob).isNotNull();
         assertThat(blob.getContentType()).isEqualTo("text/plain");
         assertThat(blob.getCreateTime()).isNotNull();
+        assertThat(blob.getMetadata()).isEqualTo(Map.of("originalname", "test.txt"));
     }
 
     @Test

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -221,6 +221,11 @@ public class GcsService {
 
     public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
             GcsCustomerEncryption customerEncryption, String baseUrl) {
+        return putObject(bucket, objectName, contentType, data, customerEncryption, null, baseUrl);
+    }
+
+    public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
+            GcsCustomerEncryption customerEncryption, Map<String, String> userMetadata, String baseUrl) {
         LOG.debugf("putObject bucket=%s name=%s contentType=%s size=%d", bucket, objectName, contentType, data.length);
         GcsBucket b = bucketStore.get(bucket).orElse(null);
         if (b == null) {
@@ -255,6 +260,9 @@ public class GcsService {
         meta.setSize(String.valueOf(data.length));
         meta.setContentType(contentType != null ? contentType : "application/octet-stream");
         meta.setCustomerEncryption(customerEncryption.metadata());
+        if (userMetadata != null && !userMetadata.isEmpty()) {
+            meta.setMetadata(new LinkedHashMap<>(userMetadata));
+        }
         meta.setStorageClass("STANDARD");
         meta.setTimeCreated(now);
         meta.setUpdated(now);
@@ -656,7 +664,7 @@ public class GcsService {
     }
 
     public String startResumableUpload(String bucket, String objectName, String contentType,
-            GcsCustomerEncryption customerEncryption) {
+            GcsCustomerEncryption customerEncryption, Map<String, String> metadata) {
         LOG.debugf("startResumableUpload bucket=%s name=%s contentType=%s", bucket, objectName, contentType);
         if (bucketStore.get(bucket).isEmpty()) {
             LOG.warnf("startResumableUpload failed: bucket not found bucket=%s", bucket);
@@ -664,7 +672,7 @@ public class GcsService {
         }
         String uploadId = UUID.randomUUID().toString();
         resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType,
-                customerEncryption.metadata(), new byte[0]));
+                customerEncryption.metadata(), metadata, new byte[0]));
         LOG.debugf("startResumableUpload uploadId=%s", uploadId);
         return uploadId;
     }
@@ -677,7 +685,7 @@ public class GcsService {
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(), baseUrl);
     }
 
     public long appendResumableUpload(String uploadId, long start, byte[] data) {
@@ -688,7 +696,8 @@ public class GcsService {
         }
         byte[] combined = appendChunk(upload, start, data);
         resumableUploads.put(uploadId, new ResumableUpload(
-                upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(), combined));
+                upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(),
+                upload.metadata(), combined));
         return combined.length - 1L;
     }
 
@@ -714,7 +723,7 @@ public class GcsService {
         }
         resumableUploads.remove(uploadId);
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(), baseUrl);
     }
 
     public GcsObjectMeta completeResumableUpload(String uploadId, long start, byte[] data,
@@ -731,7 +740,7 @@ public class GcsService {
         }
         resumableUploads.remove(uploadId);
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), baseUrl);
+                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(), baseUrl);
     }
 
     private static byte[] appendChunk(ResumableUpload upload, long start, byte[] data) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.Response;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @ApplicationScoped
@@ -172,29 +173,34 @@ public class GcsUploadController {
         if (objectContentType == null) {
             objectContentType = extractPartHeader(rawParts[1], "content-type");
         }
+        var userMetadata = extractUserMetadata(metadata);
         preconditions.check(service, bucket, objectName);
         byte[] dataBytes = extractPartBody(rawParts[1]).getBytes(ISO);
         GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes,
-                GcsCustomerEncryption.fromHeaders(headers), requestBaseUrl(headers));
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata, requestBaseUrl(headers));
         return Response.ok(meta).build();
     }
 
-    @SuppressWarnings("unchecked")
     private Response handleStartResumable(String bucket, String nameParam, HttpHeaders headers, byte[] body,
             Preconditions preconditions) {
         String contentType = headers.getHeaderString("X-Upload-Content-Type");
         String name = nameParam;
+        Map<String, String> userMetadata = null;
 
         if (body != null && body.length > 0) {
+            Map<?, ?> meta = null;
             try {
-                Map<String, Object> meta = objectMapper.readValue(body, Map.class);
-                if (name == null) {
-                    name = (String) meta.get("name");
-                }
-                if (contentType == null) {
-                    contentType = (String) meta.get("contentType");
-                }
+                meta = objectMapper.readValue(body, Map.class);
             } catch (Exception ignored) {
+            }
+            if (meta != null) {
+                if (name == null && meta.get("name") instanceof String bodyName) {
+                    name = bodyName;
+                }
+                if (contentType == null && meta.get("contentType") instanceof String bodyContentType) {
+                    contentType = bodyContentType;
+                }
+                userMetadata = extractUserMetadata(meta);
             }
         }
 
@@ -207,7 +213,7 @@ public class GcsUploadController {
 
         preconditions.check(service, bucket, name);
         String uploadId = service.startResumableUpload(bucket, name, contentType,
-                GcsCustomerEncryption.fromHeaders(headers));
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata);
         String location = requestBaseUrl(headers) + "/upload/storage/v1/b/" + bucket
                 + "/o?uploadType=resumable&upload_id=" + uploadId;
 
@@ -226,6 +232,29 @@ public class GcsUploadController {
     private String requestBaseUrl(HttpHeaders headers) {
         String host = headers.getHeaderString("Host");
         return host != null ? "http://" + host : config.baseUrl();
+    }
+
+    private static Map<String, String> extractUserMetadata(Map<?, ?> requestMetadata) {
+        var value = requestMetadata.get("metadata");
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Map<?, ?> entries)) {
+            throw GcpException.invalidArgument("metadata must be an object with string values");
+        }
+        var userMetadata = new LinkedHashMap<String, String>();
+        for (var entry : entries.entrySet()) {
+            var entryValue = entry.getValue();
+            if (entryValue == null) {
+                continue;
+            }
+            if (!(entryValue instanceof String stringValue)) {
+                throw GcpException.invalidArgument(
+                        "metadata value for key " + entry.getKey() + " must be a string");
+            }
+            userMetadata.put(String.valueOf(entry.getKey()), stringValue);
+        }
+        return userMetadata;
     }
 
     private static String[] parseMultipartRaw(String contentType, String bodyStr) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -11,6 +11,10 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
 /**
  * Handles GCS XML API requests: GET/PUT /{bucket}/{object}.
  * Used by Go SDK (STORAGE_EMULATOR_HOST) and for signed URL access.
@@ -75,7 +79,18 @@ public class GcsXmlDownloadController {
         String host = headers.getHeaderString("Host");
         String baseUrl = host != null ? "http://" + host : config.baseUrl();
         GcsObjectMeta meta = service.putObject(bucket, objectPath, contentType, body != null ? body : new byte[0],
-                GcsCustomerEncryption.fromHeaders(headers), baseUrl);
+                GcsCustomerEncryption.fromHeaders(headers), googMetaHeaders(headers), baseUrl);
         return Response.ok(meta).build();
+    }
+
+    private static Map<String, String> googMetaHeaders(HttpHeaders headers) {
+        var metadata = new LinkedHashMap<String, String>();
+        for (var headerName : headers.getRequestHeaders().keySet()) {
+            var lower = headerName.toLowerCase(Locale.ROOT);
+            if (lower.startsWith("x-goog-meta-") && lower.length() > "x-goog-meta-".length()) {
+                metadata.put(lower.substring("x-goog-meta-".length()), headers.getHeaderString(headerName));
+            }
+        }
+        return metadata;
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
@@ -3,4 +3,4 @@ package io.floci.gcp.services.gcs.model;
 import java.util.Map;
 
 public record ResumableUpload(String bucket, String objectName, String contentType,
-        Map<String, String> customerEncryption, byte[] data) {}
+        Map<String, String> customerEncryption, Map<String, String> metadata, byte[] data) {}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsUploadMetadataRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsUploadMetadataRestIntegrationTest.java
@@ -1,0 +1,213 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+class GcsUploadMetadataRestIntegrationTest {
+
+    private static final String BUCKET = "upload-metadata-bucket";
+
+    private static void ensureBucket() {
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project");
+    }
+
+    @Test
+    void multipartUploadPersistsCustomMetadata() {
+        ensureBucket();
+        var boundary = "boundary123";
+        var body = "--" + boundary + "\r\n"
+                + "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+                + "{\"name\":\"multipart-obj\",\"contentType\":\"application/json\","
+                + "\"metadata\":{\"originalname\":\"test.json\"}}\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: application/json\r\n\r\n"
+                + "{\"a\":1}\r\n"
+                + "--" + boundary + "--\r\n";
+
+        given()
+                .header("Content-Type", "multipart/related; boundary=" + boundary)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=multipart")
+                .then().statusCode(200)
+                .body("metadata.originalname", equalTo("test.json"));
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/multipart-obj")
+                .then().statusCode(200)
+                .body("contentType", equalTo("application/json"))
+                .body("metadata.originalname", equalTo("test.json"));
+    }
+
+    @Test
+    void resumableUploadPersistsCustomMetadata() {
+        ensureBucket();
+        var location = given()
+                .contentType("application/json")
+                .body(Map.of(
+                        "name", "resumable-obj",
+                        "contentType", "text/plain",
+                        "metadata", Map.of("origname", "test.txt")))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        var uploadId = location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+
+        given()
+                .contentType("text/plain")
+                .body("hello")
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(200)
+                .body("metadata.origname", equalTo("test.txt"));
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/resumable-obj")
+                .then().statusCode(200)
+                .body("contentType", equalTo("text/plain"))
+                .body("metadata.origname", equalTo("test.txt"));
+    }
+
+    @Test
+    void xmlPutPersistsGoogMetaHeaders() {
+        ensureBucket();
+        given()
+                .header("x-goog-meta-origname", "test.txt")
+                .header("X-Goog-Meta-Reviewer", "jane")
+                .contentType("text/plain")
+                .body("xml")
+                .when().put("/" + BUCKET + "/xml-obj")
+                .then().statusCode(200)
+                .body("metadata.origname", equalTo("test.txt"))
+                .body("metadata.reviewer", equalTo("jane"));
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/xml-obj")
+                .then().statusCode(200)
+                .body("metadata.origname", equalTo("test.txt"))
+                .body("metadata.reviewer", equalTo("jane"));
+    }
+
+    @Test
+    void multipartUploadRejectsScalarMetadata() {
+        ensureBucket();
+        var boundary = "boundary123";
+        var body = "--" + boundary + "\r\n"
+                + "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+                + "{\"name\":\"invalid-scalar-obj\",\"metadata\":\"not-an-object\"}\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/plain\r\n\r\n"
+                + "data\r\n"
+                + "--" + boundary + "--\r\n";
+
+        given()
+                .header("Content-Type", "multipart/related; boundary=" + boundary)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=multipart")
+                .then().statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    void multipartUploadRejectsNonStringMetadataValues() {
+        ensureBucket();
+        var boundary = "boundary123";
+        var body = "--" + boundary + "\r\n"
+                + "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+                + "{\"name\":\"invalid-value-obj\",\"metadata\":{\"count\":1}}\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/plain\r\n\r\n"
+                + "data\r\n"
+                + "--" + boundary + "--\r\n";
+
+        given()
+                .header("Content-Type", "multipart/related; boundary=" + boundary)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=multipart")
+                .then().statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    void resumableInitRejectsNonStringMetadataValues() {
+        ensureBucket();
+        given()
+                .contentType("application/json")
+                .body("{\"name\":\"invalid-resumable-obj\",\"metadata\":{\"count\":1}}")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    void resumableInitKeepsMetadataWhenSiblingFieldsAreNotStrings() {
+        ensureBucket();
+        var location = given()
+                .contentType("application/json")
+                .body("{\"contentType\":42,\"metadata\":{\"origname\":\"kept.txt\"}}")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&name=tolerant-obj")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        var uploadId = location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+
+        given()
+                .contentType("text/plain")
+                .body("hello")
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(200)
+                .body("metadata.origname", equalTo("kept.txt"));
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/tolerant-obj")
+                .then().statusCode(200)
+                .body("metadata.origname", equalTo("kept.txt"));
+    }
+
+    @Test
+    void multipartUploadSkipsNullMetadataValues() {
+        ensureBucket();
+        var boundary = "boundary123";
+        var body = "--" + boundary + "\r\n"
+                + "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+                + "{\"name\":\"null-value-obj\",\"metadata\":{\"kept\":\"yes\",\"dropped\":null}}\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/plain\r\n\r\n"
+                + "data\r\n"
+                + "--" + boundary + "--\r\n";
+
+        given()
+                .header("Content-Type", "multipart/related; boundary=" + boundary)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=multipart")
+                .then().statusCode(200)
+                .body("metadata.kept", equalTo("yes"))
+                .body("metadata.dropped", nullValue());
+    }
+
+    @Test
+    void uploadWithoutMetadataOmitsMetadataField() {
+        ensureBucket();
+        given()
+                .contentType("text/plain")
+                .body("plain")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=no-metadata-obj")
+                .then().statusCode(200)
+                .body("metadata", nullValue());
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/no-metadata-obj")
+                .then().statusCode(200)
+                .body("metadata", nullValue());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #119

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Now putObject accepts a user metadata map. The multipart handler reads it from the metadata part. The resumable handler reads it from the session initiation body and carries it through ResumableUpload. The XML handler collects x-goog-meta-* request headers.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
