### PR TITLE
fix(gcs): emit x-goog-meta headers from the same generation as the downloaded bytes

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/gcs_test.go
+++ b/compatibility-tests/sdk-test-go/tests/gcs_test.go
@@ -26,6 +26,7 @@ func TestGCS(t *testing.T) {
 		bkt := client.Bucket(bucketName)
 		bkt.Object(objectName).Delete(ctx)
 		bkt.Object("copy-" + objectName).Delete(ctx)
+		bkt.Object("meta-" + objectName).Delete(ctx)
 		bkt.Delete(ctx)
 	})
 
@@ -75,6 +76,31 @@ func TestGCS(t *testing.T) {
 		assert.Equal(t, objectName, attrs.Name)
 		assert.Equal(t, "text/plain", attrs.ContentType)
 		assert.Equal(t, int64(len(content)), attrs.Size)
+	})
+
+	t.Run("ObjectCustomMetadata", func(t *testing.T) {
+		metadata := map[string]string{"originalname": "test.txt", "reviewer": "jane"}
+		obj := client.Bucket(bucketName).Object("meta-" + objectName)
+
+		w := obj.NewWriter(ctx)
+		w.ContentType = "text/plain"
+		w.Metadata = metadata
+		_, err := io.WriteString(w, content)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		attrs, err := obj.Attrs(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, metadata, attrs.Metadata)
+
+		r, err := obj.NewReader(ctx)
+		require.NoError(t, err)
+		defer r.Close()
+		// net/http canonicalizes the x-goog-meta-* header names, so the
+		// HTTP transport surfaces reader metadata keys in title case.
+		assert.Equal(t, map[string]string{"Originalname": "test.txt", "Reviewer": "jane"}, r.Metadata())
+
+		require.NoError(t, obj.Delete(ctx))
 	})
 
 	t.Run("ListObjects", func(t *testing.T) {

--- a/compatibility-tests/sdk-test-node/tests/gcs.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/gcs.test.ts
@@ -64,6 +64,19 @@ describe('Cloud Storage (GCS)', () => {
     expect(Number(metadata.size)).toBeGreaterThan(0);
   });
 
+  it('should round-trip custom object metadata', async () => {
+    const metaObjectName = 'meta-test-object.txt';
+    await storage.bucket(bucketName).file(metaObjectName).save(objectContent, {
+      contentType: 'text/plain',
+      metadata: { metadata: { originalname: 'test.txt', reviewer: 'jane' } },
+    });
+    const [metadata] = await storage.bucket(bucketName).file(metaObjectName).getMetadata();
+    expect(metadata.metadata).toEqual({ originalname: 'test.txt', reviewer: 'jane' });
+    const [content] = await storage.bucket(bucketName).file(metaObjectName).download();
+    expect(content.toString()).toBe(objectContent);
+    await storage.bucket(bucketName).file(metaObjectName).delete();
+  });
+
   it('should list objects in bucket', async () => {
     const [files] = await storage.bucket(bucketName).getFiles();
     expect(files.some((f) => f.name === objectName)).toBe(true);

--- a/compatibility-tests/sdk-test-python/tests/test_gcs.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs.py
@@ -33,6 +33,22 @@ def test_upload_and_download_object(storage_client, unique_name):
         bucket.delete(force=True)
 
 
+def test_object_custom_metadata(storage_client, unique_name):
+    bucket_name = f"test-bucket-{unique_name}"
+    bucket = storage_client.create_bucket(storage_client.bucket(bucket_name))
+
+    try:
+        blob = bucket.blob("meta-object.txt")
+        blob.metadata = {"originalname": "test.txt", "reviewer": "jane"}
+        blob.upload_from_string("metadata content", content_type="text/plain")
+
+        fetched = bucket.get_blob("meta-object.txt")
+        assert fetched.metadata == {"originalname": "test.txt", "reviewer": "jane"}
+        assert fetched.download_as_text() == "metadata content"
+    finally:
+        bucket.delete(force=True)
+
+
 def test_list_objects_in_bucket(storage_client, unique_name):
     bucket_name = f"test-bucket-{unique_name}"
     bucket = storage_client.create_bucket(storage_client.bucket(bucket_name))

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -29,13 +29,7 @@ public class GcsDownloadController {
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam("Range") String rangeHeader) {
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
-        if (generation != null) {
-            var data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
-            var meta = service.getObjectMeta(bucket, objectPath, generation);
-            return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
-        }
-        var data = service.getObjectData(bucket, objectPath, customerEncryption);
-        var meta = service.getObjectMeta(bucket, objectPath);
-        return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
+        var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
+        return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -1,6 +1,5 @@
 package io.floci.gcp.services.gcs;
 
-import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -31,12 +30,12 @@ public class GcsDownloadController {
             @HeaderParam("Range") String rangeHeader) {
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
-            byte[] data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
-            GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath, generation);
-            return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
+            var data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
+            var meta = service.getObjectMeta(bucket, objectPath, generation);
+            return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
         }
-        byte[] data = service.getObjectData(bucket, objectPath, customerEncryption);
-        GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath);
-        return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
+        var data = service.getObjectData(bucket, objectPath, customerEncryption);
+        var meta = service.getObjectMeta(bucket, objectPath);
+        return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
@@ -1,26 +1,38 @@
 package io.floci.gcp.services.gcs;
 
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Arrays;
 
 final class GcsMediaResponses {
 
+    static final String META_HEADER_PREFIX = "x-goog-meta-";
+
     private GcsMediaResponses() {}
 
-    static Response mediaResponse(byte[] data, String contentType, String rangeHeader) {
+    static Response mediaResponse(byte[] data, GcsObjectMeta meta, String rangeHeader) {
+        Response.ResponseBuilder builder;
         if (rangeHeader == null || rangeHeader.isBlank()) {
-            return Response.ok(data).type(contentType).build();
+            builder = Response.ok(data);
+        } else {
+            var range = parseRange(rangeHeader, data.length);
+            builder = Response.status(Response.Status.PARTIAL_CONTENT)
+                    .entity(Arrays.copyOfRange(data, range.start(), range.end() + 1))
+                    .header("Content-Range", "bytes " + range.start() + "-" + range.end() + "/" + data.length);
         }
+        return withMetadataHeaders(builder.type(meta.getContentType()), meta).build();
+    }
 
-        Range range = parseRange(rangeHeader, data.length);
-        byte[] body = Arrays.copyOfRange(data, range.start(), range.end() + 1);
-        return Response.status(Response.Status.PARTIAL_CONTENT)
-                .entity(body)
-                .type(contentType)
-                .header("Content-Range", "bytes " + range.start() + "-" + range.end() + "/" + data.length)
-                .build();
+    private static Response.ResponseBuilder withMetadataHeaders(Response.ResponseBuilder builder, GcsObjectMeta meta) {
+        var metadata = meta.getMetadata();
+        if (metadata != null) {
+            for (var entry : metadata.entrySet()) {
+                builder.header(META_HEADER_PREFIX + entry.getKey(), entry.getValue());
+            }
+        }
+        return builder;
     }
 
     private static Range parseRange(String rangeHeader, int length) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
@@ -29,10 +29,47 @@ final class GcsMediaResponses {
         var metadata = meta.getMetadata();
         if (metadata != null) {
             for (var entry : metadata.entrySet()) {
-                builder.header(META_HEADER_PREFIX + entry.getKey(), entry.getValue());
+                if (isValidHeaderName(entry.getKey()) && isValidHeaderValue(entry.getValue())) {
+                    builder.header(META_HEADER_PREFIX + entry.getKey(), entry.getValue());
+                }
             }
         }
         return builder;
+    }
+
+    // Metadata stored via the JSON API may contain characters that cannot appear in an
+    // HTTP field. GCS documents XML API custom metadata as printable US-ASCII, and for
+    // the field name the printable characters usable in a header are exactly the RFC 7230
+    // token set. Entries outside those bounds stay in the object resource but are omitted
+    // from media headers so response serialization cannot fail.
+    private static boolean isValidHeaderName(String key) {
+        if (key == null || key.isEmpty()) {
+            return false;
+        }
+        for (var i = 0; i < key.length(); i++) {
+            if (!isTokenChar(key.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isTokenChar(char c) {
+        return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+                || "!#$%&'*+-.^_`|~".indexOf(c) >= 0;
+    }
+
+    private static boolean isValidHeaderValue(String value) {
+        if (value == null) {
+            return false;
+        }
+        for (var i = 0; i < value.length(); i++) {
+            var c = value.charAt(i);
+            if ((c < 0x20 || c > 0x7E) && c != '\t') {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static Range parseRange(String rangeHeader, int length) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -145,18 +145,12 @@ public class GcsObjectController {
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam("Range") String rangeHeader) {
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
-        if (generation != null) {
-            if ("media".equals(alt)) {
-                var data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
-                var meta = service.getObjectMeta(bucket, objectPath, generation);
-                return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
-            }
-            return Response.ok(service.getObjectMeta(bucket, objectPath, generation)).build();
-        }
         if ("media".equals(alt)) {
-            var data = service.getObjectData(bucket, objectPath, customerEncryption);
-            var meta = service.getObjectMeta(bucket, objectPath);
-            return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
+            var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
+            return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
+        }
+        if (generation != null) {
+            return Response.ok(service.getObjectMeta(bucket, objectPath, generation)).build();
         }
         return Response.ok(service.getObjectMeta(bucket, objectPath)).build();
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -147,16 +147,16 @@ public class GcsObjectController {
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
             if ("media".equals(alt)) {
-                byte[] data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
-                GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath, generation);
-                return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
+                var data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
+                var meta = service.getObjectMeta(bucket, objectPath, generation);
+                return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
             }
             return Response.ok(service.getObjectMeta(bucket, objectPath, generation)).build();
         }
         if ("media".equals(alt)) {
-            byte[] data = service.getObjectData(bucket, objectPath, customerEncryption);
-            GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath);
-            return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
+            var data = service.getObjectData(bucket, objectPath, customerEncryption);
+            var meta = service.getObjectMeta(bucket, objectPath);
+            return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
         }
         return Response.ok(service.getObjectMeta(bucket, objectPath)).build();
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -397,23 +397,16 @@ public class GcsService {
 
     public GcsObjectDownload getObjectForDownload(String bucket, String objectName, String generation,
             GcsCustomerEncryption customerEncryption) {
-        if (generation != null) {
-            return new GcsObjectDownload(getObjectMeta(bucket, objectName, generation),
-                    getObjectData(bucket, objectName, generation, customerEncryption));
-        }
-        // Pin the data lookup to the resolved live generation so a concurrent
-        // overwrite cannot pair one generation's bytes with another's metadata.
-        // If that generation vanishes before the data lookup, re-resolve.
-        for (var attempt = 0; ; attempt++) {
-            var meta = getObjectMeta(bucket, objectName);
-            try {
-                return new GcsObjectDownload(meta,
-                        getObjectData(bucket, objectName, meta.getGeneration(), customerEncryption));
-            } catch (GcpException e) {
-                if (e.getHttpStatus() != 404 || attempt >= 2) {
-                    throw e;
-                }
+        // Every mutation path holds this lock, so metadata and bytes resolved
+        // under it always come from the same generation.
+        synchronized (objectLock(bucket, objectName)) {
+            if (generation != null) {
+                return new GcsObjectDownload(getObjectMeta(bucket, objectName, generation),
+                        getObjectData(bucket, objectName, generation, customerEncryption));
             }
+            var meta = getObjectMeta(bucket, objectName);
+            return new GcsObjectDownload(meta,
+                    getObjectData(bucket, objectName, meta.getGeneration(), customerEncryption));
         }
     }
 
@@ -646,15 +639,17 @@ public class GcsService {
 
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject,
             GcsObjectPreconditions preconditions, String baseUrl) {
+        LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
+        // Read the source before taking the destination lock. Nesting two
+        // stripe locks could deadlock with a copy running in the other direction.
+        var src = getObjectForDownload(srcBucket, srcObject, null, GcsCustomerEncryption.none());
         synchronized (objectLock(dstBucket, dstObject)) {
             checkPreconditions(dstBucket, dstObject, preconditions);
-            return copyObjectLocked(srcBucket, srcObject, dstBucket, dstObject, baseUrl);
+            return copyObjectLocked(src, dstBucket, dstObject, baseUrl);
         }
     }
 
-    private GcsObjectMeta copyObjectLocked(String srcBucket, String srcObject, String dstBucket, String dstObject, String baseUrl) {
-        LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
-        var src = getObjectForDownload(srcBucket, srcObject, null, GcsCustomerEncryption.none());
+    private GcsObjectMeta copyObjectLocked(GcsObjectDownload src, String dstBucket, String dstObject, String baseUrl) {
         var srcMeta = src.meta();
         var dstMeta = putObjectLocked(dstBucket, dstObject, srcMeta.getContentType(), src.data(),
                 GcsCustomerEncryption.none(), null, baseUrl);

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -12,6 +12,7 @@ import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.services.gcs.model.GcsBucket;
+import io.floci.gcp.services.gcs.model.GcsObjectDownload;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.ResumableUpload;
 import io.floci.gcp.services.gcs.model.StoredAcl;
@@ -366,6 +367,28 @@ public class GcsService {
         return data;
     }
 
+    public GcsObjectDownload getObjectForDownload(String bucket, String objectName, String generation,
+            GcsCustomerEncryption customerEncryption) {
+        if (generation != null) {
+            return new GcsObjectDownload(getObjectMeta(bucket, objectName, generation),
+                    getObjectData(bucket, objectName, generation, customerEncryption));
+        }
+        // Pin the data lookup to the resolved live generation so a concurrent
+        // overwrite cannot pair one generation's bytes with another's metadata.
+        // If that generation vanishes before the data lookup, re-resolve.
+        for (var attempt = 0; ; attempt++) {
+            var meta = getObjectMeta(bucket, objectName);
+            try {
+                return new GcsObjectDownload(meta,
+                        getObjectData(bucket, objectName, meta.getGeneration(), customerEncryption));
+            } catch (GcpException e) {
+                if (e.getHttpStatus() != 404 || attempt >= 2) {
+                    throw e;
+                }
+            }
+        }
+    }
+
     private static void checkCustomerEncryption(GcsObjectMeta meta, GcsCustomerEncryption customerEncryption) {
         if (meta == null || meta.getCustomerEncryption() == null) {
             return;
@@ -481,17 +504,21 @@ public class GcsService {
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
         byte[] composed = new byte[0];
+        GcsObjectMeta firstSourceMeta = null;
         for (String src : sourceNames) {
-            byte[] data = getObjectData(bucket, src, GcsCustomerEncryption.none());
-            byte[] merged = new byte[composed.length + data.length];
+            var source = getObjectForDownload(bucket, src, null, GcsCustomerEncryption.none());
+            if (firstSourceMeta == null) {
+                firstSourceMeta = source.meta();
+            }
+            var data = source.data();
+            var merged = new byte[composed.length + data.length];
             System.arraycopy(composed, 0, merged, 0, composed.length);
             System.arraycopy(data, 0, merged, composed.length, data.length);
             composed = merged;
         }
         String resolvedType = contentType;
-        if (resolvedType == null && !sourceNames.isEmpty()) {
-            resolvedType = objectMetaStore.get(objectKey(bucket, sourceNames.get(0)))
-                    .map(GcsObjectMeta::getContentType).orElse(null);
+        if (resolvedType == null && firstSourceMeta != null) {
+            resolvedType = firstSourceMeta.getContentType();
         }
         return putObject(bucket, destObject, resolvedType != null ? resolvedType : "application/octet-stream",
                 composed, GcsCustomerEncryption.none(), baseUrl);
@@ -530,9 +557,9 @@ public class GcsService {
 
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject, String baseUrl) {
         LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
-        GcsObjectMeta srcMeta = getObjectMeta(srcBucket, srcObject);
-        byte[] data = getObjectData(srcBucket, srcObject, GcsCustomerEncryption.none());
-        GcsObjectMeta dstMeta = putObject(dstBucket, dstObject, srcMeta.getContentType(), data,
+        var src = getObjectForDownload(srcBucket, srcObject, null, GcsCustomerEncryption.none());
+        var srcMeta = src.meta();
+        var dstMeta = putObject(dstBucket, dstObject, srcMeta.getContentType(), src.data(),
                 GcsCustomerEncryption.none(), baseUrl);
         if (srcMeta.getMetadata() != null) {
             dstMeta.setMetadata(new LinkedHashMap<>(srcMeta.getMetadata()));

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -55,13 +55,13 @@ public class GcsXmlDownloadController {
         GcsSignedUrl.checkNotExpired(uriInfo);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if (generation != null) {
-            byte[] data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
-            GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath, generation);
-            return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
+            var data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
+            var meta = service.getObjectMeta(bucket, objectPath, generation);
+            return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
         }
-        byte[] data = service.getObjectData(bucket, objectPath, customerEncryption);
-        GcsObjectMeta meta = service.getObjectMeta(bucket, objectPath);
-        return GcsMediaResponses.mediaResponse(data, meta.getContentType(), rangeHeader);
+        var data = service.getObjectData(bucket, objectPath, customerEncryption);
+        var meta = service.getObjectMeta(bucket, objectPath);
+        return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
     }
 
     @PUT
@@ -84,11 +84,12 @@ public class GcsXmlDownloadController {
     }
 
     private static Map<String, String> googMetaHeaders(HttpHeaders headers) {
+        var prefix = GcsMediaResponses.META_HEADER_PREFIX;
         var metadata = new LinkedHashMap<String, String>();
         for (var headerName : headers.getRequestHeaders().keySet()) {
             var lower = headerName.toLowerCase(Locale.ROOT);
-            if (lower.startsWith("x-goog-meta-") && lower.length() > "x-goog-meta-".length()) {
-                metadata.put(lower.substring("x-goog-meta-".length()), headers.getHeaderString(headerName));
+            if (lower.startsWith(prefix) && lower.length() > prefix.length()) {
+                metadata.put(lower.substring(prefix.length()), headers.getHeaderString(headerName));
             }
         }
         return metadata;

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -54,14 +54,8 @@ public class GcsXmlDownloadController {
             @HeaderParam("Range") String rangeHeader) {
         GcsSignedUrl.checkNotExpired(uriInfo);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
-        if (generation != null) {
-            var data = service.getObjectData(bucket, objectPath, generation, customerEncryption);
-            var meta = service.getObjectMeta(bucket, objectPath, generation);
-            return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
-        }
-        var data = service.getObjectData(bucket, objectPath, customerEncryption);
-        var meta = service.getObjectMeta(bucket, objectPath);
-        return GcsMediaResponses.mediaResponse(data, meta, rangeHeader);
+        var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
+        return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
     }
 
     @PUT

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectDownload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectDownload.java
@@ -1,0 +1,3 @@
+package io.floci.gcp.services.gcs.model;
+
+public record GcsObjectDownload(GcsObjectMeta meta, byte[] data) {}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsDownloadMetadataRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsDownloadMetadataRestIntegrationTest.java
@@ -1,0 +1,102 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@QuarkusTest
+class GcsDownloadMetadataRestIntegrationTest {
+
+    private static final String BUCKET = "download-metadata-bucket";
+
+    private static void ensureBucket() {
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project");
+    }
+
+    private static void uploadWithMetadata(String objectName) {
+        given()
+                .header("x-goog-meta-origname", "test.txt")
+                .header("x-goog-meta-reviewer", "jane")
+                .contentType("text/plain")
+                .body("hello metadata")
+                .when().put("/" + BUCKET + "/" + objectName)
+                .then().statusCode(200);
+    }
+
+    @Test
+    void xmlDownloadEmitsGoogMetaHeaders() {
+        ensureBucket();
+        uploadWithMetadata("xml-read-obj");
+
+        given()
+                .when().get("/" + BUCKET + "/xml-read-obj")
+                .then().statusCode(200)
+                .header("x-goog-meta-origname", equalTo("test.txt"))
+                .header("x-goog-meta-reviewer", equalTo("jane"));
+    }
+
+    @Test
+    void jsonAltMediaDownloadEmitsGoogMetaHeaders() {
+        ensureBucket();
+        uploadWithMetadata("alt-media-obj");
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/alt-media-obj?alt=media")
+                .then().statusCode(200)
+                .header("x-goog-meta-origname", equalTo("test.txt"))
+                .header("x-goog-meta-reviewer", equalTo("jane"));
+    }
+
+    @Test
+    void downloadEndpointEmitsGoogMetaHeaders() {
+        ensureBucket();
+        uploadWithMetadata("download-obj");
+
+        given()
+                .when().get("/download/storage/v1/b/" + BUCKET + "/o/download-obj?alt=media")
+                .then().statusCode(200)
+                .header("x-goog-meta-origname", equalTo("test.txt"))
+                .header("x-goog-meta-reviewer", equalTo("jane"));
+    }
+
+    @Test
+    void rangeDownloadEmitsGoogMetaHeaders() {
+        ensureBucket();
+        uploadWithMetadata("range-obj");
+
+        given()
+                .header("Range", "bytes=0-4")
+                .when().get("/" + BUCKET + "/range-obj")
+                .then().statusCode(206)
+                .header("Content-Range", equalTo("bytes 0-4/14"))
+                .header("x-goog-meta-origname", equalTo("test.txt"))
+                .header("x-goog-meta-reviewer", equalTo("jane"));
+    }
+
+    @Test
+    void downloadWithoutMetadataOmitsGoogMetaHeaders() {
+        ensureBucket();
+        given()
+                .contentType("text/plain")
+                .body("plain")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=plain-obj")
+                .then().statusCode(200);
+
+        var response = given()
+                .when().get("/" + BUCKET + "/plain-obj")
+                .then().statusCode(200)
+                .extract();
+        var hasMetaHeader = response.headers().asList().stream()
+                .anyMatch(header -> header.getName().toLowerCase(Locale.ROOT).startsWith("x-goog-meta-"));
+        assertFalse(hasMetaHeader, "response must not contain x-goog-meta-* headers");
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsDownloadMetadataRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsDownloadMetadataRestIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @QuarkusTest
@@ -80,6 +81,38 @@ class GcsDownloadMetadataRestIntegrationTest {
                 .header("Content-Range", equalTo("bytes 0-4/14"))
                 .header("x-goog-meta-origname", equalTo("test.txt"))
                 .header("x-goog-meta-reviewer", equalTo("jane"));
+    }
+
+    @Test
+    void downloadSkipsMetadataEntriesIllegalInHeaders() {
+        ensureBucket();
+        given()
+                .contentType("text/plain")
+                .body("hello metadata")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=illegal-meta-obj")
+                .then().statusCode(200);
+        given()
+                .contentType("application/json")
+                .body(Map.of("metadata", Map.of(
+                        "origname", "test.txt",
+                        "bad key", "space",
+                        "bad:key", "colon",
+                        "bad/key", "slash",
+                        "日本語", "non-ascii-key",
+                        "badvalue1", "line\nbreak",
+                        "badvalue2", "非ASCII値")))
+                .when().patch("/storage/v1/b/" + BUCKET + "/o/illegal-meta-obj")
+                .then().statusCode(200);
+
+        var response = given()
+                .when().get("/" + BUCKET + "/illegal-meta-obj")
+                .then().statusCode(200)
+                .header("x-goog-meta-origname", equalTo("test.txt"))
+                .extract();
+        var metaHeaders = response.headers().asList().stream()
+                .filter(header -> header.getName().toLowerCase(Locale.ROOT).startsWith("x-goog-meta-"))
+                .toList();
+        assertEquals(1, metaHeaders.size(), "only the valid metadata entry must be emitted");
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -103,6 +103,68 @@ class GcsServiceTest {
     }
 
     @Test
+    void getObjectForDownloadReturnsMatchingMetaAndData() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        var data = "payload".getBytes(StandardCharsets.UTF_8);
+        var stored = service.putObject("bucket", "obj.txt", "text/plain", data,
+                GcsCustomerEncryption.none(), BASE_URL);
+
+        var download = service.getObjectForDownload("bucket", "obj.txt", null, GcsCustomerEncryption.none());
+
+        assertEquals(stored.getGeneration(), download.meta().getGeneration());
+        assertArrayEquals(data, download.data());
+    }
+
+    @Test
+    void getObjectForDownloadWithExplicitGeneration() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        var data = "payload".getBytes(StandardCharsets.UTF_8);
+        var stored = service.putObject("bucket", "obj.txt", "text/plain", data,
+                GcsCustomerEncryption.none(), BASE_URL);
+
+        var download = service.getObjectForDownload("bucket", "obj.txt", stored.getGeneration(),
+                GcsCustomerEncryption.none());
+
+        assertEquals(stored.getGeneration(), download.meta().getGeneration());
+        assertArrayEquals(data, download.data());
+
+        var ex = assertThrows(GcpException.class,
+                () -> service.getObjectForDownload("bucket", "obj.txt", "999999", GcsCustomerEncryption.none()));
+        assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void copyObjectCopiesDataContentTypeAndMetadata() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        var data = "payload".getBytes(StandardCharsets.UTF_8);
+        var stored = service.putObject("bucket", "src.txt", "text/plain", data,
+                GcsCustomerEncryption.none(), Map.of("origname", "src.txt"), BASE_URL);
+        assertNotNull(stored.getMetadata());
+
+        var copied = service.copyObject("bucket", "src.txt", "bucket", "dst.txt", BASE_URL);
+
+        assertEquals("text/plain", copied.getContentType());
+        assertEquals(Map.of("origname", "src.txt"), copied.getMetadata());
+        assertArrayEquals(data, service.getObjectData("bucket", "dst.txt", GcsCustomerEncryption.none()));
+    }
+
+    @Test
+    void composeObjectConcatenatesSourcesAndInheritsFirstContentType() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        service.putObject("bucket", "part1.txt", "text/plain", "foo".getBytes(StandardCharsets.UTF_8),
+                GcsCustomerEncryption.none(), BASE_URL);
+        service.putObject("bucket", "part2.txt", "text/csv", "bar".getBytes(StandardCharsets.UTF_8),
+                GcsCustomerEncryption.none(), BASE_URL);
+
+        var composed = service.composeObject("bucket", "all.txt", List.of("part1.txt", "part2.txt"),
+                null, BASE_URL);
+
+        assertEquals("text/plain", composed.getContentType());
+        assertArrayEquals("foobar".getBytes(StandardCharsets.UTF_8),
+                service.getObjectData("bucket", "all.txt", GcsCustomerEncryption.none()));
+    }
+
+    @Test
     void objectDataSurvivesPersistentStoreReload() {
         GcsService first = persistentService(tempDir);
         first.createBucket("bucket", "p1", BASE_URL, Map.of());

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -243,6 +244,40 @@ class GcsServiceTest {
         GcpException ex = assertThrows(GcpException.class,
                 () -> service.getBucket("bucket"));
         assertEquals("NOT_FOUND", ex.getGcpStatus());
+    }
+
+    @Test
+    void concurrentOverwriteNeverMixesGenerations() throws Exception {
+        service.createBucket("race-bucket", "p1", BASE_URL, Map.of());
+        var payloads = Map.of(
+                "a", "aaaaaaaa".getBytes(StandardCharsets.UTF_8),
+                "b", "bb".getBytes(StandardCharsets.UTF_8));
+        service.putObject("race-bucket", "obj.txt", "text/plain", payloads.get("a"),
+                GcsCustomerEncryption.none(), Map.of("tag", "a"), BASE_URL);
+
+        var stop = new AtomicBoolean(false);
+        var writer = new Thread(() -> {
+            var flip = false;
+            while (!stop.get()) {
+                var tag = flip ? "a" : "b";
+                service.putObject("race-bucket", "obj.txt", "text/plain", payloads.get(tag),
+                        GcsCustomerEncryption.none(), Map.of("tag", tag), BASE_URL);
+                flip = !flip;
+            }
+        });
+        writer.start();
+        try {
+            for (var i = 0; i < 2_000; i++) {
+                var download = service.getObjectForDownload(
+                        "race-bucket", "obj.txt", null, GcsCustomerEncryption.none());
+                var expected = payloads.get(download.meta().getMetadata().get("tag"));
+                assertArrayEquals(expected, download.data(),
+                        "bytes belong to a different generation than the metadata");
+            }
+        } finally {
+            stop.set(true);
+            writer.join();
+        }
     }
 
     private static GcsService persistentService(Path root) {


### PR DESCRIPTION
## Summary

Follow-up to review feedback on https://github.com/floci-io/floci-gcp/pull/120#issuecomment-5273938523

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

### 1. Missing x-goog-meta headers on object media downloads

Custom metadata written through any upload path was invisible to XML API readers because media responses never carried `x-goog-meta-*` headers. The Go SDK builds `Reader.Metadata()` purely from those response headers.

GcsMediaResponses.mediaResponse now takes the full object metadata and emits one `x-goog-meta-*` header per entry on both full and ranged downloads. All three download controllers share that helper, so the JSON alt=media, download, and XML paths are covered.

### 2. x-goog-meta headers were not read atomically with object data

Object bytes and metadata were fetched by two independent lookups (`downloads`, `copyObject`, `composeObject`). A concurrent overwrite between the two could pair one generation's bytes with another generation's metadata.

Added `GcsService.getObjectForDownload`, which resolves the live generation once and fetches the data pinned to it, retrying if that generation vanishes mid-lookup. All affected paths now use it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
