### PR TITLE
fix(gcs): correct resumable upload chunk handling

### DIFF
--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -790,33 +790,42 @@ public class GcsService {
         }
         String uploadId = UUID.randomUUID().toString();
         resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType,
-                customerEncryption.metadata(), metadata, preconditions, new byte[0]));
+                customerEncryption.metadata(), metadata, preconditions, new byte[0], null));
         LOG.debugf("startResumableUpload uploadId=%s", uploadId);
         return uploadId;
     }
 
     public GcsObjectMeta completeResumableUpload(String uploadId, byte[] data, String baseUrl) {
         LOG.debugf("completeResumableUpload uploadId=%s size=%d", uploadId, data.length);
-        ResumableUpload upload = resumableUploads.remove(uploadId);
+        ResumableUpload upload = resumableUploads.get(uploadId);
         if (upload == null) {
             LOG.warnf("completeResumableUpload failed: upload not found uploadId=%s", uploadId);
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
-        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
+        byte[] combined = appendChunk(upload, upload.data().length, data);
+        validateResumableTotalSize(upload, (long) combined.length);
+        resumableUploads.remove(uploadId);
+        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
                 upload.preconditions(), baseUrl);
     }
 
     public long appendResumableUpload(String uploadId, long start, byte[] data) {
+        return appendResumableUpload(uploadId, start, data, null);
+    }
+
+    public long appendResumableUpload(String uploadId, long start, byte[] data, Long totalSize) {
         ResumableUpload upload = resumableUploads.get(uploadId);
         if (upload == null) {
             LOG.warnf("appendResumableUpload failed: upload not found uploadId=%s", uploadId);
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
+        validateResumableTotalSize(upload, totalSize);
         byte[] combined = appendChunk(upload, start, data);
         resumableUploads.put(uploadId, new ResumableUpload(
                 upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(),
-                upload.metadata(), upload.preconditions(), combined));
+                upload.metadata(), upload.preconditions(), combined,
+                upload.totalSize() != null ? upload.totalSize() : totalSize));
         return combined.length - 1L;
     }
 
@@ -835,6 +844,7 @@ public class GcsService {
             LOG.warnf("completeBufferedResumableUpload failed: upload not found uploadId=%s", uploadId);
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
+        validateResumableTotalSize(upload, totalSize);
         byte[] data = upload.data();
         if (data.length != totalSize) {
             throw GcpException.invalidArgument(
@@ -853,6 +863,7 @@ public class GcsService {
             LOG.warnf("completeResumableUpload failed: upload not found uploadId=%s", uploadId);
             throw GcpException.notFound("Resumable upload not found: " + uploadId);
         }
+        validateResumableTotalSize(upload, totalSize);
         byte[] combined = appendChunk(upload, start, data);
         if (combined.length != totalSize) {
             throw GcpException.invalidArgument(
@@ -862,6 +873,13 @@ public class GcsService {
         return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
                 upload.preconditions(), baseUrl);
+    }
+
+    private static void validateResumableTotalSize(ResumableUpload upload, Long totalSize) {
+        if (upload.totalSize() != null && totalSize != null && !upload.totalSize().equals(totalSize)) {
+            throw GcpException.invalidArgument(
+                    "Content-Range total size does not match previous chunks: " + totalSize);
+        }
     }
 
     private static byte[] appendChunk(ResumableUpload upload, long start, byte[] data) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -11,7 +11,9 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -46,15 +48,16 @@ public class GcsUploadController {
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @jakarta.ws.rs.core.Context HttpHeaders headers,
+            @jakarta.ws.rs.core.Context UriInfo uriInfo,
             byte[] body) {
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         if ("multipart".equals(uploadType)) {
-            return handleMultipart(bucket, nameParam, headers, body, preconditions);
+            return handleMultipart(bucket, nameParam, headers, uriInfo, body, preconditions);
         } else if ("resumable".equals(uploadType)) {
-            return handleStartResumable(bucket, nameParam, headers, body, preconditions);
+            return handleStartResumable(bucket, nameParam, headers, uriInfo, body, preconditions);
         } else if ("media".equals(uploadType)) {
-            return handleMedia(bucket, nameParam, headers, body, preconditions);
+            return handleMedia(bucket, nameParam, headers, uriInfo, body, preconditions);
         }
         throw GcpException.invalidArgument("unsupported uploadType: " + uploadType);
     }
@@ -65,6 +68,7 @@ public class GcsUploadController {
             @PathParam("bucket") String bucket,
             @QueryParam("upload_id") String uploadId,
             @jakarta.ws.rs.core.Context HttpHeaders headers,
+            @jakarta.ws.rs.core.Context UriInfo uriInfo,
             byte[] body) {
         if (uploadId == null) {
             throw GcpException.invalidArgument("missing upload_id query parameter");
@@ -76,7 +80,7 @@ public class GcsUploadController {
                 long uploadedLength = service.resumableUploadLength(uploadId);
                 if (range.totalSize() != null && uploadedLength == range.totalSize()) {
                     GcsObjectMeta meta = service.completeBufferedResumableUpload(
-                            uploadId, range.totalSize(), requestBaseUrl(headers));
+                            uploadId, range.totalSize(), requestBaseUrl(headers, uriInfo));
                     return Response.ok(meta).build();
                 }
                 Response.ResponseBuilder response = Response.status(308);
@@ -89,11 +93,15 @@ public class GcsUploadController {
                 long end = service.appendResumableUpload(uploadId, range.start(), body);
                 return Response.status(308).header("Range", "bytes=0-" + end).build();
             }
+            if (range.end() + 1 < range.totalSize()) {
+                long end = service.appendResumableUpload(uploadId, range.start(), body, range.totalSize());
+                return Response.status(308).header("Range", "bytes=0-" + end).build();
+            }
             GcsObjectMeta meta = service.completeResumableUpload(
-                    uploadId, range.start(), body, range.totalSize(), requestBaseUrl(headers));
+                    uploadId, range.start(), body, range.totalSize(), requestBaseUrl(headers, uriInfo));
             return Response.ok(meta).build();
         }
-        GcsObjectMeta meta = service.completeResumableUpload(uploadId, body, requestBaseUrl(headers));
+        GcsObjectMeta meta = service.completeResumableUpload(uploadId, body, requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
     }
 
@@ -135,6 +143,9 @@ public class GcsUploadController {
         if (start < 0 || end < start || bodyLength != end - start + 1) {
             throw GcpException.invalidArgument("invalid Content-Range header: " + header);
         }
+        if (totalSize != null && end >= totalSize) {
+            throw GcpException.invalidArgument("invalid Content-Range header: " + header);
+        }
         return new ContentRange(start, end, totalSize, false);
     }
 
@@ -146,7 +157,7 @@ public class GcsUploadController {
         }
     }
 
-    private Response handleMultipart(String bucket, String nameParam, HttpHeaders headers, byte[] body,
+    private Response handleMultipart(String bucket, String nameParam, HttpHeaders headers, UriInfo uriInfo, byte[] body,
             GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String[] rawParts = parseMultipartRaw(contentType, new String(body, ISO));
@@ -169,11 +180,11 @@ public class GcsUploadController {
         var userMetadata = extractUserMetadata(metadata);
         byte[] dataBytes = extractPartBody(rawParts[1]).getBytes(ISO);
         GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes,
-                GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions, requestBaseUrl(headers));
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions, requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
     }
 
-    private Response handleStartResumable(String bucket, String nameParam, HttpHeaders headers, byte[] body,
+    private Response handleStartResumable(String bucket, String nameParam, HttpHeaders headers, UriInfo uriInfo, byte[] body,
             GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString("X-Upload-Content-Type");
         String name = nameParam;
@@ -205,23 +216,39 @@ public class GcsUploadController {
 
         String uploadId = service.startResumableUpload(bucket, name, contentType,
                 GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions);
-        String location = requestBaseUrl(headers) + "/upload/storage/v1/b/" + bucket
+        String location = requestBaseUrl(headers, uriInfo) + "/upload/storage/v1/b/" + bucket
                 + "/o?uploadType=resumable&upload_id=" + uploadId;
 
         return Response.ok().header("Location", location).build();
     }
 
-    private Response handleMedia(String bucket, String name, HttpHeaders headers, byte[] body,
+    private Response handleMedia(String bucket, String name, HttpHeaders headers, UriInfo uriInfo, byte[] body,
             GcsObjectPreconditions preconditions) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         GcsObjectMeta meta = service.putObject(bucket, name, contentType, body,
-                GcsCustomerEncryption.fromHeaders(headers), preconditions, requestBaseUrl(headers));
+                GcsCustomerEncryption.fromHeaders(headers), preconditions, requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
     }
 
-    private String requestBaseUrl(HttpHeaders headers) {
+    private String requestBaseUrl(HttpHeaders headers, UriInfo uriInfo) {
         String host = headers.getHeaderString("Host");
-        return host != null ? "http://" + host : config.baseUrl();
+        if (host == null) {
+            return config.baseUrl();
+        }
+        if (hasPort(host)) {
+            return "http://" + host;
+        }
+        URI baseUrl = URI.create(config.baseUrl());
+        int port = baseUrl.getPort() >= 0 ? baseUrl.getPort() : config.port();
+        String scheme = baseUrl.getScheme() != null ? baseUrl.getScheme() : uriInfo.getBaseUri().getScheme();
+        return scheme + "://" + host + ":" + port;
+    }
+
+    private static boolean hasPort(String host) {
+        if (host.startsWith("[")) {
+            return host.indexOf("]:") > 0;
+        }
+        return host.indexOf(':') >= 0;
     }
 
     private static Map<String, String> extractUserMetadata(Map<?, ?> requestMetadata) {

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
@@ -4,4 +4,4 @@ import java.util.Map;
 
 public record ResumableUpload(String bucket, String objectName, String contentType,
         Map<String, String> customerEncryption, Map<String, String> metadata,
-        GcsObjectPreconditions preconditions, byte[] data) {}
+        GcsObjectPreconditions preconditions, byte[] data, Long totalSize) {}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsUploadMetadataRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsUploadMetadataRestIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.nullValue;
 
 @QuarkusTest
@@ -76,6 +77,107 @@ class GcsUploadMetadataRestIntegrationTest {
                 .then().statusCode(200)
                 .body("contentType", equalTo("text/plain"))
                 .body("metadata.origname", equalTo("test.txt"));
+    }
+
+    @Test
+    void resumableInitFallsBackToRequestPortWhenHostHasNoPort() {
+        ensureBucket();
+
+        given()
+                .header("Host", "localhost")
+                .contentType("application/json")
+                .body(Map.of("name", "portless-host-obj"))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .header("Location", matchesPattern(
+                        "http://localhost:4588/upload/storage/v1/b/" + BUCKET
+                                + "/o\\?uploadType=resumable&upload_id=.*"));
+    }
+
+    @Test
+    void resumableUploadAcceptsIntermediateChunkWithKnownTotalSize() {
+        ensureBucket();
+        var location = given()
+                .contentType("application/json")
+                .body(Map.of("name", "known-total-chunks-obj"))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        var uploadId = location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 4-5/6")
+                .body("ok".getBytes(StandardCharsets.UTF_8))
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(200)
+                .body("size", equalTo("6"));
+    }
+
+    @Test
+    void resumableUploadRejectsInconsistentStatusQueryTotal() {
+        ensureBucket();
+        var location = given()
+                .contentType("application/json")
+                .body(Map.of("name", "inconsistent-total-obj"))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        var uploadId = location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes */4")
+                .body(new byte[0])
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    void resumableUploadRejectsBodyOnlyCompletionWithInconsistentRetainedTotal() {
+        ensureBucket();
+        var location = given()
+                .contentType("application/json")
+                .body(Map.of("name", "body-only-inconsistent-total-obj"))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        var uploadId = location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .body("x".getBytes(StandardCharsets.UTF_8))
+                .when().put("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId)
+                .then().statusCode(400)
+                .body("error.status", equalTo("INVALID_ARGUMENT"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #126.

This fixes two GCS resumable upload compatibility issues:

- Resumable upload session `Location` URLs now keep a reachable port when the incoming `Host` header does not include one.
- Intermediate resumable upload chunks with a known total size now return `308 Resume Incomplete` with a `Range` header until the declared total size is reached.

Previously, a portless `Host` header such as `Host: localhost` caused the session `Location` to be returned as `http://localhost/...`, which made clients target port 80 instead of the emulator port.

Previously, an intermediate chunk such as `Content-Range: bytes 0-262143/524288` was treated as final because the total size was present, causing the upload to fail with `400`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

The issue report says this behavior was verified against live GCS on 2026-08-17:

- Live GCS returns an absolute resumable session URL on `https://storage.googleapis.com/upload/...`.
- Live GCS returns `308 Resume Incomplete` with `Range` for intermediate chunks that declare the total size.

This PR updates the emulator behavior to match that flow.

Local verification:

```bash
./mvnw -q -Dtest=GcsUploadMetadataRestIntegrationTest test
./mvnw -q test
git diff --check
```

I did not run the SDK compatibility suite locally.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)