### PR TITLE
feat(gcs): support atomic object moves

### DIFF
--- a/compatibility-tests/sdk-test-gcloud/README.md
+++ b/compatibility-tests/sdk-test-gcloud/README.md
@@ -20,7 +20,7 @@ environment only (no `gcloud config` mutation):
 
 | Service | gcloud surface |
 |---|---|
-| Cloud Storage | `storage buckets create/list`, `storage cp/cat/ls/rm` |
+| Cloud Storage | `storage buckets create/list`, `storage cp/mv/cat/ls/rm` |
 | Secret Manager | `secrets create/list/versions add/versions access` |
 | Cloud KMS | `kms keyrings create/list`, `kms keys create/list/describe` |
 | IAM | `iam service-accounts create/list` |

--- a/compatibility-tests/sdk-test-gcloud/test/storage.bats
+++ b/compatibility-tests/sdk-test-gcloud/test/storage.bats
@@ -58,6 +58,22 @@ setup() {
     done
 }
 
+@test "storage: move object" {
+    local f="${BATS_TEST_TMPDIR}/move.txt"
+    echo "move content" > "$f"
+    gcloud_cmd storage cp "$f" "gs://${BUCKET}/move/source" >/dev/null
+
+    run gcloud_cmd storage mv "gs://${BUCKET}/move/source" "gs://${BUCKET}/move/destination"
+    assert_success
+
+    run gcloud_cmd storage cat "gs://${BUCKET}/move/destination"
+    assert_success
+    assert_output --partial "move content"
+
+    run gcloud_cmd storage ls "gs://${BUCKET}/move/source"
+    assert_failure
+}
+
 @test "storage: delete object" {
     local f="${BATS_TEST_TMPDIR}/del.txt"
     echo "x" > "$f"

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -216,6 +216,7 @@ The embedded DNS server resolves `*.localhost.floci.io` to floci-gcp's container
 - `DeleteObject`
 - `ListObjects` (with `pageToken`, `prefix`, `delimiter` pagination)
 - `CopyObject`
+- `MoveObject`
 - `HeadObject`
 - `PatchObject` (update metadata: `contentType`, `contentDisposition`, `contentEncoding`, `contentLanguage`, custom metadata)
 - `ComposeObject` (concatenate up to 32 source objects)
@@ -238,6 +239,7 @@ Object names containing `/`, spaces, `+`, or percent-encoded sequences round-tri
 
 - `ifGenerationMatch` / `ifGenerationNotMatch`
 - `ifMetagenerationMatch` / `ifMetagenerationNotMatch`
+- `ifSourceGenerationMatch` / `ifSourceGenerationNotMatch` for object moves
+- `ifSourceMetagenerationMatch` / `ifSourceMetagenerationNotMatch` for object moves
 - Returns HTTP 412 on precondition failure
-- Enforced atomically on the write paths (insert, patch/update, resumable finalize) under a per-object lock, with a monotonic generation sequence — concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)
-- Not yet enforced on `delete`, `compose`, `copyTo`, and `rewriteTo` (params are accepted and ignored)
+- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence — concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -269,6 +269,29 @@ public class GcsObjectController {
     }
 
     @POST
+    @Path("/{srcObject: .+}/moveTo/o/{dstObject: .+}")
+    public Response moveObject(@PathParam("bucket") String bucket,
+            @PathParam("srcObject") String srcObjectPath,
+            @PathParam("dstObject") String dstObjectPath,
+            @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
+            @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
+            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+            @QueryParam("ifSourceGenerationMatch") Long ifSourceGenerationMatch,
+            @QueryParam("ifSourceGenerationNotMatch") Long ifSourceGenerationNotMatch,
+            @QueryParam("ifSourceMetagenerationMatch") Long ifSourceMetagenerationMatch,
+            @QueryParam("ifSourceMetagenerationNotMatch") Long ifSourceMetagenerationNotMatch,
+            @Context HttpHeaders headers) {
+        GcsObjectPreconditions sourcePreconditions = new GcsObjectPreconditions(ifSourceGenerationMatch,
+                ifSourceGenerationNotMatch, ifSourceMetagenerationMatch, ifSourceMetagenerationNotMatch);
+        GcsObjectPreconditions destinationPreconditions = new GcsObjectPreconditions(ifGenerationMatch,
+                ifGenerationNotMatch, ifMetagenerationMatch, ifMetagenerationNotMatch);
+        GcsObjectMeta meta = service.moveObject(bucket, srcObjectPath, dstObjectPath,
+                sourcePreconditions, destinationPreconditions, requestBaseUrl(headers));
+        return Response.ok(meta).build();
+    }
+
+    @POST
     @Path("/{srcObject: .+}/rewriteTo/b/{dstBucket}/o/{dstObject: .+}")
     public Response rewriteObject(@PathParam("bucket") String srcBucket,
             @PathParam("srcObject") String srcObjectPath,

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -663,6 +663,31 @@ public class GcsService {
         return dstMeta;
     }
 
+    public GcsObjectMeta moveObject(String bucket, String srcObject, String dstObject,
+            GcsObjectPreconditions sourcePreconditions, GcsObjectPreconditions destinationPreconditions,
+            String baseUrl) {
+        LOG.debugf("moveObject bucket=%s src=%s dst=%s", bucket, srcObject, dstObject);
+        if (srcObject.equals(dstObject)) {
+            throw GcpException.invalidArgument("Source and destination object names must be different.");
+        }
+
+        int sourceLockIndex = objectLockIndex(bucket, srcObject);
+        int destinationLockIndex = objectLockIndex(bucket, dstObject);
+        // Lock stripes in a stable order so opposite-direction moves cannot deadlock.
+        synchronized (objectLocks[Math.min(sourceLockIndex, destinationLockIndex)]) {
+            synchronized (objectLocks[Math.max(sourceLockIndex, destinationLockIndex)]) {
+                var source = getObjectForDownload(bucket, srcObject, null, GcsCustomerEncryption.none());
+                checkPreconditions(Optional.of(source.meta()), sourcePreconditions);
+                checkObjectMutable(source.meta());
+                checkPreconditions(bucket, dstObject, destinationPreconditions);
+
+                GcsObjectMeta moved = copyObjectLocked(source, bucket, dstObject, baseUrl);
+                deleteObjectLocked(bucket, srcObject);
+                return moved;
+            }
+        }
+    }
+
     public List<GcsObjectMeta> listObjects(String bucket) {
         LOG.debugf("listObjects bucket=%s", bucket);
         if (bucketStore.get(bucket).isEmpty()) {
@@ -1147,8 +1172,11 @@ public class GcsService {
     }
 
     private Object objectLock(String bucket, String objectName) {
-        int index = Math.floorMod(objectKey(bucket, objectName).hashCode(), objectLocks.length);
-        return objectLocks[index];
+        return objectLocks[objectLockIndex(bucket, objectName)];
+    }
+
+    private int objectLockIndex(String bucket, String objectName) {
+        return Math.floorMod(objectKey(bucket, objectName).hashCode(), objectLocks.length);
     }
 
     private static long maxGeneration(StorageBackend<String, GcsObjectMeta> objectMetaStore) {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsMoveRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsMoveRestIntegrationTest.java
@@ -1,0 +1,137 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class GcsMoveRestIntegrationTest {
+
+    private String bucket;
+
+    @BeforeEach
+    void createBucket() {
+        bucket = "move-objects-" + UUID.randomUUID().toString().substring(0, 8);
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", bucket))
+                .when().post("/storage/v1/b?project=test-project")
+                .then().statusCode(200);
+    }
+
+    @Test
+    void movesUriEncodedObjectName() {
+        Response source = upload("source/name", "content");
+        String sourceGeneration = source.path("generation");
+
+        given()
+                .urlEncodingEnabled(false)
+                .queryParam("ifGenerationMatch", 0)
+                .queryParam("ifSourceGenerationMatch", sourceGeneration)
+                .when().post("/storage/v1/b/" + bucket + "/o/source%2Fname/moveTo/o/destination%2Fname")
+                .then().statusCode(200)
+                .body("name", equalTo("destination/name"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get("/storage/v1/b/" + bucket + "/o/source%2Fname")
+                .then().statusCode(404);
+        given()
+                .urlEncodingEnabled(false)
+                .queryParam("alt", "media")
+                .when().get("/storage/v1/b/" + bucket + "/o/destination%2Fname")
+                .then().statusCode(200)
+                .body(equalTo("content"));
+    }
+
+    @Test
+    void movesObjectWhenDestinationContainsRouteDelimiter() {
+        upload("source", "content");
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().post("/storage/v1/b/" + bucket + "/o/source/moveTo/o/destination%2FmoveTo%2Fo%2Fname")
+                .then().statusCode(200)
+                .body("name", equalTo("destination/moveTo/o/name"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get("/storage/v1/b/" + bucket + "/o/source")
+                .then().statusCode(404);
+        given()
+                .urlEncodingEnabled(false)
+                .queryParam("alt", "media")
+                .when().get("/storage/v1/b/" + bucket + "/o/destination%2FmoveTo%2Fo%2Fname")
+                .then().statusCode(200)
+                .body(equalTo("content"));
+    }
+
+    @Test
+    void failedDestinationPreconditionLeavesBothObjectsUnchanged() {
+        upload("destination-precondition-source", "source");
+        upload("destination-precondition-target", "target");
+
+        given()
+                .queryParam("ifGenerationMatch", 0)
+                .when().post("/storage/v1/b/" + bucket
+                        + "/o/destination-precondition-source/moveTo/o/destination-precondition-target")
+                .then().statusCode(412);
+
+        assertContent("destination-precondition-source", "source");
+        assertContent("destination-precondition-target", "target");
+    }
+
+    @Test
+    void failedSourcePreconditionLeavesSourceAndDestinationUnchanged() {
+        upload("source-precondition-source", "source");
+
+        given()
+                .queryParam("ifGenerationMatch", 0)
+                .queryParam("ifSourceGenerationMatch", 1)
+                .when().post("/storage/v1/b/" + bucket
+                        + "/o/source-precondition-source/moveTo/o/source-precondition-target")
+                .then().statusCode(412);
+
+        assertContent("source-precondition-source", "source");
+        given()
+                .when().get("/storage/v1/b/" + bucket + "/o/source-precondition-target")
+                .then().statusCode(404);
+    }
+
+    @Test
+    void rejectsIdenticalObjectNames() {
+        upload("same-name", "content");
+
+        given()
+                .when().post("/storage/v1/b/" + bucket + "/o/same-name/moveTo/o/same-name")
+                .then().statusCode(400);
+
+        assertContent("same-name", "content");
+    }
+
+    private Response upload(String objectName, String content) {
+        return given()
+                .queryParam("uploadType", "media")
+                .queryParam("name", objectName)
+                .contentType("text/plain")
+                .body(content)
+                .when().post("/upload/storage/v1/b/" + bucket + "/o")
+                .then().statusCode(200)
+                .extract().response();
+    }
+
+    private void assertContent(String objectName, String content) {
+        given()
+                .queryParam("alt", "media")
+                .when().get("/storage/v1/b/" + bucket + "/o/" + objectName)
+                .then().statusCode(200)
+                .body(equalTo(content));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -7,6 +7,7 @@ import io.floci.gcp.core.storage.PersistentStorage;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
+import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import io.floci.gcp.services.gcs.model.StoredAcl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -147,6 +148,61 @@ class GcsServiceTest {
         assertEquals("text/plain", copied.getContentType());
         assertEquals(Map.of("origname", "src.txt"), copied.getMetadata());
         assertArrayEquals(data, service.getObjectData("bucket", "dst.txt", GcsCustomerEncryption.none()));
+    }
+
+    @Test
+    void moveObjectMovesDataContentTypeAndMetadata() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
+        GcsObjectMeta source = service.putObject("bucket", "source/name", "text/plain", data,
+                GcsCustomerEncryption.none(), Map.of("original", "source/name"), BASE_URL);
+        GcsObjectPreconditions sourcePreconditions = new GcsObjectPreconditions(
+                Long.parseLong(source.getGeneration()), null, null, null);
+        GcsObjectPreconditions destinationPreconditions = new GcsObjectPreconditions(0L, null, null, null);
+
+        GcsObjectMeta moved = service.moveObject("bucket", "source/name", "destination/name",
+                sourcePreconditions, destinationPreconditions, BASE_URL);
+
+        assertEquals("destination/name", moved.getName());
+        assertEquals("text/plain", moved.getContentType());
+        assertEquals(Map.of("original", "source/name"), moved.getMetadata());
+        assertNotEquals(source.getGeneration(), moved.getGeneration());
+        assertArrayEquals(data, service.getObjectData("bucket", "destination/name"));
+        GcpException exception = assertThrows(GcpException.class,
+                () -> service.getObjectMeta("bucket", "source/name"));
+        assertEquals(404, exception.getHttpStatus());
+    }
+
+    @Test
+    void moveObjectPreconditionFailureDoesNotChangeEitherObject() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        service.putObject("bucket", "source", "text/plain", "source".getBytes(StandardCharsets.UTF_8),
+                GcsCustomerEncryption.none(), BASE_URL);
+        service.putObject("bucket", "destination", "text/plain", "destination".getBytes(StandardCharsets.UTF_8),
+                GcsCustomerEncryption.none(), BASE_URL);
+        GcsObjectPreconditions destinationDoesNotExist = new GcsObjectPreconditions(0L, null, null, null);
+
+        GcpException exception = assertThrows(GcpException.class,
+                () -> service.moveObject("bucket", "source", "destination", GcsObjectPreconditions.NONE,
+                        destinationDoesNotExist, BASE_URL));
+
+        assertEquals(412, exception.getHttpStatus());
+        assertArrayEquals("source".getBytes(StandardCharsets.UTF_8), service.getObjectData("bucket", "source"));
+        assertArrayEquals("destination".getBytes(StandardCharsets.UTF_8),
+                service.getObjectData("bucket", "destination"));
+    }
+
+    @Test
+    void moveObjectRejectsIdenticalNames() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        service.putObject("bucket", "object", "text/plain", new byte[0], GcsCustomerEncryption.none(), BASE_URL);
+
+        GcpException exception = assertThrows(GcpException.class,
+                () -> service.moveObject("bucket", "object", "object", GcsObjectPreconditions.NONE,
+                        GcsObjectPreconditions.NONE, BASE_URL));
+
+        assertEquals(400, exception.getHttpStatus());
+        assertEquals("Source and destination object names must be different.", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds support for same-bucket GCS object moves with source and destination preconditions.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Verified against real GCS using gcloud CLI 580.0.0 and Google Cloud Storage Java connector 4.0.4. Successful moves, precondition failures, missing sources, identical object names, and URI-encoded object names match real GCS behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)