### PR TITLE
feat(pubsub): add IAM policy support

### DIFF
--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -161,9 +161,53 @@ resource "google_kms_crypto_key" "compat" {
   purpose  = "ENCRYPT_DECRYPT"
 }
 
+# ── Pub/Sub ───────────────────────────────────────────────────────────────────
+resource "google_pubsub_topic" "compat" {
+  name = "floci-compat-topic-tofu"
+
+  labels = {
+    env = "compat-test"
+  }
+}
+
+resource "google_pubsub_subscription" "compat" {
+  name  = "floci-compat-sub-tofu"
+  topic = google_pubsub_topic.compat.id
+
+  ack_deadline_seconds = 20
+}
+
+# Two members on one topic exercise the getIamPolicy → merge → setIamPolicy
+# read-modify-write flow; both grants must survive.
+resource "google_pubsub_topic_iam_member" "publisher" {
+  topic  = google_pubsub_topic.compat.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.compat.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "viewer" {
+  topic  = google_pubsub_topic.compat.name
+  role   = "roles/pubsub.viewer"
+  member = "user:compat-viewer@example.com"
+}
+
+resource "google_pubsub_subscription_iam_member" "subscriber" {
+  subscription = google_pubsub_subscription.compat.name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.compat.email}"
+}
+
 # ── Outputs ───────────────────────────────────────────────────────────────────
 output "key_ring_name" {
   value = google_kms_key_ring.compat.name
+}
+
+output "pubsub_topic_name" {
+  value = google_pubsub_topic.compat.name
+}
+
+output "pubsub_subscription_name" {
+  value = google_pubsub_subscription.compat.name
 }
 
 output "crypto_key_name" {

--- a/compatibility-tests/compat-opentofu/provider.tf
+++ b/compatibility-tests/compat-opentofu/provider.tf
@@ -46,8 +46,8 @@ variable "cloud_run_replace_token" {
 # floci-gcp ignores auth headers unconditionally).
 #
 # Custom endpoints redirect each service API to the local emulator.
-# Services that only expose gRPC (Pub/Sub, Firestore, Datastore) are not
-# reachable via OpenTofu custom endpoints — they need REST transcoding.
+# Services that only expose gRPC (Firestore, Datastore) are not reachable via
+# OpenTofu custom endpoints — they need REST transcoding.
 provider "google" {
   project = var.project
   region  = var.region
@@ -62,6 +62,7 @@ provider "google" {
   cloud_run_v2_custom_endpoint   = "${var.endpoint}/v2/"
   sql_custom_endpoint            = "${var.endpoint}/sql/v1beta4/"
   kms_custom_endpoint            = "${var.endpoint}/v1/"
+  pubsub_custom_endpoint         = "${var.endpoint}/v1/"
 
   # Service Usage + the Cloud Resource Manager v1 project lookup that
   # google_project_service performs on every read.

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -299,7 +299,41 @@ setup() {
 
 # ── State Integrity ───────────────────────────────────────────────────────────
 
+# ── Pub/Sub Spot Checks ───────────────────────────────────────────────────────
+
+@test "OpenTofu: Pub/Sub topic created" {
+    run gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/topics/floci-compat-topic-tofu"
+    assert_success
+    assert_output --partial 'floci-compat-topic-tofu'
+}
+
+@test "OpenTofu: Pub/Sub subscription created" {
+    run gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/subscriptions/floci-compat-sub-tofu"
+    assert_success
+    assert_output --partial 'floci-compat-sub-tofu'
+}
+
+# Both google_pubsub_topic_iam_member grants must survive the provider's
+# read-modify-write; a frozen etag would let the second write clobber the first.
+@test "OpenTofu: Pub/Sub topic IAM policy holds both member grants" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/topics/floci-compat-topic-tofu:getIamPolicy")
+    [[ "$result" == *'roles/pubsub.publisher'* ]]
+    [[ "$result" == *'roles/pubsub.viewer'* ]]
+    [[ "$result" == *'floci-compat-sa-tofu@'* ]]
+    [[ "$result" == *'user:compat-viewer@example.com'* ]]
+}
+
+@test "OpenTofu: Pub/Sub subscription IAM policy holds subscriber grant" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/subscriptions/floci-compat-sub-tofu:getIamPolicy")
+    [[ "$result" == *'roles/pubsub.subscriber'* ]]
+}
+
+@test "OpenTofu: Pub/Sub topic policy does not leak subscription grant" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/topics/floci-compat-topic-tofu:getIamPolicy")
+    [[ "$result" != *'roles/pubsub.subscriber'* ]]
+}
+
 @test "OpenTofu: all managed resources tracked in state" {
     count=$(tofu state list 2>/dev/null | wc -l | tr -d ' ')
-    [ "$count" -ge 13 ]
+    [ "$count" -ge 18 ]
 }

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -161,9 +161,53 @@ resource "google_kms_crypto_key" "compat" {
   purpose  = "ENCRYPT_DECRYPT"
 }
 
+# ── Pub/Sub ───────────────────────────────────────────────────────────────────
+resource "google_pubsub_topic" "compat" {
+  name = "floci-compat-topic"
+
+  labels = {
+    env = "compat-test"
+  }
+}
+
+resource "google_pubsub_subscription" "compat" {
+  name  = "floci-compat-sub"
+  topic = google_pubsub_topic.compat.id
+
+  ack_deadline_seconds = 20
+}
+
+# Two members on one topic exercise the getIamPolicy → merge → setIamPolicy
+# read-modify-write flow; both grants must survive.
+resource "google_pubsub_topic_iam_member" "publisher" {
+  topic  = google_pubsub_topic.compat.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.compat.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "viewer" {
+  topic  = google_pubsub_topic.compat.name
+  role   = "roles/pubsub.viewer"
+  member = "user:compat-viewer@example.com"
+}
+
+resource "google_pubsub_subscription_iam_member" "subscriber" {
+  subscription = google_pubsub_subscription.compat.name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.compat.email}"
+}
+
 # ── Outputs ───────────────────────────────────────────────────────────────────
 output "key_ring_name" {
   value = google_kms_key_ring.compat.name
+}
+
+output "pubsub_topic_name" {
+  value = google_pubsub_topic.compat.name
+}
+
+output "pubsub_subscription_name" {
+  value = google_pubsub_subscription.compat.name
 }
 
 output "crypto_key_name" {

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -46,8 +46,8 @@ variable "cloud_run_replace_token" {
 # floci-gcp ignores auth headers unconditionally).
 #
 # Custom endpoints redirect each service API to the local emulator.
-# Services that only expose gRPC (Pub/Sub, Firestore, Datastore) are not
-# reachable via Terraform custom endpoints — they need REST transcoding.
+# Services that only expose gRPC (Firestore, Datastore) are not reachable via
+# Terraform custom endpoints — they need REST transcoding.
 provider "google" {
   project = var.project
   region  = var.region
@@ -62,6 +62,7 @@ provider "google" {
   cloud_run_v2_custom_endpoint   = "${var.endpoint}/v2/"
   sql_custom_endpoint            = "${var.endpoint}/sql/v1beta4/"
   kms_custom_endpoint            = "${var.endpoint}/v1/"
+  pubsub_custom_endpoint         = "${var.endpoint}/v1/"
 
   # Service Usage + the Cloud Resource Manager v1 project lookup that
   # google_project_service performs on every read.

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -299,9 +299,43 @@ setup() {
     assert_output --partial 'run.googleapis.com'
 }
 
+# ── Pub/Sub Spot Checks ───────────────────────────────────────────────────────
+
+@test "Terraform: Pub/Sub topic created" {
+    run gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/topics/floci-compat-topic"
+    assert_success
+    assert_output --partial 'floci-compat-topic'
+}
+
+@test "Terraform: Pub/Sub subscription created" {
+    run gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/subscriptions/floci-compat-sub"
+    assert_success
+    assert_output --partial 'floci-compat-sub'
+}
+
+# Both google_pubsub_topic_iam_member grants must survive the provider's
+# read-modify-write; a frozen etag would let the second write clobber the first.
+@test "Terraform: Pub/Sub topic IAM policy holds both member grants" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/topics/floci-compat-topic:getIamPolicy")
+    [[ "$result" == *'roles/pubsub.publisher'* ]]
+    [[ "$result" == *'roles/pubsub.viewer'* ]]
+    [[ "$result" == *'floci-compat-sa@'* ]]
+    [[ "$result" == *'user:compat-viewer@example.com'* ]]
+}
+
+@test "Terraform: Pub/Sub subscription IAM policy holds subscriber grant" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/subscriptions/floci-compat-sub:getIamPolicy")
+    [[ "$result" == *'roles/pubsub.subscriber'* ]]
+}
+
+@test "Terraform: Pub/Sub topic policy does not leak subscription grant" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/topics/floci-compat-topic:getIamPolicy")
+    [[ "$result" != *'roles/pubsub.subscriber'* ]]
+}
+
 # ── State Integrity ───────────────────────────────────────────────────────────
 
 @test "Terraform: all managed resources tracked in state" {
     count=$(terraform state list 2>/dev/null | wc -l | tr -d ' ')
-    [ "$count" -ge 13 ]
+    [ "$count" -ge 18 ]
 }

--- a/compatibility-tests/sdk-test-go/tests/pubsub_test.go
+++ b/compatibility-tests/sdk-test-go/tests/pubsub_test.go
@@ -81,6 +81,55 @@ func TestPubSub(t *testing.T) {
 		assert.True(t, found, "created subscription should appear in list")
 	})
 
+	t.Run("TopicIAMPolicy", func(t *testing.T) {
+		handle := topic.IAM()
+
+		policy, err := handle.Policy(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, policy.Roles(), "unset policy should be empty, not an error")
+
+		member := "serviceAccount:worker@" + testutil.ProjectID() + ".iam.gserviceaccount.com"
+		policy.Add(member, "roles/pubsub.publisher")
+		require.NoError(t, handle.SetPolicy(ctx, policy))
+
+		read, err := handle.Policy(ctx)
+		require.NoError(t, err)
+		assert.True(t, read.HasRole(member, "roles/pubsub.publisher"), "granted binding should read back")
+	})
+
+	t.Run("SubscriptionIAMPolicy", func(t *testing.T) {
+		handle := sub.IAM()
+
+		policy, err := handle.Policy(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, policy.Roles())
+
+		member := "user:analyst@example.com"
+		policy.Add(member, "roles/pubsub.subscriber")
+		require.NoError(t, handle.SetPolicy(ctx, policy))
+
+		read, err := handle.Policy(ctx)
+		require.NoError(t, err)
+		assert.True(t, read.HasRole(member, "roles/pubsub.subscriber"))
+
+		topicPolicy, err := topic.IAM().Policy(ctx)
+		require.NoError(t, err)
+		assert.False(t, topicPolicy.HasRole(member, "roles/pubsub.subscriber"),
+			"subscription grant must not leak onto the topic")
+	})
+
+	t.Run("IAMPolicyOnMissingTopicIsNotFound", func(t *testing.T) {
+		_, err := client.Topic(uniqueName("go-never-created")).IAM().Policy(ctx)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("TestIAMPermissionsEchoes", func(t *testing.T) {
+		perms := []string{"pubsub.topics.publish", "pubsub.topics.get"}
+		granted, err := topic.IAM().TestPermissions(ctx, perms)
+		require.NoError(t, err)
+		assert.Equal(t, perms, granted)
+	})
+
 	t.Run("PublishAndReceive", func(t *testing.T) {
 		messages := []string{"Hello from Go!", "Second Go message"}
 

--- a/compatibility-tests/sdk-test-go/tests/pubsub_test.go
+++ b/compatibility-tests/sdk-test-go/tests/pubsub_test.go
@@ -130,6 +130,13 @@ func TestPubSub(t *testing.T) {
 		assert.Equal(t, perms, granted)
 	})
 
+	t.Run("TestIAMPermissionsFailsOpenForMissingTopic", func(t *testing.T) {
+		granted, err := client.Topic(uniqueName("go-perm-missing")).IAM().TestPermissions(ctx,
+			[]string{"pubsub.topics.publish"})
+		require.NoError(t, err, "missing resource should fail open, not error")
+		assert.Empty(t, granted)
+	})
+
 	t.Run("PublishAndReceive", func(t *testing.T) {
 		messages := []string{"Hello from Go!", "Second Go message"}
 

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
@@ -626,6 +626,13 @@ class PubSubTest {
         assertThatThrownBy(() -> topicAdminClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
                 .setResource(missing.toString()).build()))
                 .isInstanceOf(NotFoundException.class);
+
+        TestIamPermissionsResponse perms = topicAdminClient.testIamPermissions(
+                TestIamPermissionsRequest.newBuilder()
+                        .setResource(missing.toString())
+                        .addPermissions("pubsub.topics.publish")
+                        .build());
+        assertThat(perms.getPermissionsList()).isEmpty();
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/PubSubTest.java
@@ -4,6 +4,7 @@ import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
@@ -12,6 +13,12 @@ import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.FieldMask;
 import com.google.pubsub.v1.AcknowledgeRequest;
@@ -562,6 +569,63 @@ class PubSubTest {
             try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
             try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
         }
+    }
+
+    @Test
+    @Order(18)
+    void iamPolicyRoundTripOnTopicAndSubscription() {
+        String topicId = TestFixtures.uniqueName("iam-topic");
+        String subId = TestFixtures.uniqueName("iam-sub");
+        ProjectTopicName topicName = ProjectTopicName.of(PROJECT_ID, topicId);
+        ProjectSubscriptionName subName = ProjectSubscriptionName.of(PROJECT_ID, subId);
+
+        topicAdminClient.createTopic(topicName);
+        subscriptionAdminClient.createSubscription(
+                subName, topicName, PushConfig.getDefaultInstance(), 10);
+        try {
+            Policy unset = topicAdminClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                    .setResource(topicName.toString()).build());
+            assertThat(unset.getBindingsList()).isEmpty();
+
+            Policy granted = topicAdminClient.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                    .setResource(topicName.toString())
+                    .setPolicy(Policy.newBuilder()
+                            .addBindings(Binding.newBuilder()
+                                    .setRole("roles/pubsub.publisher")
+                                    .addMembers("serviceAccount:worker@" + PROJECT_ID
+                                            + ".iam.gserviceaccount.com"))
+                            .build())
+                    .build());
+            assertThat(granted.getEtag().toStringUtf8()).isNotEmpty();
+
+            Policy readBack = topicAdminClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                    .setResource(topicName.toString()).build());
+            assertThat(readBack.getBindingsList()).isEqualTo(granted.getBindingsList());
+            assertThat(readBack.getEtag()).isEqualTo(granted.getEtag());
+
+            Policy subPolicy = subscriptionAdminClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                    .setResource(subName.toString()).build());
+            assertThat(subPolicy.getBindingsList()).isEmpty();
+
+            TestIamPermissionsResponse perms = topicAdminClient.testIamPermissions(
+                    TestIamPermissionsRequest.newBuilder()
+                            .setResource(topicName.toString())
+                            .addPermissions("pubsub.topics.publish")
+                            .build());
+            assertThat(perms.getPermissionsList()).containsExactly("pubsub.topics.publish");
+        } finally {
+            try { subscriptionAdminClient.deleteSubscription(subName); } catch (Exception ignored) {}
+            try { topicAdminClient.deleteTopic(topicName); } catch (Exception ignored) {}
+        }
+    }
+
+    @Test
+    @Order(19)
+    void iamPolicyOnMissingTopicIsNotFound() {
+        ProjectTopicName missing = ProjectTopicName.of(PROJECT_ID, TestFixtures.uniqueName("iam-missing"));
+        assertThatThrownBy(() -> topicAdminClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                .setResource(missing.toString()).build()))
+                .isInstanceOf(NotFoundException.class);
     }
 
     @Test

--- a/docs/services/pubsub.md
+++ b/docs/services/pubsub.md
@@ -291,9 +291,10 @@ Policy semantics:
   `google_pubsub_topic_iam_member` behave as they do against real GCP. Omitting
   the etag performs a blind write.
 - Deleting a resource deletes its policy; recreating the same name starts empty.
-- `testIamPermissions` echoes the requested permissions without consulting
-  stored bindings, and performs no existence check (the real API fails open for
-  missing resources).
+- `testIamPermissions` echoes the requested permissions for an existing
+  resource, never consulting stored bindings. For a resource that does not
+  exist it fails open with an empty permission set — not `NOT_FOUND` — matching
+  the service config.
 - Schemas are not implemented, so schema IAM paths are not served.
 
 Over gRPC these methods are served by the standalone `google.iam.v1.IAMPolicy`
@@ -350,4 +351,4 @@ Policy updated = topicAdminClient.setIamPolicy(SetIamPolicyRequest.newBuilder()
 
 - `GetIamPolicy`
 - `SetIamPolicy`
-- `TestIamPermissions` (echoes requested permissions)
+- `TestIamPermissions` (echoes requested permissions; empty set for missing resources)

--- a/docs/services/pubsub.md
+++ b/docs/services/pubsub.md
@@ -43,6 +43,18 @@ The REST surface supports topic and subscription create/read/list/update/delete,
 - `POST /v1/projects/{project}/subscriptions/{subscription}:pull`
 - `POST /v1/projects/{project}/subscriptions/{subscription}:acknowledge`
 
+IAM policy methods are served for topics, subscriptions, and snapshots:
+
+- `GET /v1/projects/{project}/topics/{topic}:getIamPolicy`
+- `POST /v1/projects/{project}/topics/{topic}:setIamPolicy`
+- `POST /v1/projects/{project}/topics/{topic}:testIamPermissions`
+- `GET /v1/projects/{project}/subscriptions/{subscription}:getIamPolicy`
+- `POST /v1/projects/{project}/subscriptions/{subscription}:setIamPolicy`
+- `POST /v1/projects/{project}/subscriptions/{subscription}:testIamPermissions`
+- `GET /v1/projects/{project}/snapshots/{snapshot}:getIamPolicy`
+- `POST /v1/projects/{project}/snapshots/{snapshot}:setIamPolicy`
+- `POST /v1/projects/{project}/snapshots/{snapshot}:testIamPermissions`
+
 ## Quick Start
 
 === "gcloud CLI"
@@ -260,6 +272,49 @@ subscriptionAdminClient.seek(SeekRequest.newBuilder()
     .build());
 ```
 
+## IAM Policies
+
+IAM policies on topics, subscriptions, and snapshots are **stored and returned,
+never enforced**. `setIamPolicy` followed by `getIamPolicy` returns exactly the
+bindings that were set — including `condition` blocks, which are stored verbatim
+and never evaluated — but no request is ever denied because of a policy. Do not
+build authorization tests on top of the emulator.
+
+Policy semantics:
+
+- `getIamPolicy` on an existing resource with no policy returns an empty policy
+  with the well-known etag `ACAB`, matching GCP.
+- `getIamPolicy` / `setIamPolicy` against a resource that does not exist fail
+  with `NOT_FOUND`.
+- The etag rotates on every write. A `setIamPolicy` carrying a stale etag fails
+  with `ABORTED` (HTTP 409), so read-modify-write flows such as Terraform's
+  `google_pubsub_topic_iam_member` behave as they do against real GCP. Omitting
+  the etag performs a blind write.
+- Deleting a resource deletes its policy; recreating the same name starts empty.
+- `testIamPermissions` echoes the requested permissions without consulting
+  stored bindings, and performs no existence check (the real API fails open for
+  missing resources).
+- Schemas are not implemented, so schema IAM paths are not served.
+
+Over gRPC these methods are served by the standalone `google.iam.v1.IAMPolicy`
+service (Pub/Sub declares IAM as a service-config mixin), which the Pub/Sub
+SDKs call transparently via `TopicAdminClient` / `SubscriptionAdminClient`.
+
+```java
+// Grant a worker publish access to a topic, then read it back
+TopicName topic = TopicName.of("floci-local", "my-topic");
+Policy policy = topicAdminClient.getIamPolicy(GetIamPolicyRequest.newBuilder()
+    .setResource(topic.toString()).build());
+Policy updated = topicAdminClient.setIamPolicy(SetIamPolicyRequest.newBuilder()
+    .setResource(topic.toString())
+    .setPolicy(policy.toBuilder()
+        .addBindings(Binding.newBuilder()
+            .setRole("roles/pubsub.publisher")
+            .addMembers("serviceAccount:worker@floci-local.iam.gserviceaccount.com"))
+        .build())
+    .build());
+```
+
 ## Supported Operations
 
 **Publisher:**
@@ -290,3 +345,9 @@ subscriptionAdminClient.seek(SeekRequest.newBuilder()
 - `UpdateSnapshot`
 - `DeleteSnapshot`
 - `Seek`
+
+**IAM (`google.iam.v1.IAMPolicy` mixin — stored, never enforced):**
+
+- `GetIamPolicy`
+- `SetIamPolicy`
+- `TestIamPermissions` (echoes requested permissions)

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
             <version>1.152.0</version>
         </dependency>
 
+        <!-- google.iam.v1.IAMPolicy gRPC stub (IAMPolicyGrpc ImplBase) -->
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>grpc-google-iam-v1</artifactId>
+        </dependency>
+
         <!-- Secret Manager gRPC stubs (SecretManagerServiceGrpc ImplBase) -->
         <dependency>
             <groupId>com.google.api.grpc</groupId>

--- a/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
@@ -41,6 +41,7 @@ public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
             case "OUT_OF_RANGE" -> "outOfRange";
             case "FAILED_PRECONDITION" -> "failedPrecondition";
             case "CONDITION_NOT_MET" -> "conditionNotMet";
+            case "ABORTED" -> "aborted";
             case "PERMISSION_DENIED" -> "forbidden";
 			case "UNAUTHENTICATED" -> "authError";
             case "RESOURCE_EXHAUSTED" -> "rateLimitExceeded";

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunController.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunController.java
@@ -106,7 +106,8 @@ public class CloudRunController {
                                        @PathParam("serviceId") String serviceId,
                                        String body) {
         TestIamPermissionsRequest request = ProtoJson.merge(body, TestIamPermissionsRequest.newBuilder()).build();
-        return json(ProtoJson.print(service.testIamPermissions(request.getPermissionsList())));
+        return json(ProtoJson.print(service.testIamPermissions(
+                serviceName(project, location, serviceId), request.getPermissionsList())));
     }
 
     @GET

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -570,6 +570,7 @@ public class CloudRunService {
         revisionStore.keys().stream()
                 .filter(k -> k.startsWith(revisionPrefix))
                 .forEach(revisionStore::delete);
+        iamService.deletePolicy(name);
     }
 
     private static Condition readyCondition(Timestamp now) {

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -565,12 +565,13 @@ public class CloudRunService {
     }
 
     private void deleteMetadata(String name) {
-        serviceStore.delete(name);
-        String revisionPrefix = name + "/revisions/";
-        revisionStore.keys().stream()
-                .filter(k -> k.startsWith(revisionPrefix))
-                .forEach(revisionStore::delete);
-        iamService.deletePolicy(name);
+        iamService.deleteResourceAndPolicy(name, () -> {
+            serviceStore.delete(name);
+            String revisionPrefix = name + "/revisions/";
+            revisionStore.keys().stream()
+                    .filter(k -> k.startsWith(revisionPrefix))
+                    .forEach(revisionStore::delete);
+        });
     }
 
     private static Condition readyCondition(Timestamp now) {

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -8,15 +8,12 @@ import com.google.cloud.run.v2.Revision;
 import com.google.cloud.run.v2.TrafficTarget;
 import com.google.cloud.run.v2.TrafficTargetAllocationType;
 import com.google.cloud.run.v2.TrafficTargetStatus;
-import com.google.iam.v1.Binding;
 import com.google.iam.v1.Policy;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import com.google.longrunning.Operation;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
-import com.google.type.Expr;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.GcpResourceNames;
@@ -28,6 +25,7 @@ import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.services.cloudrun.model.CloudRunRuntimeInstance;
+import io.floci.gcp.services.iam.IamPolicyCodec;
 import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.iam.model.StoredPolicy;
 import io.floci.gcp.services.operations.LongRunningOperationsService;
@@ -42,7 +40,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -369,11 +366,11 @@ public class CloudRunService {
     }
 
     public Policy getIamPolicy(String resource) {
-        return toProtoPolicy(iamService.getPolicy(resource));
+        return IamPolicyCodec.toProtoPolicy(iamService.getPolicy(resource));
     }
 
     public Policy setIamPolicy(String resource, Policy policy) {
-        return toProtoPolicy(iamService.setPolicy(resource, toStoredPolicy(policy)));
+        return IamPolicyCodec.toProtoPolicy(iamService.setPolicy(resource, IamPolicyCodec.toStoredPolicy(policy)));
     }
 
     public TestIamPermissionsResponse testIamPermissions(List<String> permissions) {
@@ -641,70 +638,6 @@ public class CloudRunService {
         return transientOnly
                 ? operations.doneTransient(parent, response, metadata)
                 : operations.done(parent, response, metadata);
-    }
-
-    private static StoredPolicy toStoredPolicy(Policy policy) {
-        StoredPolicy stored = new StoredPolicy();
-        stored.setVersion(policy.getVersion());
-        if (!policy.getEtag().isEmpty()) {
-            stored.setEtag(policy.getEtag().toStringUtf8());
-        }
-        stored.setBindings(policy.getBindingsList().stream()
-                .map(CloudRunService::bindingToMap)
-                .toList());
-        return stored;
-    }
-
-    private static Policy toProtoPolicy(StoredPolicy stored) {
-        Policy.Builder builder = Policy.newBuilder()
-                .setVersion(stored.getVersion());
-        if (stored.getEtag() != null) {
-            builder.setEtag(ByteString.copyFromUtf8(stored.getEtag()));
-        }
-        if (stored.getBindings() != null) {
-            for (Map<String, Object> binding : stored.getBindings()) {
-                builder.addBindings(mapToBinding(binding));
-            }
-        }
-        return builder.build();
-    }
-
-    private static Map<String, Object> bindingToMap(Binding binding) {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("role", binding.getRole());
-        map.put("members", List.copyOf(binding.getMembersList()));
-        if (binding.hasCondition()) {
-            Map<String, Object> condition = new LinkedHashMap<>();
-            condition.put("expression", binding.getCondition().getExpression());
-            condition.put("title", binding.getCondition().getTitle());
-            condition.put("description", binding.getCondition().getDescription());
-            condition.put("location", binding.getCondition().getLocation());
-            map.put("condition", condition);
-        }
-        return map;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Binding mapToBinding(Map<String, Object> map) {
-        Binding.Builder builder = Binding.newBuilder()
-                .setRole((String) map.getOrDefault("role", ""));
-        Object members = map.get("members");
-        if (members instanceof List<?> list) {
-            for (Object member : list) {
-                builder.addMembers(String.valueOf(member));
-            }
-        }
-        Object condition = map.get("condition");
-        if (condition instanceof Map<?, ?> raw) {
-            Map<String, Object> c = (Map<String, Object>) raw;
-            builder.setCondition(Expr.newBuilder()
-                    .setExpression((String) c.getOrDefault("expression", ""))
-                    .setTitle((String) c.getOrDefault("title", ""))
-                    .setDescription((String) c.getOrDefault("description", ""))
-                    .setLocation((String) c.getOrDefault("location", ""))
-                    .build());
-        }
-        return builder.build();
     }
 
     private static String firstPresent(String first, String second) {

--- a/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
+++ b/src/main/java/io/floci/gcp/services/cloudrun/CloudRunService.java
@@ -373,9 +373,9 @@ public class CloudRunService {
         return IamPolicyCodec.toProtoPolicy(iamService.setPolicy(resource, IamPolicyCodec.toStoredPolicy(policy)));
     }
 
-    public TestIamPermissionsResponse testIamPermissions(List<String> permissions) {
+    public TestIamPermissionsResponse testIamPermissions(String resource, List<String> permissions) {
         return TestIamPermissionsResponse.newBuilder()
-                .addAllPermissions(iamService.testPermissions(permissions))
+                .addAllPermissions(iamService.testPermissions(resource, permissions))
                 .build();
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
@@ -182,7 +182,7 @@ public class GcsBucketController {
         service.getBucket(bucket);
         @SuppressWarnings("unchecked")
         List<String> requested = body != null ? (List<String>) body.get("permissions") : List.of();
-        List<String> granted = iamService.testPermissions(requested != null ? requested : List.of());
+        List<String> granted = iamService.testPermissions("buckets/" + bucket, requested != null ? requested : List.of());
         return Response.ok(Map.of("permissions", granted)).build();
     }
 

--- a/src/main/java/io/floci/gcp/services/iam/IamController.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamController.java
@@ -169,7 +169,7 @@ public class IamController {
             }
             case "setIamPolicy" -> {
                 Map<String, Object> policyMap = body != null ? (Map<String, Object>) body.get("policy") : null;
-                StoredPolicy policy = parsePolicy(policyMap);
+                StoredPolicy policy = IamPolicyCodec.fromJsonMap(policyMap);
                 yield Response.ok(service.setPolicy(resource, policy)).build();
             }
             case "testIamPermissions" -> {
@@ -205,24 +205,6 @@ public class IamController {
         String description = (String) saProps.get("description");
         StoredServiceAccount sa = service.createServiceAccount(project, accountId, displayName, description);
         return Response.ok(sa).build();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static StoredPolicy parsePolicy(Map<String, Object> policyMap) {
-        StoredPolicy policy = new StoredPolicy();
-        if (policyMap == null) {
-            return policy;
-        }
-        if (policyMap.containsKey("version")) {
-            policy.setVersion(((Number) policyMap.get("version")).intValue());
-        }
-        if (policyMap.containsKey("bindings")) {
-            policy.setBindings((List<Map<String, Object>>) policyMap.get("bindings"));
-        }
-        if (policyMap.containsKey("etag")) {
-            policy.setEtag((String) policyMap.get("etag"));
-        }
-        return policy;
     }
 
     // ── Path parsing ───────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/iam/IamController.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamController.java
@@ -174,7 +174,7 @@ public class IamController {
             }
             case "testIamPermissions" -> {
                 List<String> requested = body != null ? (List<String>) body.get("permissions") : List.of();
-                List<String> granted = service.testPermissions(requested != null ? requested : List.of());
+                List<String> granted = service.testPermissions(resource, requested != null ? requested : List.of());
                 yield Response.ok(Map.of("permissions", granted)).build();
             }
             case "signBlob" -> {

--- a/src/main/java/io/floci/gcp/services/iam/IamPolicyCodec.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamPolicyCodec.java
@@ -19,6 +19,24 @@ public final class IamPolicyCodec {
 
     private IamPolicyCodec() {}
 
+    @SuppressWarnings("unchecked")
+    public static StoredPolicy fromJsonMap(Map<String, Object> policyMap) {
+        StoredPolicy policy = new StoredPolicy();
+        if (policyMap == null) {
+            return policy;
+        }
+        if (policyMap.containsKey("version")) {
+            policy.setVersion(((Number) policyMap.get("version")).intValue());
+        }
+        if (policyMap.containsKey("bindings")) {
+            policy.setBindings((List<Map<String, Object>>) policyMap.get("bindings"));
+        }
+        if (policyMap.containsKey("etag")) {
+            policy.setEtag((String) policyMap.get("etag"));
+        }
+        return policy;
+    }
+
     public static StoredPolicy toStoredPolicy(Policy policy) {
         StoredPolicy stored = new StoredPolicy();
         stored.setVersion(policy.getVersion());

--- a/src/main/java/io/floci/gcp/services/iam/IamPolicyCodec.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamPolicyCodec.java
@@ -1,0 +1,85 @@
+package io.floci.gcp.services.iam;
+
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
+import com.google.protobuf.ByteString;
+import com.google.type.Expr;
+import io.floci.gcp.services.iam.model.StoredPolicy;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts between {@code google.iam.v1.Policy} protos and {@link StoredPolicy}.
+ * Bindings round-trip losslessly, including {@code condition} blocks — the
+ * emulator stores and returns conditions but never evaluates them.
+ */
+public final class IamPolicyCodec {
+
+    private IamPolicyCodec() {}
+
+    public static StoredPolicy toStoredPolicy(Policy policy) {
+        StoredPolicy stored = new StoredPolicy();
+        stored.setVersion(policy.getVersion());
+        if (!policy.getEtag().isEmpty()) {
+            stored.setEtag(policy.getEtag().toStringUtf8());
+        }
+        stored.setBindings(policy.getBindingsList().stream()
+                .map(IamPolicyCodec::bindingToMap)
+                .toList());
+        return stored;
+    }
+
+    public static Policy toProtoPolicy(StoredPolicy stored) {
+        Policy.Builder builder = Policy.newBuilder()
+                .setVersion(stored.getVersion());
+        if (stored.getEtag() != null) {
+            builder.setEtag(ByteString.copyFromUtf8(stored.getEtag()));
+        }
+        if (stored.getBindings() != null) {
+            for (Map<String, Object> binding : stored.getBindings()) {
+                builder.addBindings(mapToBinding(binding));
+            }
+        }
+        return builder.build();
+    }
+
+    private static Map<String, Object> bindingToMap(Binding binding) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("role", binding.getRole());
+        map.put("members", List.copyOf(binding.getMembersList()));
+        if (binding.hasCondition()) {
+            Map<String, Object> condition = new LinkedHashMap<>();
+            condition.put("expression", binding.getCondition().getExpression());
+            condition.put("title", binding.getCondition().getTitle());
+            condition.put("description", binding.getCondition().getDescription());
+            condition.put("location", binding.getCondition().getLocation());
+            map.put("condition", condition);
+        }
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Binding mapToBinding(Map<String, Object> map) {
+        Binding.Builder builder = Binding.newBuilder()
+                .setRole((String) map.getOrDefault("role", ""));
+        Object members = map.get("members");
+        if (members instanceof List<?> list) {
+            for (Object member : list) {
+                builder.addMembers(String.valueOf(member));
+            }
+        }
+        Object condition = map.get("condition");
+        if (condition instanceof Map<?, ?> raw) {
+            Map<String, Object> c = (Map<String, Object>) raw;
+            builder.setCondition(Expr.newBuilder()
+                    .setExpression((String) c.getOrDefault("expression", ""))
+                    .setTitle((String) c.getOrDefault("title", ""))
+                    .setDescription((String) c.getOrDefault("description", ""))
+                    .setLocation((String) c.getOrDefault("location", ""))
+                    .build());
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/iam/IamPolicyGrpcController.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamPolicyGrpcController.java
@@ -17,8 +17,8 @@ import org.jboss.logging.Logger;
  * such service on the single emulator port.
  *
  * <p>Policies are stored and returned, never enforced. {@code testIamPermissions}
- * echoes the requested permissions and performs no existence check, matching the
- * real API's fail-open behavior for missing resources.
+ * echoes the requested permissions for existing resources and returns an empty
+ * set for missing ones, matching the real API's fail-open behavior.
  */
 public class IamPolicyGrpcController extends IAMPolicyGrpc.IAMPolicyImplBase {
 
@@ -63,7 +63,8 @@ public class IamPolicyGrpcController extends IAMPolicyGrpc.IAMPolicyImplBase {
         LOG.debugf("testIamPermissions resource=%s", request.getResource());
         try {
             responseObserver.onNext(TestIamPermissionsResponse.newBuilder()
-                    .addAllPermissions(iamService.testPermissions(request.getPermissionsList()))
+                    .addAllPermissions(iamService.testPermissions(
+                            request.getResource(), request.getPermissionsList()))
                     .build());
             responseObserver.onCompleted();
         } catch (Exception e) {

--- a/src/main/java/io/floci/gcp/services/iam/IamPolicyGrpcController.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamPolicyGrpcController.java
@@ -1,0 +1,74 @@
+package io.floci.gcp.services.iam;
+
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.IAMPolicyGrpc;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import io.floci.gcp.core.common.GcpGrpcController;
+import io.grpc.stub.StreamObserver;
+import org.jboss.logging.Logger;
+
+/**
+ * Shared {@code google.iam.v1.IAMPolicy} gRPC service for APIs that declare IAM
+ * as a service-config mixin instead of on their own gRPC services (e.g. Pub/Sub).
+ * Dispatches on the resource name in the request, so one binding serves every
+ * such service on the single emulator port.
+ *
+ * <p>Policies are stored and returned, never enforced. {@code testIamPermissions}
+ * echoes the requested permissions and performs no existence check, matching the
+ * real API's fail-open behavior for missing resources.
+ */
+public class IamPolicyGrpcController extends IAMPolicyGrpc.IAMPolicyImplBase {
+
+    private static final Logger LOG = Logger.getLogger(IamPolicyGrpcController.class);
+
+    private final IamService iamService;
+
+    public IamPolicyGrpcController(IamService iamService) {
+        this.iamService = iamService;
+    }
+
+    @Override
+    public void getIamPolicy(GetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
+        LOG.debugf("getIamPolicy resource=%s", request.getResource());
+        try {
+            Policy policy = IamPolicyCodec.toProtoPolicy(iamService.getPolicy(request.getResource()));
+            responseObserver.onNext(policy);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("getIamPolicy failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void setIamPolicy(SetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
+        LOG.debugf("setIamPolicy resource=%s", request.getResource());
+        try {
+            Policy policy = IamPolicyCodec.toProtoPolicy(iamService.setPolicy(
+                    request.getResource(), IamPolicyCodec.toStoredPolicy(request.getPolicy())));
+            responseObserver.onNext(policy);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("setIamPolicy failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+
+    @Override
+    public void testIamPermissions(TestIamPermissionsRequest request,
+            StreamObserver<TestIamPermissionsResponse> responseObserver) {
+        LOG.debugf("testIamPermissions resource=%s", request.getResource());
+        try {
+            responseObserver.onNext(TestIamPermissionsResponse.newBuilder()
+                    .addAllPermissions(iamService.testPermissions(request.getPermissionsList()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("testIamPermissions failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
+    }
+}

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -219,7 +219,21 @@ public class IamService {
         }
     }
 
-    public List<String> testPermissions(List<String> permissions) {
+    /**
+     * Echoes the requested permissions for an existing resource. For a resource
+     * a registered resolver reports missing, fails open with an empty set — the
+     * real API returns "an empty set of permissions, not a NOT_FOUND error"
+     * (pubsub_v1.yaml). Stored bindings are never consulted.
+     */
+    public List<String> testPermissions(String resource, List<String> permissions) {
+        try {
+            requireResourceExists(resource);
+        } catch (GcpException e) {
+            if (e.getHttpStatus() == 404) {
+                return List.of();
+            }
+            throw e;
+        }
         return permissions;
     }
 

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -170,18 +170,24 @@ public class IamService {
 
     public StoredPolicy setPolicy(String resource, StoredPolicy policy) {
         requireResourceExists(resource);
-        String currentEtag = policyStore.get(policyKey(resource))
-                .map(StoredPolicy::getEtag)
-                .orElse(EMPTY_POLICY_ETAG);
-        String requestEtag = policy.getEtag();
-        if (requestEtag != null && !requestEtag.isEmpty() && !requestEtag.equals(currentEtag)) {
-            throw GcpException.aborted(
-                    "There were concurrent policy changes. Please retry the whole read-modify-write with exponential backoff. "
-                            + "The request's ETag '" + requestEtag + "' did not match the current policy's ETag '" + currentEtag + "'.");
+        String key = policyKey(resource);
+        // Serializes the etag read-compare-write per resource so two concurrent
+        // setPolicy calls can't both pass the etag check against the same
+        // currentEtag and silently clobber one another.
+        synchronized (policyLock(key)) {
+            String currentEtag = policyStore.get(key)
+                    .map(StoredPolicy::getEtag)
+                    .orElse(EMPTY_POLICY_ETAG);
+            String requestEtag = policy.getEtag();
+            if (requestEtag != null && !requestEtag.isEmpty() && !requestEtag.equals(currentEtag)) {
+                throw GcpException.aborted(
+                        "There were concurrent policy changes. Please retry the whole read-modify-write with exponential backoff. "
+                                + "The request's ETag '" + requestEtag + "' did not match the current policy's ETag '" + currentEtag + "'.");
+            }
+            policy.setEtag(newEtag());
+            policyStore.put(key, policy);
+            return policy;
         }
-        policy.setEtag(newEtag());
-        policyStore.put(policyKey(resource), policy);
-        return policy;
     }
 
     public void deletePolicy(String resource) {
@@ -213,6 +219,21 @@ public class IamService {
             }
         }
         return true;
+    }
+
+    private static final int POLICY_LOCK_COUNT = 64;
+    private static final Object[] POLICY_LOCKS = createPolicyLocks();
+
+    private static Object[] createPolicyLocks() {
+        Object[] locks = new Object[POLICY_LOCK_COUNT];
+        for (int i = 0; i < locks.length; i++) {
+            locks[i] = new Object();
+        }
+        return locks;
+    }
+
+    private static Object policyLock(String key) {
+        return POLICY_LOCKS[Math.floorMod(key.hashCode(), POLICY_LOCKS.length)];
     }
 
     private static StoredPolicy emptyPolicy() {

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -164,8 +164,11 @@ public class IamService {
     }
 
     public StoredPolicy getPolicy(String resource) {
-        requireResourceExists(resource);
-        return policyStore.get(policyKey(resource)).orElseGet(IamService::emptyPolicy);
+        String key = policyKey(resource);
+        synchronized (policyLock(key)) {
+            requireResourceExists(resource);
+            return policyStore.get(key).orElseGet(IamService::emptyPolicy);
+        }
     }
 
     public StoredPolicy setPolicy(String resource, StoredPolicy policy) {
@@ -195,6 +198,23 @@ public class IamService {
     public void deletePolicy(String resource) {
         String key = policyKey(resource);
         synchronized (policyLock(key)) {
+            policyStore.delete(key);
+        }
+    }
+
+    /**
+     * Runs {@code deleteResource} and removes the resource's policy under the
+     * same lock that guards policy reads and writes. Owning services call this
+     * from their delete paths so no policy operation can interleave between
+     * resource removal and policy cleanup — a write landing in that gap (e.g.
+     * on a just-recreated name) would otherwise be silently erased by the
+     * trailing cleanup, and a read could see the previous name-holder's
+     * bindings.
+     */
+    public void deleteResourceAndPolicy(String resource, Runnable deleteResource) {
+        String key = policyKey(resource);
+        synchronized (policyLock(key)) {
+            deleteResource.run();
             policyStore.delete(key);
         }
     }

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -169,12 +169,14 @@ public class IamService {
     }
 
     public StoredPolicy setPolicy(String resource, StoredPolicy policy) {
-        requireResourceExists(resource);
         String key = policyKey(resource);
-        // Serializes the etag read-compare-write per resource so two concurrent
-        // setPolicy calls can't both pass the etag check against the same
-        // currentEtag and silently clobber one another.
+        // Serializes existence check + etag read-compare-write per resource, both
+        // against concurrent setPolicy (two writers passing the etag check on the
+        // same currentEtag would silently clobber one another) and against
+        // deletePolicy (a write slipping in after resource deletion would
+        // resurrect the policy when the same name is recreated).
         synchronized (policyLock(key)) {
+            requireResourceExists(resource);
             String currentEtag = policyStore.get(key)
                     .map(StoredPolicy::getEtag)
                     .orElse(EMPTY_POLICY_ETAG);
@@ -191,7 +193,10 @@ public class IamService {
     }
 
     public void deletePolicy(String resource) {
-        policyStore.delete(policyKey(resource));
+        String key = policyKey(resource);
+        synchronized (policyLock(key)) {
+            policyStore.delete(key);
+        }
     }
 
     public List<String> testPermissions(List<String> permissions) {

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -31,7 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 @ApplicationScoped
 public class IamService {
@@ -44,6 +47,7 @@ public class IamService {
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
     private final AtomicLong uniqueIdSeq = new AtomicLong(100000000000000000L);
+    private final Map<String, Consumer<String>> policyResolvers = new ConcurrentHashMap<>();
 
     @Inject
     public IamService(ServiceRegistry serviceRegistry, EmulatorConfig config, StorageFactory storageFactory) {
@@ -137,17 +141,82 @@ public class IamService {
 
     // ── IAM Policies ───────────────────────────────────────────────────────────
 
+    // GCP returns this fixed etag for a policy that has never been set.
+    static final String EMPTY_POLICY_ETAG = "ACAB";
+
+    /**
+     * Registers an existence check for policy resources matching {@code pattern},
+     * a slash-segmented template where {@code *} matches exactly one segment.
+     * The resolver throws {@link GcpException} not-found for missing resources.
+     * Resources matching no pattern skip the check, preserving permissive
+     * behavior for services that have not opted in.
+     */
+    public void registerPolicyResourceResolver(String pattern, Consumer<String> requireExists) {
+        policyResolvers.put(pattern, requireExists);
+    }
+
     public StoredPolicy getPolicy(String resource) {
-        return policyStore.get(policyKey(resource)).orElse(new StoredPolicy());
+        requireResourceExists(resource);
+        return policyStore.get(policyKey(resource)).orElseGet(IamService::emptyPolicy);
     }
 
     public StoredPolicy setPolicy(String resource, StoredPolicy policy) {
+        requireResourceExists(resource);
+        String currentEtag = policyStore.get(policyKey(resource))
+                .map(StoredPolicy::getEtag)
+                .orElse(EMPTY_POLICY_ETAG);
+        String requestEtag = policy.getEtag();
+        if (requestEtag != null && !requestEtag.isEmpty() && !requestEtag.equals(currentEtag)) {
+            throw GcpException.aborted(
+                    "There were concurrent policy changes. Please retry the whole read-modify-write with exponential backoff. "
+                            + "The request's ETag '" + requestEtag + "' did not match the current policy's ETag '" + currentEtag + "'.");
+        }
+        policy.setEtag(newEtag());
         policyStore.put(policyKey(resource), policy);
         return policy;
     }
 
+    public void deletePolicy(String resource) {
+        policyStore.delete(policyKey(resource));
+    }
+
     public List<String> testPermissions(List<String> permissions) {
         return permissions;
+    }
+
+    private void requireResourceExists(String resource) {
+        for (Map.Entry<String, Consumer<String>> entry : policyResolvers.entrySet()) {
+            if (matchesPattern(entry.getKey(), resource)) {
+                entry.getValue().accept(resource);
+                return;
+            }
+        }
+    }
+
+    private static boolean matchesPattern(String pattern, String resource) {
+        String[] p = pattern.split("/");
+        String[] r = resource.split("/");
+        if (p.length != r.length) {
+            return false;
+        }
+        for (int i = 0; i < p.length; i++) {
+            if (!p[i].equals("*") && !p[i].equals(r[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static StoredPolicy emptyPolicy() {
+        StoredPolicy policy = new StoredPolicy();
+        policy.setEtag(EMPTY_POLICY_ETAG);
+        return policy;
+    }
+
+    private static String newEtag() {
+        byte[] bytes = new byte[8];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     // ── Service Account Keys ───────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -9,6 +9,7 @@ import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.lifecycle.GrpcServerManager;
 import io.floci.gcp.services.iam.model.StoredPolicy;
 import io.floci.gcp.services.iam.model.StoredServiceAccount;
 import io.floci.gcp.services.iam.model.StoredServiceAccountKey;
@@ -46,13 +47,16 @@ public class IamService {
     private final StorageBackend<String, StoredPolicy> policyStore;
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
+    private final GrpcServerManager grpcServerManager;
     private final AtomicLong uniqueIdSeq = new AtomicLong(100000000000000000L);
     private final Map<String, Consumer<String>> policyResolvers = new ConcurrentHashMap<>();
 
     @Inject
-    public IamService(ServiceRegistry serviceRegistry, EmulatorConfig config, StorageFactory storageFactory) {
+    public IamService(ServiceRegistry serviceRegistry, EmulatorConfig config, StorageFactory storageFactory,
+            GrpcServerManager grpcServerManager) {
         this.serviceRegistry = serviceRegistry;
         this.config = config;
+        this.grpcServerManager = grpcServerManager;
         this.saStore = storageFactory.createGlobal("iam-service-accounts", "iam-service-accounts.json",
                 new TypeReference<Map<String, StoredServiceAccount>>() {});
         this.keyStore = storageFactory.createGlobal("iam-sa-keys", "iam-sa-keys.json",
@@ -69,6 +73,7 @@ public class IamService {
         this.policyStore = policyStore;
         this.serviceRegistry = null;
         this.config = null;
+        this.grpcServerManager = null;
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -78,6 +83,9 @@ public class IamService {
                 .protocol(ServiceProtocol.REST)
                 .resourceClasses(IamController.class)
                 .build());
+        // Serves the google.iam.v1.IAMPolicy mixin for all services; not gated on
+        // the iam REST toggle so Pub/Sub IAM keeps working when iam is disabled.
+        grpcServerManager.bind(new IamPolicyGrpcController(this));
     }
 
     // ── Service Accounts ───────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/iam/model/StoredPolicy.java
+++ b/src/main/java/io/floci/gcp/services/iam/model/StoredPolicy.java
@@ -11,7 +11,9 @@ public class StoredPolicy {
 
     private int version = 1;
     private List<Map<String, Object>> bindings = new ArrayList<>();
-    private String etag = "ACAB";
+    // Empty means "no etag provided"; IamService assigns one on write. Reads of an
+    // unset policy surface GCP's well-known empty-policy etag "ACAB" instead.
+    private String etag = "";
 
     public StoredPolicy() {}
 

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
@@ -4,6 +4,8 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.ReceivedMessage;
 import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.services.iam.IamPolicyCodec;
+import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.pubsub.model.StoredSubscription;
 import io.floci.gcp.services.pubsub.model.StoredTopic;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -38,14 +40,17 @@ public class PubSubRestController {
     private static final Logger LOG = Logger.getLogger(PubSubRestController.class);
 
     private final PubSubService service;
+    private final IamService iamService;
 
     PubSubRestController() {
         this.service = null;
+        this.iamService = null;
     }
 
     @Inject
-    public PubSubRestController(PubSubService service) {
+    public PubSubRestController(PubSubService service, IamService iamService) {
         this.service = service;
+        this.iamService = iamService;
     }
 
     @PUT
@@ -226,8 +231,99 @@ public class PubSubRestController {
         return Response.ok(Map.of()).build();
     }
 
+    // ── IAM policies (google.iam.v1.IAMPolicy mixin) ───────────────────────────
+    // More-literal templates win over /topics/{topic} etc. during JAX-RS sorting,
+    // the same mechanism the :publish and :pull routes rely on.
+
+    @GET
+    @Path("/topics/{topic}:getIamPolicy")
+    public Response getTopicIamPolicy(@PathParam("project") String project,
+                                      @PathParam("topic") String topicId) {
+        return Response.ok(iamService.getPolicy(topicName(project, topicId))).build();
+    }
+
+    @POST
+    @Path("/topics/{topic}:setIamPolicy")
+    public Response setTopicIamPolicy(@PathParam("project") String project,
+                                      @PathParam("topic") String topicId,
+                                      Map<String, Object> body) {
+        return setIamPolicy(topicName(project, topicId), body);
+    }
+
+    @POST
+    @Path("/topics/{topic}:testIamPermissions")
+    public Response testTopicIamPermissions(@PathParam("project") String project,
+                                            @PathParam("topic") String topicId,
+                                            Map<String, Object> body) {
+        return testIamPermissions(body);
+    }
+
+    @GET
+    @Path("/subscriptions/{subscription}:getIamPolicy")
+    public Response getSubscriptionIamPolicy(@PathParam("project") String project,
+                                             @PathParam("subscription") String subscriptionId) {
+        return Response.ok(iamService.getPolicy(subscriptionName(project, subscriptionId))).build();
+    }
+
+    @POST
+    @Path("/subscriptions/{subscription}:setIamPolicy")
+    public Response setSubscriptionIamPolicy(@PathParam("project") String project,
+                                             @PathParam("subscription") String subscriptionId,
+                                             Map<String, Object> body) {
+        return setIamPolicy(subscriptionName(project, subscriptionId), body);
+    }
+
+    @POST
+    @Path("/subscriptions/{subscription}:testIamPermissions")
+    public Response testSubscriptionIamPermissions(@PathParam("project") String project,
+                                                   @PathParam("subscription") String subscriptionId,
+                                                   Map<String, Object> body) {
+        return testIamPermissions(body);
+    }
+
+    @GET
+    @Path("/snapshots/{snapshot}:getIamPolicy")
+    public Response getSnapshotIamPolicy(@PathParam("project") String project,
+                                         @PathParam("snapshot") String snapshotId) {
+        return Response.ok(iamService.getPolicy(snapshotName(project, snapshotId))).build();
+    }
+
+    @POST
+    @Path("/snapshots/{snapshot}:setIamPolicy")
+    public Response setSnapshotIamPolicy(@PathParam("project") String project,
+                                         @PathParam("snapshot") String snapshotId,
+                                         Map<String, Object> body) {
+        return setIamPolicy(snapshotName(project, snapshotId), body);
+    }
+
+    @POST
+    @Path("/snapshots/{snapshot}:testIamPermissions")
+    public Response testSnapshotIamPermissions(@PathParam("project") String project,
+                                               @PathParam("snapshot") String snapshotId,
+                                               Map<String, Object> body) {
+        return testIamPermissions(body);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Response setIamPolicy(String resource, Map<String, Object> body) {
+        LOG.infof("REST setIamPolicy resource=%s", resource);
+        Map<String, Object> policyMap = body != null ? (Map<String, Object>) body.get("policy") : null;
+        return Response.ok(iamService.setPolicy(resource, IamPolicyCodec.fromJsonMap(policyMap))).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Response testIamPermissions(Map<String, Object> body) {
+        List<String> requested = body != null ? (List<String>) body.get("permissions") : List.of();
+        List<String> granted = iamService.testPermissions(requested != null ? requested : List.of());
+        return Response.ok(Map.of("permissions", granted)).build();
+    }
+
     private static String topicName(String project, String topicId) {
         return "projects/" + project + "/topics/" + topicId;
+    }
+
+    private static String snapshotName(String project, String snapshotId) {
+        return "projects/" + project + "/snapshots/" + snapshotId;
     }
 
     private static String subscriptionName(String project, String subscriptionId) {

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubRestController.java
@@ -255,7 +255,7 @@ public class PubSubRestController {
     public Response testTopicIamPermissions(@PathParam("project") String project,
                                             @PathParam("topic") String topicId,
                                             Map<String, Object> body) {
-        return testIamPermissions(body);
+        return testIamPermissions(topicName(project, topicId), body);
     }
 
     @GET
@@ -278,7 +278,7 @@ public class PubSubRestController {
     public Response testSubscriptionIamPermissions(@PathParam("project") String project,
                                                    @PathParam("subscription") String subscriptionId,
                                                    Map<String, Object> body) {
-        return testIamPermissions(body);
+        return testIamPermissions(subscriptionName(project, subscriptionId), body);
     }
 
     @GET
@@ -301,7 +301,7 @@ public class PubSubRestController {
     public Response testSnapshotIamPermissions(@PathParam("project") String project,
                                                @PathParam("snapshot") String snapshotId,
                                                Map<String, Object> body) {
-        return testIamPermissions(body);
+        return testIamPermissions(snapshotName(project, snapshotId), body);
     }
 
     @SuppressWarnings("unchecked")
@@ -312,9 +312,9 @@ public class PubSubRestController {
     }
 
     @SuppressWarnings("unchecked")
-    private Response testIamPermissions(Map<String, Object> body) {
+    private Response testIamPermissions(String resource, Map<String, Object> body) {
         List<String> requested = body != null ? (List<String>) body.get("permissions") : List.of();
-        List<String> granted = iamService.testPermissions(requested != null ? requested : List.of());
+        List<String> granted = iamService.testPermissions(resource, requested != null ? requested : List.of());
         return Response.ok(Map.of("permissions", granted)).build();
     }
 

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -13,6 +13,7 @@ import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.lifecycle.GrpcServerManager;
+import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.pubsub.model.StoredMessage;
 import io.floci.gcp.services.pubsub.model.StoredSnapshot;
 import io.floci.gcp.services.pubsub.model.StoredSubscription;
@@ -56,16 +57,18 @@ public class PubSubService {
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
     private final GrpcServerManager grpcServerManager;
+    private final IamService iamService;
 
     @Inject
     jakarta.enterprise.inject.Instance<io.floci.gcp.services.eventarc.EventarcService> eventarcServiceInstance;
 
     @Inject
     public PubSubService(ServiceRegistry serviceRegistry, EmulatorConfig config,
-            StorageFactory storageFactory, GrpcServerManager grpcServerManager) {
+            StorageFactory storageFactory, GrpcServerManager grpcServerManager, IamService iamService) {
         this.serviceRegistry = serviceRegistry;
         this.config = config;
         this.grpcServerManager = grpcServerManager;
+        this.iamService = iamService;
         this.topicStore = storageFactory.createGlobal("pubsub-topics", "pubsub-topics.json",
                 new TypeReference<Map<String, StoredTopic>>() {});
         this.subStore = storageFactory.createGlobal("pubsub-subs", "pubsub-subs.json",
@@ -76,13 +79,16 @@ public class PubSubService {
 
     PubSubService(StorageBackend<String, StoredTopic> topicStore,
             StorageBackend<String, StoredSubscription> subStore,
-            StorageBackend<String, StoredSnapshot> snapshotStore) {
+            StorageBackend<String, StoredSnapshot> snapshotStore,
+            IamService iamService) {
         this.topicStore = topicStore;
         this.subStore = subStore;
         this.snapshotStore = snapshotStore;
+        this.iamService = iamService;
         this.serviceRegistry = null;
         this.config = null;
         this.grpcServerManager = null;
+        registerPolicyResolvers();
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -95,6 +101,13 @@ public class PubSubService {
                 .build());
         grpcServerManager.bind(new PubSubPublisherController(this));
         grpcServerManager.bind(new PubSubSubscriberController(this));
+        registerPolicyResolvers();
+    }
+
+    private void registerPolicyResolvers() {
+        iamService.registerPolicyResourceResolver("projects/*/topics/*", this::getTopic);
+        iamService.registerPolicyResourceResolver("projects/*/subscriptions/*", this::getSubscription);
+        iamService.registerPolicyResourceResolver("projects/*/snapshots/*", this::getSnapshot);
     }
 
     // ── Topics ─────────────────────────────────────────────────────────────────
@@ -172,6 +185,7 @@ public class PubSubService {
             throw GcpException.notFound("Topic not found: " + name);
         }
         topicStore.delete(name);
+        iamService.deletePolicy(name);
     }
 
     // ── Subscriptions ──────────────────────────────────────────────────────────
@@ -371,6 +385,7 @@ public class PubSubService {
         queues.remove(name);
         delivered.remove(name);
         listeners.remove(name);
+        iamService.deletePolicy(name);
     }
 
     public void detachSubscription(String name) {
@@ -609,6 +624,7 @@ public class PubSubService {
         snapshotStore.get(snapshotName)
                 .orElseThrow(() -> GcpException.notFound("Snapshot not found: " + snapshotName));
         snapshotStore.delete(snapshotName);
+        iamService.deletePolicy(snapshotName);
     }
 
     public void seek(String subscriptionName, String snapshotName) {

--- a/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
+++ b/src/main/java/io/floci/gcp/services/pubsub/PubSubService.java
@@ -184,8 +184,7 @@ public class PubSubService {
             LOG.warnf("deleteTopic failed: topic not found name=%s", name);
             throw GcpException.notFound("Topic not found: " + name);
         }
-        topicStore.delete(name);
-        iamService.deletePolicy(name);
+        iamService.deleteResourceAndPolicy(name, () -> topicStore.delete(name));
     }
 
     // ── Subscriptions ──────────────────────────────────────────────────────────
@@ -381,11 +380,10 @@ public class PubSubService {
             LOG.warnf("deleteSubscription failed: subscription not found name=%s", name);
             throw GcpException.notFound("Subscription not found: " + name);
         }
-        subStore.delete(name);
+        iamService.deleteResourceAndPolicy(name, () -> subStore.delete(name));
         queues.remove(name);
         delivered.remove(name);
         listeners.remove(name);
-        iamService.deletePolicy(name);
     }
 
     public void detachSubscription(String name) {
@@ -623,8 +621,7 @@ public class PubSubService {
         LOG.infof("deleteSnapshot name=%s", snapshotName);
         snapshotStore.get(snapshotName)
                 .orElseThrow(() -> GcpException.notFound("Snapshot not found: " + snapshotName));
-        snapshotStore.delete(snapshotName);
-        iamService.deletePolicy(snapshotName);
+        iamService.deleteResourceAndPolicy(snapshotName, () -> snapshotStore.delete(snapshotName));
     }
 
     public void seek(String subscriptionName, String snapshotName) {

--- a/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
+++ b/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
@@ -90,5 +90,7 @@ class GcpExceptionMapperTest {
                 GcpExceptionMapper.ErrorDetail.of(403, "x", "PERMISSION_DENIED").errors().get(0).reason());
         assertEquals("backendError",
                 GcpExceptionMapper.ErrorDetail.of(503, "x", "UNAVAILABLE").errors().get(0).reason());
+        assertEquals("aborted",
+                GcpExceptionMapper.ErrorDetail.of(409, "x", "ABORTED").errors().get(0).reason());
     }
 }

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
@@ -41,6 +41,12 @@ class CloudRunServiceTest {
     @BeforeEach
     void setUp() {
         iamService = mock(IamService.class);
+        // The mock must still run the resource-deletion callback or delete paths
+        // would silently stop removing services and revisions.
+        doAnswer(invocation -> {
+            invocation.getArgument(1, Runnable.class).run();
+            return null;
+        }).when(iamService).deleteResourceAndPolicy(anyString(), any(Runnable.class));
         service = new CloudRunService(new InMemoryStorage<>(), new InMemoryStorage<>(), operationsMock(), iamService);
     }
 
@@ -468,7 +474,7 @@ class CloudRunServiceTest {
         assertTrue(operation.getDone());
         assertThrows(GcpException.class, () -> service.getService(name));
         assertThrows(GcpException.class, () -> service.getRevision(revision));
-        verify(iamService).deletePolicy(name);
+        verify(iamService).deleteResourceAndPolicy(eq(name), any(Runnable.class));
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/cloudrun/CloudRunServiceTest.java
@@ -468,6 +468,7 @@ class CloudRunServiceTest {
         assertTrue(operation.getDone());
         assertThrows(GcpException.class, () -> service.getService(name));
         assertThrows(GcpException.class, () -> service.getRevision(revision));
+        verify(iamService).deletePolicy(name);
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/iam/IamPolicyCodecTest.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamPolicyCodecTest.java
@@ -1,0 +1,78 @@
+package io.floci.gcp.services.iam;
+
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
+import com.google.protobuf.ByteString;
+import com.google.type.Expr;
+import io.floci.gcp.services.iam.model.StoredPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class IamPolicyCodecTest {
+
+    @Test
+    void protoPolicyRoundTripsThroughStoredForm() {
+        Policy original = Policy.newBuilder()
+                .setVersion(3)
+                .setEtag(ByteString.copyFromUtf8("abc123"))
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/pubsub.publisher")
+                        .addMembers("serviceAccount:a@p.iam.gserviceaccount.com")
+                        .addMembers("user:b@example.com"))
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/pubsub.viewer")
+                        .addMembers("group:c@example.com"))
+                .build();
+
+        Policy roundTripped = IamPolicyCodec.toProtoPolicy(IamPolicyCodec.toStoredPolicy(original));
+
+        assertEquals(original, roundTripped);
+    }
+
+    @Test
+    void conditionBlockRoundTripsUnchanged() {
+        Policy original = Policy.newBuilder()
+                .setVersion(3)
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/pubsub.publisher")
+                        .addMembers("user:x@example.com")
+                        .setCondition(Expr.newBuilder()
+                                .setExpression("request.time < timestamp('2030-01-01T00:00:00Z')")
+                                .setTitle("expiry")
+                                .setDescription("temporary grant")
+                                .setLocation("policy.tf:12")))
+                .build();
+
+        Policy roundTripped = IamPolicyCodec.toProtoPolicy(IamPolicyCodec.toStoredPolicy(original));
+
+        assertEquals(original, roundTripped);
+    }
+
+    @Test
+    void fromJsonMapParsesRestPolicyShape() {
+        Map<String, Object> json = Map.of(
+                "version", 1,
+                "etag", "xyz",
+                "bindings", List.of(Map.of(
+                        "role", "roles/pubsub.publisher",
+                        "members", List.of("user:x@example.com"))));
+
+        StoredPolicy stored = IamPolicyCodec.fromJsonMap(json);
+
+        assertEquals(1, stored.getVersion());
+        assertEquals("xyz", stored.getEtag());
+        assertEquals("roles/pubsub.publisher", stored.getBindings().get(0).get("role"));
+    }
+
+    @Test
+    void fromJsonMapWithoutEtagLeavesItEmptyForBlindWrites() {
+        StoredPolicy stored = IamPolicyCodec.fromJsonMap(Map.of("bindings", List.of()));
+        assertEquals("", stored.getEtag());
+        assertFalse(stored.getBindings() == null);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/iam/IamPolicyGrpcControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamPolicyGrpcControllerTest.java
@@ -1,0 +1,154 @@
+package io.floci.gcp.services.iam;
+
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import io.floci.gcp.core.common.GcpException;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IamPolicyGrpcControllerTest {
+
+    private IamService iamService;
+    private IamPolicyGrpcController controller;
+
+    @BeforeEach
+    void setUp() {
+        iamService = IamServices.inMemory();
+        controller = new IamPolicyGrpcController(iamService);
+    }
+
+    @Test
+    void setThenGetReturnsSameBindings() {
+        Policy requested = Policy.newBuilder()
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/pubsub.publisher")
+                        .addMembers("serviceAccount:worker@p.iam.gserviceaccount.com"))
+                .build();
+
+        RecordingObserver<Policy> setObserver = new RecordingObserver<>();
+        controller.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/topics/t")
+                .setPolicy(requested)
+                .build(), setObserver);
+        assertNull(setObserver.error.get());
+
+        RecordingObserver<Policy> getObserver = new RecordingObserver<>();
+        controller.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/topics/t")
+                .build(), getObserver);
+
+        assertNull(getObserver.error.get());
+        Policy read = getObserver.values.get(0);
+        assertEquals(1, read.getBindingsCount());
+        assertEquals("roles/pubsub.publisher", read.getBindings(0).getRole());
+        assertEquals(setObserver.values.get(0).getEtag(), read.getEtag());
+    }
+
+    @Test
+    void grpcWriteIsVisibleInSharedStore() {
+        RecordingObserver<Policy> setObserver = new RecordingObserver<>();
+        controller.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/subscriptions/s")
+                .setPolicy(Policy.newBuilder()
+                        .addBindings(Binding.newBuilder()
+                                .setRole("roles/pubsub.subscriber")
+                                .addMembers("user:x@example.com")))
+                .build(), setObserver);
+        assertNull(setObserver.error.get());
+
+        assertEquals("roles/pubsub.subscriber",
+                iamService.getPolicy("projects/p/subscriptions/s").getBindings().get(0).get("role"));
+    }
+
+    @Test
+    void getOnMissingRegisteredResourceIsNotFound() {
+        iamService.registerPolicyResourceResolver("projects/*/topics/*", resource -> {
+            throw GcpException.notFound("Topic not found: " + resource);
+        });
+
+        RecordingObserver<Policy> observer = new RecordingObserver<>();
+        controller.getIamPolicy(GetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/topics/missing")
+                .build(), observer);
+
+        StatusRuntimeException e = (StatusRuntimeException) observer.error.get();
+        assertEquals(Status.Code.NOT_FOUND, e.getStatus().getCode());
+    }
+
+    @Test
+    void staleEtagWriteIsAborted() {
+        RecordingObserver<Policy> first = new RecordingObserver<>();
+        controller.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/topics/t")
+                .setPolicy(Policy.getDefaultInstance())
+                .build(), first);
+        Policy stale = first.values.get(0);
+
+        RecordingObserver<Policy> second = new RecordingObserver<>();
+        controller.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/topics/t")
+                .setPolicy(Policy.getDefaultInstance())
+                .build(), second);
+        assertNull(second.error.get());
+
+        RecordingObserver<Policy> conflicting = new RecordingObserver<>();
+        controller.setIamPolicy(SetIamPolicyRequest.newBuilder()
+                .setResource("projects/p/topics/t")
+                .setPolicy(Policy.newBuilder().setEtag(stale.getEtag()))
+                .build(), conflicting);
+
+        StatusRuntimeException e = (StatusRuntimeException) conflicting.error.get();
+        assertEquals(Status.Code.ABORTED, e.getStatus().getCode());
+    }
+
+    @Test
+    void testIamPermissionsEchoesRequestedPermissions() {
+        RecordingObserver<TestIamPermissionsResponse> observer = new RecordingObserver<>();
+        controller.testIamPermissions(TestIamPermissionsRequest.newBuilder()
+                .setResource("projects/p/topics/never-created")
+                .addPermissions("pubsub.topics.publish")
+                .addPermissions("pubsub.topics.get")
+                .build(), observer);
+
+        assertNull(observer.error.get());
+        assertEquals(List.of("pubsub.topics.publish", "pubsub.topics.get"),
+                observer.values.get(0).getPermissionsList());
+    }
+
+    private static final class RecordingObserver<T> implements StreamObserver<T> {
+        final List<T> values = new ArrayList<>();
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        boolean completed;
+
+        @Override
+        public void onNext(T value) {
+            values.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            error.set(t);
+        }
+
+        @Override
+        public void onCompleted() {
+            completed = true;
+            assertTrue(!values.isEmpty());
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/iam/IamPolicyGrpcControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamPolicyGrpcControllerTest.java
@@ -117,10 +117,16 @@ class IamPolicyGrpcControllerTest {
     }
 
     @Test
-    void testIamPermissionsEchoesRequestedPermissions() {
+    void testIamPermissionsEchoesForExistingResource() {
+        iamService.registerPolicyResourceResolver("projects/*/topics/*", resource -> {
+            if (resource.endsWith("/missing")) {
+                throw GcpException.notFound("Topic not found: " + resource);
+            }
+        });
+
         RecordingObserver<TestIamPermissionsResponse> observer = new RecordingObserver<>();
         controller.testIamPermissions(TestIamPermissionsRequest.newBuilder()
-                .setResource("projects/p/topics/never-created")
+                .setResource("projects/p/topics/exists")
                 .addPermissions("pubsub.topics.publish")
                 .addPermissions("pubsub.topics.get")
                 .build(), observer);
@@ -128,6 +134,22 @@ class IamPolicyGrpcControllerTest {
         assertNull(observer.error.get());
         assertEquals(List.of("pubsub.topics.publish", "pubsub.topics.get"),
                 observer.values.get(0).getPermissionsList());
+    }
+
+    @Test
+    void testIamPermissionsFailsOpenWithEmptySetForMissingResource() {
+        iamService.registerPolicyResourceResolver("projects/*/topics/*", resource -> {
+            throw GcpException.notFound("Topic not found: " + resource);
+        });
+
+        RecordingObserver<TestIamPermissionsResponse> observer = new RecordingObserver<>();
+        controller.testIamPermissions(TestIamPermissionsRequest.newBuilder()
+                .setResource("projects/p/topics/never-created")
+                .addPermissions("pubsub.topics.publish")
+                .build(), observer);
+
+        assertNull(observer.error.get());
+        assertEquals(List.of(), observer.values.get(0).getPermissionsList());
     }
 
     private static final class RecordingObserver<T> implements StreamObserver<T> {

--- a/src/test/java/io/floci/gcp/services/iam/IamServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -100,5 +101,104 @@ class IamServiceTest {
         assertNotNull(policy);
         assertEquals(1, policy.getVersion());
         assertTrue(policy.getBindings() == null || policy.getBindings().isEmpty());
+    }
+
+    @Test
+    void unsetPolicyCarriesEmptyPolicyEtag() {
+        assertEquals("ACAB", service.getPolicy("projects/p1/resource/r1").getEtag());
+    }
+
+    @Test
+    void setPolicyRotatesEtagOnEveryWrite() {
+        StoredPolicy first = service.setPolicy("projects/p1/resource/r1", new StoredPolicy());
+        String firstEtag = first.getEtag();
+        assertNotNull(firstEtag);
+        assertFalse(firstEtag.isEmpty());
+        assertNotEquals("ACAB", firstEtag);
+
+        StoredPolicy second = service.setPolicy("projects/p1/resource/r1", new StoredPolicy());
+        assertNotEquals(firstEtag, second.getEtag());
+    }
+
+    @Test
+    void setPolicyWithoutEtagIsBlindWrite() {
+        service.setPolicy("projects/p1/resource/r1", new StoredPolicy());
+
+        StoredPolicy blind = new StoredPolicy();
+        assertEquals("", blind.getEtag());
+        assertDoesNotThrow(() -> service.setPolicy("projects/p1/resource/r1", blind));
+    }
+
+    @Test
+    void setPolicyWithCurrentEtagSucceeds() {
+        service.setPolicy("projects/p1/resource/r1", new StoredPolicy());
+        String current = service.getPolicy("projects/p1/resource/r1").getEtag();
+
+        StoredPolicy update = new StoredPolicy();
+        update.setEtag(current);
+        assertDoesNotThrow(() -> service.setPolicy("projects/p1/resource/r1", update));
+    }
+
+    @Test
+    void setPolicyWithStaleEtagIsAborted() {
+        StoredPolicy reader = service.setPolicy("projects/p1/resource/r1", new StoredPolicy());
+        String stale = reader.getEtag();
+        service.setPolicy("projects/p1/resource/r1", new StoredPolicy());
+
+        StoredPolicy lostUpdate = new StoredPolicy();
+        lostUpdate.setEtag(stale);
+        GcpException e = assertThrows(GcpException.class,
+                () -> service.setPolicy("projects/p1/resource/r1", lostUpdate));
+        assertEquals(409, e.getHttpStatus());
+        assertEquals("ABORTED", e.getGcpStatus());
+    }
+
+    @Test
+    void setPolicyAgainstUnsetPolicyAcceptsEmptyPolicyEtag() {
+        StoredPolicy update = new StoredPolicy();
+        update.setEtag("ACAB");
+        assertDoesNotThrow(() -> service.setPolicy("projects/p1/resource/r1", update));
+    }
+
+    @Test
+    void deletePolicyRemovesStoredPolicy() {
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of("role", "roles/viewer", "members", List.of("user:x@example.com"))));
+        service.setPolicy("projects/p1/resource/r1", policy);
+
+        service.deletePolicy("projects/p1/resource/r1");
+
+        assertTrue(service.getPolicy("projects/p1/resource/r1").getBindings().isEmpty());
+        assertEquals("ACAB", service.getPolicy("projects/p1/resource/r1").getEtag());
+    }
+
+    @Test
+    void policiesSurviveServiceRestart() {
+        InMemoryStorage<String, StoredPolicy> policyStore = new InMemoryStorage<>();
+        IamService first = new IamService(new InMemoryStorage<>(), new InMemoryStorage<>(), policyStore);
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of("role", "roles/pubsub.publisher", "members", List.of("user:x@example.com"))));
+        first.setPolicy("projects/p1/topics/t1", policy);
+
+        IamService second = new IamService(new InMemoryStorage<>(), new InMemoryStorage<>(), policyStore);
+
+        assertEquals("roles/pubsub.publisher",
+                second.getPolicy("projects/p1/topics/t1").getBindings().get(0).get("role"));
+    }
+
+    @Test
+    void resolverEnforcesExistenceOnlyForMatchingResources() {
+        service.registerPolicyResourceResolver("projects/*/widgets/*", resource -> {
+            throw GcpException.notFound("Widget not found: " + resource);
+        });
+
+        GcpException e = assertThrows(GcpException.class,
+                () -> service.getPolicy("projects/p1/widgets/w1"));
+        assertEquals(404, e.getHttpStatus());
+        assertThrows(GcpException.class,
+                () -> service.setPolicy("projects/p1/widgets/w1", new StoredPolicy()));
+
+        assertDoesNotThrow(() -> service.getPolicy("projects/p1/gadgets/g1"));
+        assertDoesNotThrow(() -> service.getPolicy("projects/p1/widgets/w1/sub/s1"));
     }
 }

--- a/src/test/java/io/floci/gcp/services/iam/IamServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamServiceTest.java
@@ -173,6 +173,21 @@ class IamServiceTest {
     }
 
     @Test
+    void testPermissionsEchoesWhenNoResolverMatches() {
+        assertEquals(List.of("a.b.c", "d.e.f"),
+                service.testPermissions("projects/p1/gadgets/g1", List.of("a.b.c", "d.e.f")));
+    }
+
+    @Test
+    void testPermissionsFailsOpenEmptyForMissingResolvedResource() {
+        service.registerPolicyResourceResolver("projects/*/widgets/*", resource -> {
+            throw GcpException.notFound("Widget not found: " + resource);
+        });
+
+        assertEquals(List.of(), service.testPermissions("projects/p1/widgets/w1", List.of("a.b.c")));
+    }
+
+    @Test
     void policiesSurviveServiceRestart() {
         InMemoryStorage<String, StoredPolicy> policyStore = new InMemoryStorage<>();
         IamService first = new IamService(new InMemoryStorage<>(), new InMemoryStorage<>(), policyStore);

--- a/src/test/java/io/floci/gcp/services/iam/IamServices.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamServices.java
@@ -1,0 +1,13 @@
+package io.floci.gcp.services.iam;
+
+import io.floci.gcp.core.storage.InMemoryStorage;
+
+/** Test factory granting other packages access to the package-private constructor. */
+public final class IamServices {
+
+    private IamServices() {}
+
+    public static IamService inMemory() {
+        return new IamService(new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
@@ -508,18 +508,30 @@ class PubSubRestIntegrationTest {
     }
 
     @Test
-    void testIamPermissionsEchoesRequestedPermissions() {
+    void testIamPermissionsEchoesForExistingTopicAndFailsOpenEmptyForMissing() {
         String project = "pubsub-rest-iam-perm-it";
         String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/perm-target").then().statusCode(200);
 
         given()
                 .urlEncodingEnabled(false)
                 .contentType("application/json")
                 .body("{\"permissions\": [\"pubsub.topics.publish\", \"pubsub.topics.get\"]}")
-                .when().post(base + "/topics/any:testIamPermissions")
+                .when().post(base + "/topics/perm-target:testIamPermissions")
                 .then()
                 .statusCode(200)
                 .body("permissions[0]", equalTo("pubsub.topics.publish"))
                 .body("permissions[1]", equalTo("pubsub.topics.get"));
+
+        // Missing resource fails open: empty permission set, not NOT_FOUND.
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"permissions\": [\"pubsub.topics.publish\"]}")
+                .when().post(base + "/topics/never-created:testIamPermissions")
+                .then()
+                .statusCode(200)
+                .body("permissions", empty());
     }
 }

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubRestIntegrationTest.java
@@ -7,6 +7,7 @@ import java.util.Base64;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
@@ -362,5 +363,163 @@ class PubSubRestIntegrationTest {
                 .then()
                 .statusCode(400)
                 .body("error.status", equalTo("INVALID_ARGUMENT"));
+    }
+
+    // Regression: before IAM routing existed, :getIamPolicy fell into the plain
+    // topic GET route and reported an existing topic as "Topic not found".
+    @Test
+    void getIamPolicyOnExistingTopicReturnsEmptyPolicyNotTopicNotFound() {
+        String project = "pubsub-rest-iam-it";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/iam-target").then().statusCode(200);
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(base + "/topics/iam-target:getIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("etag", equalTo("ACAB"))
+                .body("bindings", empty());
+    }
+
+    @Test
+    void topicIamPolicySetReadBackAndClearedOnDelete() {
+        String project = "pubsub-rest-iam-crud-it";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/orders").then().statusCode(200);
+
+        String etag = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "policy": {
+                            "bindings": [
+                              {
+                                "role": "roles/pubsub.publisher",
+                                "members": ["serviceAccount:worker@%s.iam.gserviceaccount.com"]
+                              }
+                            ]
+                          }
+                        }
+                        """.formatted(project))
+                .when().post(base + "/topics/orders:setIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("bindings[0].role", equalTo("roles/pubsub.publisher"))
+                .extract().path("etag");
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(base + "/topics/orders:getIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("etag", equalTo(etag))
+                .body("bindings[0].members[0]",
+                        equalTo("serviceAccount:worker@" + project + ".iam.gserviceaccount.com"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"policy\": {\"etag\": \"bm90LXRoZS1ldGFn\"}}")
+                .when().post(base + "/topics/orders:setIamPolicy")
+                .then()
+                .statusCode(409)
+                .body("error.status", equalTo("ABORTED"));
+
+        given().when().delete(base + "/topics/orders").then().statusCode(200);
+        given().when().put(base + "/topics/orders").then().statusCode(200);
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(base + "/topics/orders:getIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("etag", equalTo("ACAB"))
+                .body("bindings", empty());
+    }
+
+    @Test
+    void iamPolicyOnMissingTopicIsNotFound() {
+        String project = "pubsub-rest-iam-missing-it";
+        String base = "/v1/projects/" + project;
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(base + "/topics/never-created:getIamPolicy")
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"policy\": {}}")
+                .when().post(base + "/topics/never-created:setIamPolicy")
+                .then()
+                .statusCode(404)
+                .body("error.status", equalTo("NOT_FOUND"));
+    }
+
+    @Test
+    void subscriptionIamPolicyIndependentOfTopic() {
+        String project = "pubsub-rest-iam-sub-it";
+        String base = "/v1/projects/" + project;
+
+        given().when().put(base + "/topics/shared").then().statusCode(200);
+        given()
+                .contentType("application/json")
+                .body("{\"topic\": \"projects/" + project + "/topics/shared\"}")
+                .when().put(base + "/subscriptions/shared")
+                .then()
+                .statusCode(200);
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("""
+                        {
+                          "policy": {
+                            "bindings": [
+                              {"role": "roles/pubsub.subscriber", "members": ["user:sub@example.com"]}
+                            ]
+                          }
+                        }
+                        """)
+                .when().post(base + "/subscriptions/shared:setIamPolicy")
+                .then()
+                .statusCode(200);
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(base + "/topics/shared:getIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("bindings", empty());
+
+        given()
+                .urlEncodingEnabled(false)
+                .when().get(base + "/subscriptions/shared:getIamPolicy")
+                .then()
+                .statusCode(200)
+                .body("bindings[0].role", equalTo("roles/pubsub.subscriber"));
+    }
+
+    @Test
+    void testIamPermissionsEchoesRequestedPermissions() {
+        String project = "pubsub-rest-iam-perm-it";
+        String base = "/v1/projects/" + project;
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("{\"permissions\": [\"pubsub.topics.publish\", \"pubsub.topics.get\"]}")
+                .when().post(base + "/topics/any:testIamPermissions")
+                .then()
+                .statusCode(200)
+                .body("permissions[0]", equalTo("pubsub.topics.publish"))
+                .body("permissions[1]", equalTo("pubsub.topics.get"));
     }
 }

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
@@ -7,6 +7,7 @@ import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.storage.InMemoryStorage;
 import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.iam.IamServices;
+import io.floci.gcp.services.iam.model.StoredPolicy;
 import io.floci.gcp.services.pubsub.model.StoredSnapshot;
 import io.floci.gcp.services.pubsub.model.StoredSubscription;
 import io.floci.gcp.services.pubsub.model.StoredTopic;
@@ -458,6 +459,118 @@ class PubSubServiceTest {
 
         List<ReceivedMessage> second = service.pull("projects/p1/subscriptions/s1", 10);
         assertTrue(second.isEmpty());
+    }
+
+    // ── IAM policies ───────────────────────────────────────────────────────────
+
+    @Test
+    void topicPolicyRoundTripsWithBindingOrderPreserved() {
+        service.createTopic("projects/p1/topics/t1");
+
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(
+                Map.of("role", "roles/pubsub.publisher", "members", List.of("serviceAccount:a@p1.iam.gserviceaccount.com")),
+                Map.of("role", "roles/pubsub.viewer", "members", List.of("user:b@example.com", "user:c@example.com"))));
+        iamService.setPolicy("projects/p1/topics/t1", policy);
+
+        StoredPolicy read = iamService.getPolicy("projects/p1/topics/t1");
+        assertEquals(2, read.getBindings().size());
+        assertEquals("roles/pubsub.publisher", read.getBindings().get(0).get("role"));
+        assertEquals("roles/pubsub.viewer", read.getBindings().get(1).get("role"));
+        assertEquals(List.of("user:b@example.com", "user:c@example.com"), read.getBindings().get(1).get("members"));
+    }
+
+    @Test
+    void subscriptionPolicyIndependentOfTopicWithSameShortName() {
+        service.createTopic("projects/p1/topics/shared");
+        service.createSubscription("projects/p1/subscriptions/shared", "projects/p1/topics/shared", 10);
+
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of("role", "roles/pubsub.subscriber", "members", List.of("user:s@example.com"))));
+        iamService.setPolicy("projects/p1/subscriptions/shared", policy);
+
+        assertTrue(iamService.getPolicy("projects/p1/topics/shared").getBindings().isEmpty());
+        assertEquals(1, iamService.getPolicy("projects/p1/subscriptions/shared").getBindings().size());
+    }
+
+    @Test
+    void unsetPolicyOnExistingTopicReturnsEmptyNotError() {
+        service.createTopic("projects/p1/topics/t1");
+
+        StoredPolicy policy = iamService.getPolicy("projects/p1/topics/t1");
+        assertTrue(policy.getBindings().isEmpty());
+        assertEquals("ACAB", policy.getEtag());
+    }
+
+    @Test
+    void policyOnMissingTopicIsNotFound() {
+        GcpException get = assertThrows(GcpException.class,
+                () -> iamService.getPolicy("projects/p1/topics/missing"));
+        assertEquals(404, get.getHttpStatus());
+
+        GcpException set = assertThrows(GcpException.class,
+                () -> iamService.setPolicy("projects/p1/topics/missing", new StoredPolicy()));
+        assertEquals(404, set.getHttpStatus());
+    }
+
+    @Test
+    void policiesAreProjectScoped() {
+        service.createTopic("projects/p1/topics/t");
+        service.createTopic("projects/p2/topics/t");
+
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of("role", "roles/pubsub.publisher", "members", List.of("user:p1@example.com"))));
+        iamService.setPolicy("projects/p1/topics/t", policy);
+
+        assertEquals(1, iamService.getPolicy("projects/p1/topics/t").getBindings().size());
+        assertTrue(iamService.getPolicy("projects/p2/topics/t").getBindings().isEmpty());
+    }
+
+    @Test
+    void deletingTopicClearsPolicySoRecreateStartsEmpty() {
+        service.createTopic("projects/p1/topics/t1");
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of("role", "roles/pubsub.publisher", "members", List.of("user:x@example.com"))));
+        iamService.setPolicy("projects/p1/topics/t1", policy);
+
+        service.deleteTopic("projects/p1/topics/t1");
+        service.createTopic("projects/p1/topics/t1");
+
+        assertTrue(iamService.getPolicy("projects/p1/topics/t1").getBindings().isEmpty());
+    }
+
+    @Test
+    void deletingSubscriptionClearsPolicy() {
+        service.createTopic("projects/p1/topics/t1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of("role", "roles/pubsub.subscriber", "members", List.of("user:x@example.com"))));
+        iamService.setPolicy("projects/p1/subscriptions/s1", policy);
+
+        service.deleteSubscription("projects/p1/subscriptions/s1");
+        service.createSubscription("projects/p1/subscriptions/s1", "projects/p1/topics/t1", 10);
+
+        assertTrue(iamService.getPolicy("projects/p1/subscriptions/s1").getBindings().isEmpty());
+    }
+
+    @Test
+    void conditionBlockRoundTripsUnchanged() {
+        service.createTopic("projects/p1/topics/t1");
+
+        Map<String, Object> condition = Map.of(
+                "expression", "request.time < timestamp('2030-01-01T00:00:00Z')",
+                "title", "expiry",
+                "description", "temporary grant",
+                "location", "policy.tf:12");
+        StoredPolicy policy = new StoredPolicy();
+        policy.setBindings(List.of(Map.of(
+                "role", "roles/pubsub.publisher",
+                "members", List.of("user:x@example.com"),
+                "condition", condition)));
+        iamService.setPolicy("projects/p1/topics/t1", policy);
+
+        StoredPolicy read = iamService.getPolicy("projects/p1/topics/t1");
+        assertEquals(condition, read.getBindings().get(0).get("condition"));
     }
 
     private void createFilteredSubscription(String name, String topic, String filter) {

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubServiceTest.java
@@ -5,6 +5,8 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.ReceivedMessage;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.iam.IamService;
+import io.floci.gcp.services.iam.IamServices;
 import io.floci.gcp.services.pubsub.model.StoredSnapshot;
 import io.floci.gcp.services.pubsub.model.StoredSubscription;
 import io.floci.gcp.services.pubsub.model.StoredTopic;
@@ -19,15 +21,18 @@ import static org.junit.jupiter.api.Assertions.*;
 class PubSubServiceTest {
 
     private PubSubService service;
+    private IamService iamService;
     private InMemoryStorage<String, StoredSubscription> subStore;
 
     @BeforeEach
     void setUp() {
         subStore = new InMemoryStorage<>();
+        iamService = IamServices.inMemory();
         service = new PubSubService(
                 new InMemoryStorage<>(),
                 subStore,
-                new InMemoryStorage<>());
+                new InMemoryStorage<>(),
+                iamService);
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/pubsub/PubSubSubscriberControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/pubsub/PubSubSubscriberControllerTest.java
@@ -6,6 +6,7 @@ import com.google.pubsub.v1.StreamingPullRequest;
 import com.google.pubsub.v1.StreamingPullResponse;
 import com.google.pubsub.v1.Subscription;
 import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.iam.IamServices;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -34,7 +35,8 @@ class PubSubSubscriberControllerTest {
         service = new PubSubService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>());
+                new InMemoryStorage<>(),
+                IamServices.inMemory());
         controller = new PubSubSubscriberController(service);
     }
 


### PR DESCRIPTION
## Summary

Closes #130

Adds the missing IAM policy surface for Pub/Sub — `getIamPolicy` / `setIamPolicy` / `testIamPermissions` on topics, subscriptions, and snapshots, over both protocols. Fixes the misleading failure where `GET :getIamPolicy` on an existing topic returned `"Topic not found"` because the suffix fell into the plain topic route.

**Control-plane fidelity only.** Policies are stored and returned, never enforced — no request is denied because of a stored policy, no condition/CEL evaluation, and `testIamPermissions` echoes the requested permissions for existing resources (empty set for missing ones — see below). This matches the emulator's accept-all-requests invariant; `docs/services/pubsub.md` documents the boundary so nobody builds an authorization test on top of it.

### How

- **gRPC** — Pub/Sub declares IAM as a service-config mixin, not on `Publisher`/`Subscriber`, so this adds a shared `google.iam.v1.IAMPolicy` implementation (`IamPolicyGrpcController`) that dispatches on resource name. One binding serves every mixin-style service on the single port; Pub/Sub is the first registrant. Uses the pre-compiled `grpc-google-iam-v1` stub (BOM-managed, same version line as the `proto-google-iam-v1` already on the classpath).
- **REST** — explicit `:getIamPolicy` (GET) / `:setIamPolicy` / `:testIamPermissions` (POST) routes on `PubSubRestController`, verbs verified against `googleapis/google/pubsub/v1/pubsub_v1.yaml`. More-literal templates win over `/topics/{topic}` — the same JAX-RS mechanism the existing `:publish` route relies on.
- **Storage** — delegates to the shared `IamService` policy store (the pattern Cloud Run already uses), with three additions:
  - **Resource existence checks** via an opt-in resolver seam: policy calls on a topic/subscription/snapshot that doesn't exist fail `NOT_FOUND`; services that haven't opted in keep today's permissive behavior. `testIamPermissions` runs the same existence check but fails open for a missing resource with an empty permission set rather than `NOT_FOUND`, per the service config's documented behavior.
  - **Etag rotation + conflict detection**: etags rotate on every write; a `setIamPolicy` carrying a stale etag fails `ABORTED`/409 (concurrency control matching real GCP, not enforcement). Previously every policy carried the constant `"ACAB"` forever, which silently lost updates in read-modify-write flows — exactly what `google_pubsub_topic_iam_member` does. Unset policies still read back with GCP's well-known empty-policy etag `ACAB`. The read-compare-write is serialized per resource with a striped lock (mirrors `GcsService.objectLock`).
  - **`deletePolicy`**: deleting a topic/subscription/snapshot clears its policy, so recreating the same name doesn't resurrect old grants.
- Bindings round-trip losslessly, including `condition` blocks — stored verbatim, never evaluated.
- Converters extracted from `CloudRunService` into a shared `IamPolicyCodec` (pure move; a codec test pins the condition round-trip).

### Intentional scope notes

- **Etag rotation is shared behavior**: Cloud Run and GCS bucket policies now rotate etags too (one store, one behavior). Nothing in the tree asserted the old constant.
- **Cloud Run had the same policy-leak-on-delete bug** — fixed here with one line in `deleteMetadata` (plus a test), rather than shipping `deletePolicy` with a single caller.
- **Schemas are excluded**: the emulator has no schema resource, so schema IAM routes would return `NOT_FOUND` unconditionally and advertise a capability that doesn't exist. Noted in docs; snapshot IAM is included since snapshots are fully implemented.
- The stale "Pub/Sub is not reachable via Terraform custom endpoints" comment in both compat `provider.tf` files is corrected, since this PR (with the existing REST controller) falsifies it.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

- Wire mappings verified against the published service config (`pubsub_v1.yaml`), not assumed — `getIamPolicy` is GET; `setIamPolicy`/`testIamPermissions` are POST with body `*`.
- **Go SDK** `cloud.google.com/go/pubsub` v1.50.1: `topic.IAM()` / `sub.IAM()` round-trips, missing-resource `NotFound`, `TestPermissions` echo — new subtests in `sdk-test-go`, run green against a live emulator.
- **Java SDK** `libraries-bom` 26.85.1: `TopicAdminClient`/`SubscriptionAdminClient` IAM round-trip + `NotFoundException` — new tests in `sdk-test-java` (19/19 green live).
- **Terraform/OpenTofu**: Pub/Sub onboarded to both IaC suites (`pubsub_custom_endpoint`, `google_pubsub_topic`, `google_pubsub_subscription`, two `google_pubsub_topic_iam_member`s on one topic plus a subscription member, bats spot checks). Verified live with OpenTofu 1.12.5 / `hashicorp/google` ~>7.36: full apply succeeds, **both topic members survive the read-modify-write**, re-plan converges with zero drift, destroy is clean. The two-members-on-one-topic case is the regression guard for the frozen-etag lost-update.
- Limitation stated per AGENTS.md: the Docker-based CI suite flow itself was not run locally; the Go/Java suites and the OpenTofu apply were executed directly against a locally built emulator instead. The `compat-terraform` HCL was validated with `tofu validate` (terraform binary not available locally); it is identical to the opentofu suite that was applied end-to-end.

## Checklist

- [x] `./mvnw test` passes locally (718 tests)
- [x] New or updated integration test added (`PubSubRestIntegrationTest` — includes the regression test for the `"Topic not found"` symptom; unit coverage for round-trip, independence, project scoping, restart survival, delete-clears-policy, condition round-trip, etag rotation/conflict/blind-write)
- [x] Commit messages follow Conventional Commits
