### PR TITLE
fix(gcs): track resumable upload sessions across POST chunks

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/gcs_test.go
+++ b/compatibility-tests/sdk-test-go/tests/gcs_test.go
@@ -195,6 +195,35 @@ func TestGCS(t *testing.T) {
 		require.NoError(t, composed.Delete(ctx))
 	})
 
+	// The Go SDK sends resumable chunks as POST requests to the session URL, so a
+	// payload larger than ChunkSize exercises multi-chunk session tracking.
+	t.Run("ChunkedResumableUpload", func(t *testing.T) {
+		chunkedName := "chunked-" + objectName
+		obj := client.Bucket(bucketName).Object(chunkedName)
+		payload := randomBytes(1024 * 1024)
+
+		w := obj.NewWriter(ctx)
+		w.ChunkSize = 256 * 1024
+		_, err := w.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		attrs, err := obj.Attrs(ctx)
+		require.NoError(t, err)
+		assert.EqualValues(t, len(payload), attrs.Size)
+
+		r, err := obj.NewReader(ctx)
+		require.NoError(t, err)
+		defer r.Close()
+
+		var buf bytes.Buffer
+		_, err = buf.ReadFrom(r)
+		require.NoError(t, err)
+		assert.Equal(t, payload, buf.Bytes())
+
+		require.NoError(t, obj.Delete(ctx))
+	})
+
 	t.Run("DeleteObject", func(t *testing.T) {
 		err := client.Bucket(bucketName).Object(objectName).Delete(ctx)
 		require.NoError(t, err)

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableUploadRawTest.java
@@ -198,4 +198,117 @@ class GcsResumableUploadRawTest {
         assertThat(download.statusCode()).isEqualTo(200);
         assertThat(download.body()).containsExactly(data);
     }
+
+    // Session semantics below were verified against live GCS on 2026-08-23: POST to the
+    // session URL behaves exactly like PUT, a resent chunk is acknowledged without
+    // appending, and a completed session keeps replaying the stored object metadata.
+    @Test
+    void resumableUploadTracksPostChunksAcrossTheSameSession() throws Exception {
+        String objectName = "post-chunked.bin";
+        int chunkSize = 256 * 1024;
+        int totalSize = chunkSize * 2;
+        byte[] first = new byte[chunkSize];
+        byte[] second = new byte[chunkSize];
+        Arrays.fill(first, (byte) 'a');
+        Arrays.fill(second, (byte) 'b');
+
+        HttpResponse<String> init = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/upload/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=resumable&name=" + objectName))
+                        .header("X-Upload-Content-Type", "application/octet-stream")
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(init.statusCode()).isEqualTo(200);
+        URI uploadUri = URI.create(init.headers().firstValue("Location").orElseThrow());
+
+        HttpResponse<String> firstChunk = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes 0-" + (chunkSize - 1) + "/" + totalSize)
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(first))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(firstChunk.statusCode()).isEqualTo(308);
+        assertThat(firstChunk.headers().firstValue("Range")).contains("bytes=0-" + (chunkSize - 1));
+
+        HttpResponse<String> resentChunk = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes 0-" + (chunkSize - 1) + "/" + totalSize)
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(first))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(resentChunk.statusCode()).isEqualTo(308);
+        assertThat(resentChunk.headers().firstValue("Range")).contains("bytes=0-" + (chunkSize - 1));
+
+        HttpResponse<String> finalChunk = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes " + chunkSize + "-" + (totalSize - 1) + "/" + totalSize)
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(second))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(finalChunk.statusCode()).isEqualTo(200);
+        assertThat(finalChunk.body()).contains("\"size\":\"" + totalSize + "\"");
+
+        HttpResponse<String> statusAfterCompletion = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Range", "bytes */" + totalSize)
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(statusAfterCompletion.statusCode()).isEqualTo(200);
+        assertThat(statusAfterCompletion.body()).contains("\"size\":\"" + totalSize + "\"");
+
+        HttpResponse<byte[]> download = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/storage/v1/b/" + BUCKET + "/o/" + objectName + "?alt=media"))
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(download.statusCode()).isEqualTo(200);
+        assertThat(download.body()).hasSize(totalSize);
+        assertThat(download.body()[0]).isEqualTo((byte) 'a');
+        assertThat(download.body()[chunkSize]).isEqualTo((byte) 'b');
+    }
+
+    @Test
+    void resumableUploadRejectsChunkPastTheReceivedBytes() throws Exception {
+        String objectName = "gap-chunk.bin";
+        int chunkSize = 256 * 1024;
+        byte[] data = new byte[chunkSize];
+        Arrays.fill(data, (byte) 'c');
+
+        HttpResponse<String> init = CLIENT.send(
+                HttpRequest.newBuilder(URI.create(TestFixtures.endpoint()
+                                + "/upload/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=resumable&name=" + objectName))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(init.statusCode()).isEqualTo(200);
+        URI uploadUri = URI.create(init.headers().firstValue("Location").orElseThrow());
+
+        HttpResponse<String> gap = CLIENT.send(
+                HttpRequest.newBuilder(uploadUri)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes " + chunkSize + "-" + (2 * chunkSize - 1)
+                                + "/" + (2 * chunkSize))
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(data))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(gap.statusCode()).isEqualTo(503);
+    }
 }

--- a/compatibility-tests/sdk-test-node/tests/gcs.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/gcs.test.ts
@@ -52,6 +52,28 @@ describe('Cloud Storage (GCS)', () => {
     await storage.bucket(bucketName).file(largeObjectName).delete();
   });
 
+  // save() sends the whole body in one request. A chunkSize makes the SDK split
+  // the payload across several requests against one resumable session.
+  it('should upload an object in chunks against one resumable session', async () => {
+    const chunkSize = 256 * 1024;
+    const chunkedContent = Buffer.alloc(4 * chunkSize, 'c');
+    const chunkedObjectName = 'chunked-test-object.bin';
+    const file = storage.bucket(bucketName).file(chunkedObjectName);
+
+    await new Promise<void>((resolve, reject) => {
+      file
+        .createWriteStream({ resumable: true, chunkSize, contentType: 'application/octet-stream' })
+        .on('error', reject)
+        .on('finish', resolve)
+        .end(chunkedContent);
+    });
+
+    const [downloaded] = await file.download();
+    expect(downloaded.length).toBe(chunkedContent.length);
+    expect(downloaded.equals(chunkedContent)).toBe(true);
+    await file.delete();
+  });
+
   it('should download and verify object content', async () => {
     const [content] = await storage.bucket(bucketName).file(objectName).download();
     expect(content.toString()).toBe(objectContent);

--- a/compatibility-tests/sdk-test-python/tests/test_gcs.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs.py
@@ -33,6 +33,29 @@ def test_upload_and_download_object(storage_client, unique_name):
         bucket.delete(force=True)
 
 
+def test_chunked_resumable_upload(storage_client, unique_name):
+    """A chunk_size smaller than the payload makes the SDK send several chunks
+    against one resumable session, each acknowledged with 308."""
+    bucket_name = f"test-bucket-{unique_name}"
+    object_name = "chunked-object.bin"
+    chunk_size = 256 * 1024
+    payload = b"p" * (4 * chunk_size)
+
+    bucket = storage_client.create_bucket(storage_client.bucket(bucket_name))
+
+    try:
+        blob = bucket.blob(object_name)
+        with blob.open("wb", chunk_size=chunk_size) as writer:
+            writer.write(payload)
+
+        assert blob.download_as_bytes() == payload
+
+        blob.reload()
+        assert blob.size == len(payload)
+    finally:
+        bucket.delete(force=True)
+
+
 def test_download_populates_blob_from_response_headers(storage_client, unique_name):
     bucket_name = f"test-bucket-{unique_name}"
     object_name = "header-object.txt"

--- a/compatibility-tests/sdk-test-rust/tests/gcs.rs
+++ b/compatibility-tests/sdk-test-rust/tests/gcs.rs
@@ -213,3 +213,33 @@ async fn resumable_upload_round_trips() -> anyhow::Result<()> {
     assert_eq!(read_all(&mut response).await?, payload.as_ref());
     Ok(())
 }
+
+#[tokio::test]
+async fn resumable_upload_sends_multiple_chunks() -> anyhow::Result<()> {
+    let endpoint = endpoint();
+    ensure_bucket(&endpoint).await?;
+    let client = storage_client(&endpoint).await?;
+
+    let bucket_path = format!("projects/_/buckets/{BUCKET}");
+    // The SDK flushes its 8 MiB buffer as soon as it fills, so a larger payload
+    // is split across several chunks that share one resumable session. Each
+    // intermediate chunk declares the total size.
+    let payload = bytes::Bytes::from(vec![b'y'; 9 * 1024 * 1024]);
+
+    let upload = client
+        .write_object(&bucket_path, "resumable-chunked.bin", payload.clone())
+        .with_resumable_upload_threshold(0_usize)
+        .send_buffered();
+    let uploaded = tokio::time::timeout(std::time::Duration::from_secs(60), upload).await??;
+    assert_eq!(uploaded.size, payload.len() as i64);
+
+    let mut response = client
+        .read_object(&bucket_path, "resumable-chunked.bin")
+        .send()
+        .await?;
+    assert_eq!(response.object().size, payload.len() as i64);
+    let downloaded = read_all(&mut response).await?;
+    assert_eq!(downloaded.len(), payload.len());
+    assert!(downloaded.iter().all(|byte| *byte == b'y'));
+    Ok(())
+}

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -151,6 +151,39 @@ and Bearer tokens are not validated.
 
 floci-gcp supports multipart (resumable) upload — the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
 
+## Resumable Upload Sessions
+
+`POST /upload/storage/v1/b/{bucket}/o?uploadType=resumable` opens a session and returns
+the session URL in the `Location` header. Chunks go to that URL with a `Content-Range`
+header, using either `PUT` or `POST` — the Java, Node and Python SDKs send `PUT`, the Go
+SDK sends `POST`, and both are handled the same way.
+
+Session behavior matches GCS:
+
+| Request to the session URL | Response |
+|---|---|
+| Chunk that leaves bytes missing | `308` with `Range: bytes=0-<last received byte>` |
+| Chunk that completes the object | `200` with the object metadata |
+| Status query (`Content-Range: bytes */<total>` or `bytes */*`) | `308` with the received range, or `200` with the object metadata once complete |
+| Chunk already received in full | `308` with the unchanged received range, without appending it again |
+| Chunk starting past the received bytes | `503`, so the client re-syncs with a status query |
+| Any request after completion | `200` with the stored object metadata |
+| Unknown or expired `upload_id` | `404` |
+
+The Go SDK sends `X-GUploader-No-308: yes` because `308` collides with the RFC 7238
+"Permanent Redirect" semantics. floci-gcp answers those requests the way GCS does: `200`
+with `X-HTTP-Status-Code-Override: 308` and the same `Range` header. Other status codes
+are unaffected by the header.
+
+Documented deviations from real GCS:
+
+- GCS requires every non-final chunk to be a multiple of 256 KiB; floci-gcp accepts any
+  chunk size.
+- GCS answers a chunk `POST` that carries no `uploadType` with `405`; floci-gcp accepts
+  it, since the `upload_id` alone identifies the session.
+- Completed sessions are remembered for the most recent 1024 uploads rather than for a
+  week.
+
 ## Object Versioning
 
 Enable versioning on a bucket:

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -945,13 +945,15 @@ public class GcsService {
         return completedResumableUploads.get(uploadId);
     }
 
+    // The completed session is recorded before the active one is dropped, so a retry that
+    // overlaps persistence always finds the upload id in one of the two maps.
     private GcsObjectMeta finishResumableUpload(String uploadId, ResumableUpload upload, byte[] data, String baseUrl) {
-        resumableUploads.remove(uploadId);
         GcsObjectMeta meta = putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
                 upload.preconditions(), baseUrl);
         completedResumableUploads.put(uploadId,
                 new CompletedResumableUpload(upload.bucket(), upload.objectName(), meta));
+        resumableUploads.remove(uploadId);
         LOG.debugf("finishResumableUpload uploadId=%s size=%d", uploadId, data.length);
         return meta;
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -13,9 +13,11 @@ import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.services.gcs.model.CompletedResumableUpload;
 import io.floci.gcp.services.gcs.model.GcsBucket;
+import io.floci.gcp.services.gcs.model.GcsContentRange;
 import io.floci.gcp.services.gcs.model.GcsObjectDownload;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
+import io.floci.gcp.services.gcs.model.ResumableChunkOutcome;
 import io.floci.gcp.services.gcs.model.ResumableUpload;
 import io.floci.gcp.services.gcs.model.StoredAcl;
 import io.floci.gcp.services.gcs.model.StoredNotification;
@@ -66,6 +68,7 @@ public class GcsService {
                 }
             });
     private final Object[] objectLocks = createObjectLocks();
+    private final Object[] uploadLocks = createObjectLocks();
     private final AtomicLong generationSequence;
 
     private final ServiceRegistry serviceRegistry;
@@ -865,75 +868,49 @@ public class GcsService {
 		return resumableUploads.get(uploadId);
 	}
 
-    public GcsObjectMeta completeResumableUpload(String uploadId, byte[] data, String baseUrl) {
-        LOG.debugf("completeResumableUpload uploadId=%s size=%d", uploadId, data.length);
-        ResumableUpload upload = resumableUploads.get(uploadId);
-        if (upload == null) {
-            LOG.warnf("completeResumableUpload failed: upload not found uploadId=%s", uploadId);
-            throw GcpException.notFound("Resumable upload not found: " + uploadId);
+    // Every chunk of one session is handled under the same lock, so a retry that overlaps
+    // finalization waits and then replays the stored metadata instead of uploading twice.
+    public ResumableChunkOutcome applyResumableChunk(String uploadId, GcsContentRange range, byte[] data,
+            String baseUrl) {
+        synchronized (uploadLock(uploadId)) {
+            CompletedResumableUpload completed = completedResumableUploads.get(uploadId);
+            if (completed != null) {
+                return ResumableChunkOutcome.completed(completed.meta());
+            }
+            ResumableUpload upload = resumableUploads.get(uploadId);
+            if (upload == null) {
+                LOG.warnf("applyResumableChunk failed: upload not found uploadId=%s", uploadId);
+                throw GcpException.notFound("Resumable upload not found: " + uploadId);
+            }
+            if (range == null) {
+                byte[] combined = appendChunk(upload, upload.data().length, data);
+                validateResumableTotalSize(upload, (long) combined.length);
+                return ResumableChunkOutcome.completed(finishResumableUpload(uploadId, upload, combined, baseUrl));
+            }
+            if (range.statusQuery()) {
+                validateResumableTotalSize(upload, range.totalSize());
+                byte[] received = upload.data();
+                if (range.totalSize() != null && received.length == range.totalSize()) {
+                    return ResumableChunkOutcome.completed(
+                            finishResumableUpload(uploadId, upload, received, baseUrl));
+                }
+                return ResumableChunkOutcome.incomplete(received.length);
+            }
+            validateResumableTotalSize(upload, range.totalSize());
+            byte[] combined = appendChunk(upload, range.start(), data);
+            if (range.totalSize() == null || range.end() + 1 < range.totalSize()) {
+                resumableUploads.put(uploadId, new ResumableUpload(
+                        upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(),
+                        upload.metadata(), upload.preconditions(), combined,
+                        upload.totalSize() != null ? upload.totalSize() : range.totalSize()));
+                return ResumableChunkOutcome.incomplete(combined.length);
+            }
+            if (combined.length != range.totalSize()) {
+                throw GcpException.invalidArgument(
+                        "Content-Range total size does not match uploaded bytes: " + range.totalSize());
+            }
+            return ResumableChunkOutcome.completed(finishResumableUpload(uploadId, upload, combined, baseUrl));
         }
-        byte[] combined = appendChunk(upload, upload.data().length, data);
-        validateResumableTotalSize(upload, (long) combined.length);
-        return finishResumableUpload(uploadId, upload, combined, baseUrl);
-    }
-
-    public long appendResumableUpload(String uploadId, long start, byte[] data) {
-        return appendResumableUpload(uploadId, start, data, null);
-    }
-
-    public long appendResumableUpload(String uploadId, long start, byte[] data, Long totalSize) {
-        ResumableUpload upload = resumableUploads.get(uploadId);
-        if (upload == null) {
-            LOG.warnf("appendResumableUpload failed: upload not found uploadId=%s", uploadId);
-            throw GcpException.notFound("Resumable upload not found: " + uploadId);
-        }
-        validateResumableTotalSize(upload, totalSize);
-        byte[] combined = appendChunk(upload, start, data);
-        resumableUploads.put(uploadId, new ResumableUpload(
-                upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(),
-                upload.metadata(), upload.preconditions(), combined,
-                upload.totalSize() != null ? upload.totalSize() : totalSize));
-        return combined.length - 1L;
-    }
-
-    public long resumableUploadLength(String uploadId) {
-        ResumableUpload upload = resumableUploads.get(uploadId);
-        if (upload == null) {
-            LOG.warnf("resumableUploadLength failed: upload not found uploadId=%s", uploadId);
-            throw GcpException.notFound("Resumable upload not found: " + uploadId);
-        }
-        return upload.data().length;
-    }
-
-    public GcsObjectMeta completeBufferedResumableUpload(String uploadId, long totalSize, String baseUrl) {
-        ResumableUpload upload = resumableUploads.get(uploadId);
-        if (upload == null) {
-            LOG.warnf("completeBufferedResumableUpload failed: upload not found uploadId=%s", uploadId);
-            throw GcpException.notFound("Resumable upload not found: " + uploadId);
-        }
-        validateResumableTotalSize(upload, totalSize);
-        byte[] data = upload.data();
-        if (data.length != totalSize) {
-            throw GcpException.invalidArgument(
-                    "Content-Range total size does not match uploaded bytes: " + totalSize);
-        }
-        return finishResumableUpload(uploadId, upload, data, baseUrl);
-    }
-
-    public GcsObjectMeta completeResumableUpload(String uploadId, long start, byte[] data,
-            long totalSize, String baseUrl) {
-        ResumableUpload upload = resumableUploads.get(uploadId);
-        if (upload == null) {
-            LOG.warnf("completeResumableUpload failed: upload not found uploadId=%s", uploadId);
-            throw GcpException.notFound("Resumable upload not found: " + uploadId);
-        }
-        validateResumableTotalSize(upload, totalSize);
-        byte[] combined = appendChunk(upload, start, data);
-        if (combined.length != totalSize) {
-            throw GcpException.invalidArgument(
-                    "Content-Range total size does not match uploaded bytes: " + totalSize);
-        }
-        return finishResumableUpload(uploadId, upload, combined, baseUrl);
     }
 
     public CompletedResumableUpload completedResumableUpload(String uploadId) {
@@ -1207,6 +1184,10 @@ public class GcsService {
             locks[i] = new Object();
         }
         return locks;
+    }
+
+    private Object uploadLock(String uploadId) {
+        return uploadLocks[Math.floorMod(uploadId.hashCode(), uploadLocks.length)];
     }
 
     private Object objectLock(String bucket, String objectName) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -861,13 +861,8 @@ public class GcsService {
         return uploadId;
     }
 
-	public ResumableUpload getResumableUpload(String uploadId) {
-		ResumableUpload upload = resumableUploads.get(uploadId);
-		if (upload == null) {
-			LOG.warnf("getResumableUpload failed: upload not found uploadId=%s", uploadId);
-			throw GcpException.notFound("Resumable upload not found: " + uploadId);
-		}
-		return upload;
+	public ResumableUpload findResumableUpload(String uploadId) {
+		return resumableUploads.get(uploadId);
 	}
 
     public GcsObjectMeta completeResumableUpload(String uploadId, byte[] data, String baseUrl) {
@@ -945,8 +940,8 @@ public class GcsService {
         return completedResumableUploads.get(uploadId);
     }
 
-    // The completed session is recorded before the active one is dropped, so a retry that
-    // overlaps persistence always finds the upload id in one of the two maps.
+    // The completed session is recorded before the active one is dropped. Callers rely on
+    // that order: a miss on the active map means the completed entry is already visible.
     private GcsObjectMeta finishResumableUpload(String uploadId, ResumableUpload upload, byte[] data, String baseUrl) {
         GcsObjectMeta meta = putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -11,6 +11,7 @@ import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.gcs.model.CompletedResumableUpload;
 import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.GcsObjectDownload;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
@@ -35,6 +36,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,7 @@ public class GcsService {
 
     private static final Logger LOG = Logger.getLogger(GcsService.class);
     private static final int OBJECT_LOCK_COUNT = 256;
+    private static final int COMPLETED_RESUMABLE_UPLOAD_HISTORY = 1024;
 
     private final StorageBackend<String, GcsBucket> bucketStore;
     private final StorageBackend<String, GcsObjectMeta> objectMetaStore;
@@ -55,6 +58,13 @@ public class GcsService {
     private final StorageBackend<String, StoredAcl> aclStore;
     private final StorageBackend<String, StoredNotification> notificationStore;
     private final ConcurrentHashMap<String, ResumableUpload> resumableUploads = new ConcurrentHashMap<>();
+    private final Map<String, CompletedResumableUpload> completedResumableUploads = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, CompletedResumableUpload> eldest) {
+                    return size() > COMPLETED_RESUMABLE_UPLOAD_HISTORY;
+                }
+            });
     private final Object[] objectLocks = createObjectLocks();
     private final AtomicLong generationSequence;
 
@@ -869,10 +879,7 @@ public class GcsService {
         }
         byte[] combined = appendChunk(upload, upload.data().length, data);
         validateResumableTotalSize(upload, (long) combined.length);
-        resumableUploads.remove(uploadId);
-        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
-                upload.preconditions(), baseUrl);
+        return finishResumableUpload(uploadId, upload, combined, baseUrl);
     }
 
     public long appendResumableUpload(String uploadId, long start, byte[] data) {
@@ -915,10 +922,7 @@ public class GcsService {
             throw GcpException.invalidArgument(
                     "Content-Range total size does not match uploaded bytes: " + totalSize);
         }
-        resumableUploads.remove(uploadId);
-        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
-                GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
-                upload.preconditions(), baseUrl);
+        return finishResumableUpload(uploadId, upload, data, baseUrl);
     }
 
     public GcsObjectMeta completeResumableUpload(String uploadId, long start, byte[] data,
@@ -934,10 +938,22 @@ public class GcsService {
             throw GcpException.invalidArgument(
                     "Content-Range total size does not match uploaded bytes: " + totalSize);
         }
+        return finishResumableUpload(uploadId, upload, combined, baseUrl);
+    }
+
+    public CompletedResumableUpload completedResumableUpload(String uploadId) {
+        return completedResumableUploads.get(uploadId);
+    }
+
+    private GcsObjectMeta finishResumableUpload(String uploadId, ResumableUpload upload, byte[] data, String baseUrl) {
         resumableUploads.remove(uploadId);
-        return putObject(upload.bucket(), upload.objectName(), upload.contentType(), combined,
+        GcsObjectMeta meta = putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
                 upload.preconditions(), baseUrl);
+        completedResumableUploads.put(uploadId,
+                new CompletedResumableUpload(upload.bucket(), upload.objectName(), meta));
+        LOG.debugf("finishResumableUpload uploadId=%s size=%d", uploadId, data.length);
+        return meta;
     }
 
     private static void validateResumableTotalSize(ResumableUpload upload, Long totalSize) {
@@ -949,6 +965,13 @@ public class GcsService {
 
     private static byte[] appendChunk(ResumableUpload upload, long start, byte[] data) {
         byte[] existing = upload.data();
+        if (start > existing.length) {
+            throw GcpException.unavailable("Invalid request. According to the Content-Range header, the upload offset is "
+                    + start + " byte(s), which exceeds already uploaded size of " + existing.length + " byte(s).");
+        }
+        if (start + data.length <= existing.length) {
+            return existing;
+        }
         if (start != existing.length) {
             throw GcpException.invalidArgument("Content-Range start does not match uploaded bytes: " + start);
         }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -87,13 +87,18 @@ public class GcsUploadController {
     }
 
     private Response resumableChunk(String uploadId, HttpHeaders headers, UriInfo uriInfo, byte[] body) {
-        CompletedResumableUpload completed = service.completedResumableUpload(uploadId);
-        if (completed != null) {
+        ResumableUpload upload = service.findResumableUpload(uploadId);
+        if (upload == null) {
+            // The active session is dropped only after the completed one is recorded, so
+            // reading the completed map after this miss cannot land in a gap.
+            CompletedResumableUpload completed = service.completedResumableUpload(uploadId);
+            if (completed == null) {
+                throw GcpException.notFound("Resumable upload not found: " + uploadId);
+            }
             authorizationService.requireObjectWrite(
                     headers.getHeaderString(HttpHeaders.AUTHORIZATION), completed.bucket(), completed.objectName());
             return Response.ok(completed.meta()).build();
         }
-		ResumableUpload upload = service.getResumableUpload(uploadId);
 		authorizationService.requireObjectWrite(
 				headers.getHeaderString(HttpHeaders.AUTHORIZATION), upload.bucket(), upload.objectName());
         String contentRange = headers.getHeaderString("Content-Range");

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
+import io.floci.gcp.services.gcs.model.CompletedResumableUpload;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import io.floci.gcp.services.gcs.model.ResumableUpload;
@@ -47,6 +48,7 @@ public class GcsUploadController {
     public Response upload(
             @PathParam("bucket") String bucket,
             @QueryParam("uploadType") String uploadType,
+            @QueryParam("upload_id") String uploadId,
             @QueryParam("name") String nameParam,
             @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
             @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
@@ -55,6 +57,9 @@ public class GcsUploadController {
             @jakarta.ws.rs.core.Context HttpHeaders headers,
             @jakarta.ws.rs.core.Context UriInfo uriInfo,
             byte[] body) {
+        if (uploadId != null && !uploadId.isBlank()) {
+            return resumableChunk(uploadId, headers, uriInfo, body);
+        }
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         if ("multipart".equals(uploadType)) {
@@ -75,8 +80,18 @@ public class GcsUploadController {
             @jakarta.ws.rs.core.Context HttpHeaders headers,
             @jakarta.ws.rs.core.Context UriInfo uriInfo,
             byte[] body) {
-        if (uploadId == null) {
+        if (uploadId == null || uploadId.isBlank()) {
             throw GcpException.invalidArgument("missing upload_id query parameter");
+        }
+        return resumableChunk(uploadId, headers, uriInfo, body);
+    }
+
+    private Response resumableChunk(String uploadId, HttpHeaders headers, UriInfo uriInfo, byte[] body) {
+        CompletedResumableUpload completed = service.completedResumableUpload(uploadId);
+        if (completed != null) {
+            authorizationService.requireObjectWrite(
+                    headers.getHeaderString(HttpHeaders.AUTHORIZATION), completed.bucket(), completed.objectName());
+            return Response.ok(completed.meta()).build();
         }
 		ResumableUpload upload = service.getResumableUpload(uploadId);
 		authorizationService.requireObjectWrite(
@@ -91,7 +106,7 @@ public class GcsUploadController {
                             uploadId, range.totalSize(), requestBaseUrl(headers, uriInfo));
                     return Response.ok(meta).build();
                 }
-                Response.ResponseBuilder response = Response.status(308);
+                Response.ResponseBuilder response = resumeIncomplete(headers);
                 if (uploadedLength > 0) {
                     response.header("Range", "bytes=0-" + (uploadedLength - 1));
                 }
@@ -99,11 +114,11 @@ public class GcsUploadController {
             }
             if (range.totalSize() == null) {
                 long end = service.appendResumableUpload(uploadId, range.start(), body);
-                return Response.status(308).header("Range", "bytes=0-" + end).build();
+                return resumeIncomplete(headers).header("Range", "bytes=0-" + end).build();
             }
             if (range.end() + 1 < range.totalSize()) {
                 long end = service.appendResumableUpload(uploadId, range.start(), body, range.totalSize());
-                return Response.status(308).header("Range", "bytes=0-" + end).build();
+                return resumeIncomplete(headers).header("Range", "bytes=0-" + end).build();
             }
             GcsObjectMeta meta = service.completeResumableUpload(
                     uploadId, range.start(), body, range.totalSize(), requestBaseUrl(headers, uriInfo));
@@ -111,6 +126,15 @@ public class GcsUploadController {
         }
         GcsObjectMeta meta = service.completeResumableUpload(uploadId, body, requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
+    }
+
+    // The Go SDK sets X-GUploader-No-308 because 308 collides with the RFC 7238
+    // "Permanent Redirect" semantics, and expects 200 with the override header instead.
+    private static Response.ResponseBuilder resumeIncomplete(HttpHeaders headers) {
+        if ("yes".equalsIgnoreCase(headers.getHeaderString("X-GUploader-No-308"))) {
+            return Response.ok().header("X-HTTP-Status-Code-Override", "308");
+        }
+        return Response.status(308);
     }
 
     private record ContentRange(long start, long end, Long totalSize, boolean statusQuery) {}
@@ -196,6 +220,10 @@ public class GcsUploadController {
 
     private Response handleStartResumable(String bucket, String nameParam, HttpHeaders headers, UriInfo uriInfo, byte[] body,
             GcsObjectPreconditions preconditions) {
+        String requestContentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        if (body != null && body.length > 0 && !isJsonContentType(requestContentType)) {
+            throw GcpException.invalidArgument("Unsupported content with type: " + mediaType(requestContentType));
+        }
         String contentType = headers.getHeaderString("X-Upload-Content-Type");
         String name = nameParam;
         Map<String, String> userMetadata = null;
@@ -242,6 +270,15 @@ public class GcsUploadController {
         GcsObjectMeta meta = service.putObject(bucket, name, contentType, body,
                 GcsCustomerEncryption.fromHeaders(headers), preconditions, requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
+    }
+
+    private static String mediaType(String contentType) {
+        int parameters = contentType.indexOf(';');
+        return parameters < 0 ? contentType.trim() : contentType.substring(0, parameters).trim();
+    }
+
+    private static boolean isJsonContentType(String contentType) {
+        return contentType == null || contentType.isBlank() || contentType.toLowerCase().contains("json");
     }
 
     private String requestBaseUrl(HttpHeaders headers, UriInfo uriInfo) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -5,8 +5,10 @@ import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.CompletedResumableUpload;
+import io.floci.gcp.services.gcs.model.GcsContentRange;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
+import io.floci.gcp.services.gcs.model.ResumableChunkOutcome;
 import io.floci.gcp.services.gcs.model.ResumableUpload;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -88,49 +90,38 @@ public class GcsUploadController {
 
     private Response resumableChunk(String uploadId, HttpHeaders headers, UriInfo uriInfo, byte[] body) {
         ResumableUpload upload = service.findResumableUpload(uploadId);
-        if (upload == null) {
+        String bucket;
+        String objectName;
+        if (upload != null) {
+            bucket = upload.bucket();
+            objectName = upload.objectName();
+        } else {
             // The active session is dropped only after the completed one is recorded, so
             // reading the completed map after this miss cannot land in a gap.
             CompletedResumableUpload completed = service.completedResumableUpload(uploadId);
             if (completed == null) {
                 throw GcpException.notFound("Resumable upload not found: " + uploadId);
             }
-            authorizationService.requireObjectWrite(
-                    headers.getHeaderString(HttpHeaders.AUTHORIZATION), completed.bucket(), completed.objectName());
-            return Response.ok(completed.meta()).build();
+            bucket = completed.bucket();
+            objectName = completed.objectName();
         }
-		authorizationService.requireObjectWrite(
-				headers.getHeaderString(HttpHeaders.AUTHORIZATION), upload.bucket(), upload.objectName());
+        authorizationService.requireObjectWrite(
+                headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, objectName);
+
         String contentRange = headers.getHeaderString("Content-Range");
-        if (contentRange != null && !contentRange.isBlank()) {
-            ContentRange range = parseContentRange(contentRange, body.length);
-            if (range.statusQuery()) {
-                long uploadedLength = service.resumableUploadLength(uploadId);
-                if (range.totalSize() != null && uploadedLength == range.totalSize()) {
-                    GcsObjectMeta meta = service.completeBufferedResumableUpload(
-                            uploadId, range.totalSize(), requestBaseUrl(headers, uriInfo));
-                    return Response.ok(meta).build();
-                }
-                Response.ResponseBuilder response = resumeIncomplete(headers);
-                if (uploadedLength > 0) {
-                    response.header("Range", "bytes=0-" + (uploadedLength - 1));
-                }
-                return response.build();
-            }
-            if (range.totalSize() == null) {
-                long end = service.appendResumableUpload(uploadId, range.start(), body);
-                return resumeIncomplete(headers).header("Range", "bytes=0-" + end).build();
-            }
-            if (range.end() + 1 < range.totalSize()) {
-                long end = service.appendResumableUpload(uploadId, range.start(), body, range.totalSize());
-                return resumeIncomplete(headers).header("Range", "bytes=0-" + end).build();
-            }
-            GcsObjectMeta meta = service.completeResumableUpload(
-                    uploadId, range.start(), body, range.totalSize(), requestBaseUrl(headers, uriInfo));
-            return Response.ok(meta).build();
+        GcsContentRange range = contentRange != null && !contentRange.isBlank()
+                ? parseContentRange(contentRange, body.length)
+                : null;
+        ResumableChunkOutcome outcome = service.applyResumableChunk(
+                uploadId, range, body, requestBaseUrl(headers, uriInfo));
+        if (outcome.completed() != null) {
+            return Response.ok(outcome.completed()).build();
         }
-        GcsObjectMeta meta = service.completeResumableUpload(uploadId, body, requestBaseUrl(headers, uriInfo));
-        return Response.ok(meta).build();
+        Response.ResponseBuilder response = resumeIncomplete(headers);
+        if (outcome.receivedLength() > 0) {
+            response.header("Range", "bytes=0-" + (outcome.receivedLength() - 1));
+        }
+        return response.build();
     }
 
     // The Go SDK sets X-GUploader-No-308 because 308 collides with the RFC 7238
@@ -142,9 +133,7 @@ public class GcsUploadController {
         return Response.status(308);
     }
 
-    private record ContentRange(long start, long end, Long totalSize, boolean statusQuery) {}
-
-    private static ContentRange parseContentRange(String header, int bodyLength) {
+    private static GcsContentRange parseContentRange(String header, int bodyLength) {
         if (!header.startsWith("bytes ")) {
             throw GcpException.invalidArgument("invalid Content-Range header: " + header);
         }
@@ -155,7 +144,7 @@ public class GcsUploadController {
             }
             String totalValue = value.substring(2);
             Long totalSize = "*".equals(totalValue) ? null : parseLong(totalValue, header);
-            return new ContentRange(0, -1, totalSize, true);
+            return new GcsContentRange(0, -1, totalSize, true);
         }
         int dash = value.indexOf('-');
         int slash = value.indexOf('/');
@@ -183,7 +172,7 @@ public class GcsUploadController {
         if (totalSize != null && end >= totalSize) {
             throw GcpException.invalidArgument("invalid Content-Range header: " + header);
         }
-        return new ContentRange(start, end, totalSize, false);
+        return new GcsContentRange(start, end, totalSize, false);
     }
 
     private static long parseLong(String value, String header) {

--- a/src/main/java/io/floci/gcp/services/gcs/model/CompletedResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/CompletedResumableUpload.java
@@ -1,0 +1,3 @@
+package io.floci.gcp.services.gcs.model;
+
+public record CompletedResumableUpload(String bucket, String objectName, GcsObjectMeta meta) {}

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsContentRange.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsContentRange.java
@@ -1,0 +1,3 @@
+package io.floci.gcp.services.gcs.model;
+
+public record GcsContentRange(long start, long end, Long totalSize, boolean statusQuery) {}

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableChunkOutcome.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableChunkOutcome.java
@@ -1,0 +1,12 @@
+package io.floci.gcp.services.gcs.model;
+
+public record ResumableChunkOutcome(GcsObjectMeta completed, long receivedLength) {
+
+    public static ResumableChunkOutcome completed(GcsObjectMeta meta) {
+        return new ResumableChunkOutcome(meta, 0);
+    }
+
+    public static ResumableChunkOutcome incomplete(long receivedLength) {
+        return new ResumableChunkOutcome(null, receivedLength);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsObjectPreconditionTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsObjectPreconditionTest.java
@@ -98,8 +98,8 @@ class GcsObjectPreconditionTest {
         service.putObject(BUCKET, OBJECT, "text/plain", competing, BASE_URL);
 
         GcpException exception = assertThrows(GcpException.class,
-                () -> service.completeResumableUpload(
-                        uploadId, "original".getBytes(StandardCharsets.UTF_8), BASE_URL));
+                () -> service.applyResumableChunk(
+                        uploadId, null, "original".getBytes(StandardCharsets.UTF_8), BASE_URL));
 
         assertEquals(412, exception.getHttpStatus());
         assertArrayEquals(competing, service.getObjectData(BUCKET, OBJECT));
@@ -113,8 +113,8 @@ class GcsObjectPreconditionTest {
         String uploadId = service.startResumableUpload(BUCKET, OBJECT, "text/plain", GcsCustomerEncryption.none(), createOnly);
 
         GcpException exception = assertThrows(GcpException.class,
-                () -> service.completeResumableUpload(
-                        uploadId, "replacement".getBytes(StandardCharsets.UTF_8), BASE_URL));
+                () -> service.applyResumableChunk(
+                        uploadId, null, "replacement".getBytes(StandardCharsets.UTF_8), BASE_URL));
         assertEquals(412, exception.getHttpStatus());
         assertArrayEquals("existing".getBytes(StandardCharsets.UTF_8), service.getObjectData(BUCKET, OBJECT));
     }

--- a/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
@@ -1,0 +1,238 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class GcsResumableSessionRestIntegrationTest {
+
+    private static final String BUCKET = "resumable-session-bucket";
+
+    private static void ensureBucket() {
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project");
+    }
+
+    private static String startUpload(String objectName) {
+        var location = given()
+                .contentType("application/json")
+                .body(Map.of("name", objectName))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+        return location.substring(location.indexOf("upload_id=") + "upload_id=".length());
+    }
+
+    private static String sessionPath(String uploadId) {
+        return "/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&upload_id=" + uploadId;
+    }
+
+    @Test
+    void postChunksContinueTheSameSession() {
+        ensureBucket();
+        var uploadId = startUpload("post-chunked-obj");
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 4-5/6")
+                .body("ok".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .body("name", equalTo("post-chunked-obj"))
+                .body("size", equalTo("6"));
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/post-chunked-obj?alt=media")
+                .then().statusCode(200)
+                .body(equalTo("testok"));
+    }
+
+    @Test
+    void postStatusQueryReportsReceivedBytes() {
+        ensureBucket();
+        var uploadId = startUpload("post-status-obj");
+
+        given()
+                .header("Content-Range", "bytes */6")
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(308)
+                .header("Range", equalTo(null));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(308);
+
+        given()
+                .header("Content-Range", "bytes */6")
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+    }
+
+    @Test
+    void resentChunkIsAcknowledgedWithoutAppending() {
+        ensureBucket();
+        var uploadId = startUpload("resent-chunk-obj");
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(308)
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 4-5/6")
+                .body("ok".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .body("size", equalTo("6"));
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/resent-chunk-obj?alt=media")
+                .then().statusCode(200)
+                .body(equalTo("testok"));
+    }
+
+    @Test
+    void chunkPastTheReceivedBytesIsRetryable() {
+        ensureBucket();
+        var uploadId = startUpload("gap-chunk-obj");
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 4-5/6")
+                .body("ok".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(503)
+                .body("error.status", equalTo("UNAVAILABLE"));
+    }
+
+    @Test
+    void completedSessionReplaysTheObjectMetadata() {
+        ensureBucket();
+        var uploadId = startUpload("completed-session-obj");
+
+        var generation = given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-5/6")
+                .body("testok".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .extract().path("generation").toString();
+
+        given()
+                .header("Content-Range", "bytes */6")
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .body("generation", equalTo(generation));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-5/6")
+                .body("testok".getBytes(StandardCharsets.UTF_8))
+                .when().put(sessionPath(uploadId))
+                .then().statusCode(200)
+                .body("generation", equalTo(generation));
+    }
+
+    @Test
+    void resumeIncompleteIsOverriddenForClientsThatOptOutOf308() {
+        ensureBucket();
+        var uploadId = startUpload("no-308-obj");
+
+        given()
+                .contentType("application/octet-stream")
+                .header("X-GUploader-No-308", "yes")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .header("X-HTTP-Status-Code-Override", equalTo("308"))
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .header("X-GUploader-No-308", "yes")
+                .header("Content-Range", "bytes */6")
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .header("X-HTTP-Status-Code-Override", equalTo("308"))
+                .header("Range", equalTo("bytes=0-3"));
+
+        given()
+                .contentType("application/octet-stream")
+                .header("X-GUploader-No-308", "yes")
+                .header("Content-Range", "bytes 4-5/6")
+                .body("ok".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .header("X-HTTP-Status-Code-Override", equalTo(null))
+                .body("size", equalTo("6"));
+    }
+
+    @Test
+    void optingOutOf308LeavesOtherStatusesAlone() {
+        ensureBucket();
+        var uploadId = startUpload("no-308-gap-obj");
+
+        given()
+                .contentType("application/octet-stream")
+                .header("X-GUploader-No-308", "yes")
+                .header("Content-Range", "bytes 4-5/6")
+                .body("ok".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(503);
+    }
+
+    @Test
+    void resumableInitRejectsANonJsonBody() {
+        ensureBucket();
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&name=stray-chunk-obj")
+                .then().statusCode(400)
+                .body("error.message", equalTo("Unsupported content with type: application/octet-stream"));
+    }
+
+    @Test
+    void unknownUploadIdIsNotFound() {
+        ensureBucket();
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-3/6")
+                .body("test".getBytes(StandardCharsets.UTF_8))
+                .when().post(sessionPath("does-not-exist"))
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @QuarkusTest
@@ -246,6 +247,37 @@ class GcsResumableSessionRestIntegrationTest {
         poller.join();
 
         assertFalse(observed.contains(404), "a status query saw the session disappear: " + observed);
+    }
+
+    @Test
+    void concurrentFinalChunksStoreTheObjectOnce() throws Exception {
+        ensureBucket();
+        var uploadId = startUpload("concurrent-final-obj");
+        var payload = new byte[2 * 1024 * 1024];
+        Set<String> generations = ConcurrentHashMap.newKeySet();
+
+        Runnable finalChunk = () -> generations.add(given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-" + (payload.length - 1) + "/" + payload.length)
+                .body(payload)
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200)
+                .extract().path("generation").toString());
+
+        var first = new Thread(finalChunk);
+        var second = new Thread(finalChunk);
+        first.start();
+        second.start();
+        first.join();
+        second.join();
+
+        assertEquals(1, generations.size(), "the session was persisted more than once: " + generations);
+
+        given()
+                .when().get("/storage/v1/b/" + BUCKET + "/o/concurrent-final-obj")
+                .then().statusCode(200)
+                .body("generation", equalTo(generations.iterator().next()))
+                .body("size", equalTo(String.valueOf(payload.length)));
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
@@ -5,9 +5,13 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @QuarkusTest
 class GcsResumableSessionRestIntegrationTest {
@@ -211,6 +215,37 @@ class GcsResumableSessionRestIntegrationTest {
                 .body("ok".getBytes(StandardCharsets.UTF_8))
                 .when().post(sessionPath(uploadId))
                 .then().statusCode(503);
+    }
+
+    @Test
+    void statusQueriesOverlappingFinalizationNeverSeeAMissingSession() throws Exception {
+        ensureBucket();
+        var uploadId = startUpload("concurrent-finalize-obj");
+        var payload = new byte[4 * 1024 * 1024];
+        Set<Integer> observed = ConcurrentHashMap.newKeySet();
+        var finalized = new AtomicBoolean(false);
+
+        var poller = new Thread(() -> {
+            while (!finalized.get()) {
+                observed.add(given()
+                        .header("Content-Range", "bytes */" + payload.length)
+                        .when().post(sessionPath(uploadId))
+                        .getStatusCode());
+            }
+        });
+        poller.start();
+
+        given()
+                .contentType("application/octet-stream")
+                .header("Content-Range", "bytes 0-" + (payload.length - 1) + "/" + payload.length)
+                .body(payload)
+                .when().post(sessionPath(uploadId))
+                .then().statusCode(200);
+
+        finalized.set(true);
+        poller.join();
+
+        assertFalse(observed.contains(404), "a status query saw the session disappear: " + observed);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #122.

`GcsUploadController.upload()` dispatched on `uploadType` and ignored `upload_id`, so a POST to a session URL started a new upload. Every chunk POST opened a fresh session and no object was created. The Go SDK sends chunks with POST, so its chunked uploads never completed.

Chunk handling now keys off `upload_id` for both POST and PUT. Four more session behaviors were wrong on SDK retry paths:

| Case | Before | Now, matching GCS |
|---|---|---|
| Request to a completed session | 404 | 200 with the object metadata |
| Resent chunk | 400 | 308 with the unchanged range |
| Chunk past the received bytes | 400 | 503 |
| `X-GUploader-No-308: yes` | 308 | 200 with `X-HTTP-Status-Code-Override: 308` |

The last row is what unblocks the Go SDK. It sets that header on every chunk and fails with `unexpected 308 response status code` otherwise, so the routing fix alone was not enough.

Two smaller changes. A resumable init with a non-JSON body now returns 400 like GCS, instead of silently opening an empty session. The completed session is recorded before the active one is dropped, so a retry overlapping persistence no longer sees 404.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Sent the same 44 requests to live GCS and to this build on 2026-08-23. 42 gave the same status code, `Range`, `X-HTTP-Status-Code-Override` and body. The other two differ on purpose and are documented in `docs/services/gcs.md`:

- A chunk POST without `uploadType` gets 405 on GCS. Accepted here, since `upload_id` identifies the session.
- GCS drops a session after a chunk that breaks its 256 KiB alignment rule. Chunk alignment is not enforced here.

Logged the requests each SDK sends, through a proxy in front of the emulator. All five open the session with the same POST and send chunks to the session URL. GCS accepts both methods, and the comparison above got the same responses for POST and PUT.

| SDK | Chunk method | Finalization |
|---|---|---|
| Python 3.13.1 | PUT | empty `bytes */total` |
| Node 7.x | PUT | last data chunk with the total |
| Java 2.47 | PUT | empty `bytes */total` |
| Go 1.62 | POST with `X-GUploader-No-308` | empty `bytes */total` |
| Rust 1.17 | PUT | last data chunk with the total |

The two ways of finalizing hit different service methods, `completeBufferedResumableUpload` and `completeResumableUpload`.

## Checklist

- [x] `./mvnw test` passes locally (718 tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Added `GcsResumableSessionRestIntegrationTest` (10 cases, including a status query that overlaps finalization), POST-chunk and gap cases in `sdk-test-java/GcsResumableUploadRawTest`, and multi-chunk uploads in the Go, Python, Node and Rust suites. Only the Go one reproduces this bug. The other three pass on main and cover the PUT chunk path against regressions.

The `sdk-test-java` raw HTTP tests could not run locally. Every test in `GcsResumableUploadRawTest` fails there with `java.net.ConnectException` from the JDK HttpClient, including the tests already on main and also against the 0.7.0 image, so it is not caused by this change. The same requests were sent to the Docker image with another client instead.
