### PR TITLE
fix(gcs): serve the resumable offset gap as text/plain

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableOffsetGapRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsResumableOffsetGapRawTest.java
@@ -1,0 +1,83 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A chunk whose offset sits past the bytes the backend holds is a client-side data loss, not a
+ * transient failure. Real GCS reports it as a 503 with a {@code text/plain} body, and the Java SDK
+ * keys on exactly that shape in {@code JsonResumableSessionPutTask} to fail fast instead of
+ * retrying. The SDK class is package private, so this asserts the wire shape it inspects.
+ */
+class GcsResumableOffsetGapRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("offset-gap-bucket");
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void chunkPastTheReceivedBytesIsPlainText() throws Exception {
+        URI session = URI.create(startResumableSession());
+
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(session)
+                        .header("Content-Type", "application/octet-stream")
+                        .header("Content-Range", "bytes 4-5/6")
+                        .PUT(HttpRequest.BodyPublishers.ofString("ok"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(503);
+        assertThat(response.headers().firstValue("Content-Type")).hasValue("text/plain; charset=utf-8");
+        assertThat(response.headers().firstValueAsLong("Content-Length")).hasValue(138);
+        // Byte for byte what live GCS returned on 2026-08-27, double space included.
+        assertThat(response.body()).isEqualTo(
+                "Invalid request.  According to the Content-Range header, the upload offset is "
+                        + "4 byte(s), which exceeds already uploaded size of 0 byte(s).");
+
+        String body = response.body().toLowerCase(Locale.US);
+        assertThat(body).contains("content-range");
+        // The SDK reads "earlier" as the rewind case, a separate scenario it does retry.
+        assertThat(body).doesNotContain("earlier");
+    }
+
+    private static String startResumableSession() throws Exception {
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable&name=offset-gap.bin");
+        HttpResponse<String> response = CLIENT.send(
+                HttpRequest.newBuilder(uri)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}", StandardCharsets.UTF_8))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        return response.headers().firstValue("Location").orElseThrow();
+    }
+}

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -166,9 +166,22 @@ Session behavior matches GCS:
 | Chunk that completes the object | `200` with the object metadata |
 | Status query (`Content-Range: bytes */<total>` or `bytes */*`) | `308` with the received range, or `200` with the object metadata once complete |
 | Chunk already received in full | `308` with the unchanged received range, without appending it again |
-| Chunk starting past the received bytes | `503`, so the client re-syncs with a status query |
+| Chunk starting past the received bytes | `503` with a `text/plain` body, matching GCS |
 | Any request after completion | `200` with the stored object metadata |
 | Unknown or expired `upload_id` | `404` |
+
+The offset gap is the one session error GCS does not serve as JSON. Its body is the bare
+message as `text/plain`, and the Java SDK sniffs that content type to tell a client-side
+data loss apart from a transient `503`, failing fast rather than retrying. floci-gcp
+reproduces the response byte for byte, down to the double space after `Invalid request.`:
+
+```
+HTTP/1.1 503 Service Unavailable
+content-type: text/plain; charset=utf-8
+content-length: 138
+
+Invalid request.  According to the Content-Range header, the upload offset is 4 byte(s), which exceeds already uploaded size of 0 byte(s).
+```
 
 The Go SDK sends `X-GUploader-No-308: yes` because `308` collides with the RFC 7238
 "Permanent Redirect" semantics. floci-gcp answers those requests the way GCS does: `200`

--- a/src/main/java/io/floci/gcp/core/common/GcpException.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpException.java
@@ -12,18 +12,20 @@ public class GcpException extends RuntimeException {
     private final String gcpStatus;
     private final Status.Code grpcCode;
     private final String reason;
+    private final boolean plainText;
 
     private GcpException(int httpStatus, String gcpStatus, Status.Code grpcCode, String message) {
-        this(httpStatus, gcpStatus, grpcCode, message, null);
+        this(httpStatus, gcpStatus, grpcCode, message, null, false);
     }
 
     private GcpException(int httpStatus, String gcpStatus, Status.Code grpcCode, String message,
-                         String reason) {
+                         String reason, boolean plainText) {
         super(message);
         this.httpStatus = httpStatus;
         this.gcpStatus = gcpStatus;
         this.grpcCode = grpcCode;
         this.reason = reason;
+        this.plainText = plainText;
     }
 
     public int getHttpStatus() {
@@ -44,7 +46,21 @@ public class GcpException extends RuntimeException {
     }
 
     public GcpException withReason(String reason) {
-        return new GcpException(httpStatus, gcpStatus, grpcCode, getMessage(), reason);
+        return new GcpException(httpStatus, gcpStatus, grpcCode, getMessage(), reason, plainText);
+    }
+
+    /** True when the REST body must be the bare message as {@code text/plain}, not the JSON error shape. */
+    public boolean isPlainText() {
+        return plainText;
+    }
+
+    /**
+     * Renders this error as a {@code text/plain} body carrying only the message. Real GCS serves a
+     * handful of errors that way, and SDKs classify them by sniffing the content type, so the JSON
+     * error shape would change how a client reacts.
+     */
+    public GcpException asPlainText() {
+        return new GcpException(httpStatus, gcpStatus, grpcCode, getMessage(), reason, true);
     }
 
     public static GcpException notFound(String message) {

--- a/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
+++ b/src/main/java/io/floci/gcp/core/common/GcpExceptionMapper.java
@@ -2,6 +2,7 @@ package io.floci.gcp.core.common;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -17,12 +18,24 @@ import java.util.List;
  * </pre>
  * The nested {@code errors[]} array (with {@code domain} and {@code reason}) mirrors the
  * legacy Google JSON API error format that some SDK retry/handling logic inspects.
+ *
+ * <p>Errors flagged with {@link GcpException#asPlainText()} skip that shape and carry the bare
+ * message as {@code text/plain}, matching the few responses real GCS serves that way.
  */
 @Provider
 public class GcpExceptionMapper implements ExceptionMapper<GcpException> {
 
+    /** Spelled out rather than built from {@link MediaType}, which drops the space and upper cases the charset. */
+    private static final String PLAIN_TEXT_CONTENT_TYPE = "text/plain; charset=utf-8";
+
     @Override
     public Response toResponse(GcpException ex) {
+        if (ex.isPlainText()) {
+            return Response.status(ex.getHttpStatus())
+                    .header(HttpHeaders.CONTENT_TYPE, PLAIN_TEXT_CONTENT_TYPE)
+                    .entity(ex.getMessage())
+                    .build();
+        }
         String reason = ex.getReason() != null ? ex.getReason() : reasonFor(ex.getGcpStatus());
         return Response.status(ex.getHttpStatus())
                 .type(MediaType.APPLICATION_JSON)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -940,8 +940,13 @@ public class GcsService {
     private static byte[] appendChunk(ResumableUpload upload, long start, byte[] data) {
         byte[] existing = upload.data();
         if (start > existing.length) {
-            throw GcpException.unavailable("Invalid request. According to the Content-Range header, the upload offset is "
-                    + start + " byte(s), which exceeds already uploaded size of " + existing.length + " byte(s).");
+            // Real GCS serves this one as text/plain. The Java SDK sniffs that content type to
+            // recognize the offset gap (JsonResumableSessionPutTask) and fails fast, so a JSON
+            // body would make it spend its whole retry budget on an error that never clears.
+            // The double space after "Invalid request." is what the live service sends.
+            throw GcpException.unavailable("Invalid request.  According to the Content-Range header, the upload offset is "
+                    + start + " byte(s), which exceeds already uploaded size of " + existing.length + " byte(s).")
+                    .asPlainText();
         }
         if (start + data.length <= existing.length) {
             return existing;

--- a/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
+++ b/src/test/java/io/floci/gcp/core/common/GcpExceptionMapperTest.java
@@ -79,6 +79,29 @@ class GcpExceptionMapperTest {
     }
 
     @Test
+    void plainTextErrorsCarryTheBareMessage() {
+        GcpException ex = GcpException.unavailable("upload offset is 4 byte(s)").asPlainText();
+        var response = new GcpExceptionMapper().toResponse(ex);
+
+        assertEquals(503, response.getStatus());
+        // Spelled out the way live GCS sends it, rather than however MediaType would render it.
+        assertEquals("text/plain; charset=utf-8", response.getHeaderString("Content-Type"));
+        assertEquals("upload offset is 4 byte(s)", response.getEntity());
+    }
+
+    @Test
+    void plainTextFlagSurvivesWithReason() {
+        GcpException ex = GcpException.unavailable("gap").asPlainText().withReason("backendError");
+        assertTrue(ex.isPlainText());
+        assertEquals("backendError", ex.getReason());
+    }
+
+    @Test
+    void errorsAreJsonUnlessFlagged() {
+        assertFalse(GcpException.unavailable("gap").isPlainText());
+    }
+
+    @Test
     void reasonIsDerivedFromStatus() {
         assertEquals("alreadyExists",
                 GcpExceptionMapper.ErrorDetail.of(409, "x", "ALREADY_EXISTS").errors().get(0).reason());

--- a/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsResumableSessionRestIntegrationTest.java
@@ -4,6 +4,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -128,18 +129,28 @@ class GcsResumableSessionRestIntegrationTest {
                 .body(equalTo("testok"));
     }
 
+    // Real GCS serves the offset gap as text/plain, and the Java SDK keys on that content type
+    // plus the words in the body to fail fast instead of retrying (JsonResumableSessionPutTask).
     @Test
-    void chunkPastTheReceivedBytesIsRetryable() {
+    void chunkPastTheReceivedBytesIsPlainText() {
         ensureBucket();
         var uploadId = startUpload("gap-chunk-obj");
 
-        given()
+        var body = given()
                 .contentType("application/octet-stream")
                 .header("Content-Range", "bytes 4-5/6")
                 .body("ok".getBytes(StandardCharsets.UTF_8))
                 .when().post(sessionPath(uploadId))
                 .then().statusCode(503)
-                .body("error.status", equalTo("UNAVAILABLE"));
+                .header("Content-Type", equalTo("text/plain; charset=utf-8"))
+                .header("Content-Length", equalTo("138"))
+                .extract().body().asString();
+
+        // Byte for byte what live GCS returned on 2026-08-27, double space included.
+        assertEquals("Invalid request.  According to the Content-Range header, the upload offset is "
+                + "4 byte(s), which exceeds already uploaded size of 0 byte(s).", body);
+        // The SDK reads "earlier" as the rewind case, which is a different scenario it does retry.
+        assertFalse(body.toLowerCase(Locale.US).contains("earlier"));
     }
 
     @Test
@@ -215,7 +226,8 @@ class GcsResumableSessionRestIntegrationTest {
                 .header("Content-Range", "bytes 4-5/6")
                 .body("ok".getBytes(StandardCharsets.UTF_8))
                 .when().post(sessionPath(uploadId))
-                .then().statusCode(503);
+                .then().statusCode(503)
+                .header("Content-Type", equalTo("text/plain; charset=utf-8"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/floci-io/floci-gcp/pull/132#pullrequestreview-5026255524

> (follow-up, separate PR) One small parity note on the offset gap 503. Real GCS serves it as plain text, and the Java SDK classifies that exact scenario by sniffing the text/plain content type ([JsonResumableSessionPutTask.java](https://github.com/googleapis/google-cloud-java/blob/e5e5f141677/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java#L217-L231)), failing fast instead of retrying. Our JSON error body means java-storage would burn its retry budget on it. Your message text already matches the real service word for word, so serving just this error as text/plain would complete the picture.

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Real GCS returns a chunk whose offset sits past the received bytes with a 503 carrying a plain text body. The Java SDK sniffs that content type in JsonResumableSessionPutTask and fails fast, so the JSON error shape made java-storage retry an error that never clears.

Checked against live GCS. The content type is "text/plain; charset=utf-8" and the message carries a double space after "Invalid request.", which puts the body at 138 bytes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
