### PR TITLE
fix(firestore): resolve nested query field paths

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirestoreTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirestoreTest.java
@@ -250,4 +250,34 @@ class FirestoreTest {
             docRef.delete().get();
         }
     }
+
+    @Test
+    @Order(11)
+    void queryDocumentsByNestedMapField() throws ExecutionException, InterruptedException {
+        String collection = TestFixtures.uniqueName("nested-query");
+        DocumentReference matching = firestore.collection(collection).document("matching");
+        DocumentReference different = firestore.collection(collection).document("different");
+        DocumentReference missing = firestore.collection(collection).document("missing");
+
+        matching.set(Map.of("billing", Map.of("stripe_customer_id", "cus_matching"))).get();
+        different.set(Map.of("billing", Map.of("stripe_customer_id", "cus_different"))).get();
+        missing.set(Map.of("name", "No billing field")).get();
+
+        try {
+            List<String> documentIds = firestore.collection(collection)
+                    .whereEqualTo("billing.stripe_customer_id", "cus_matching")
+                    .get()
+                    .get()
+                    .getDocuments()
+                    .stream()
+                    .map(DocumentSnapshot::getId)
+                    .toList();
+
+            assertThat(documentIds).containsExactly("matching");
+        } finally {
+            matching.delete().get();
+            different.delete().get();
+            missing.delete().get();
+        }
+    }
 }

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -573,14 +574,17 @@ public class FirestoreService {
         String path = ff.getField().getFieldPath();
         StoredValue stored = resolveFieldPath(doc, path);
         Value filterValue = ff.getValue();
+        OptionalInt filterComparison = stored == null
+                ? OptionalInt.empty()
+                : compareFilterValues(stored, filterValue);
 
         return switch (ff.getOp()) {
             case EQUAL -> stored != null && stored.matchesEqual(filterValue);
             case NOT_EQUAL -> stored == null || !stored.matchesEqual(filterValue);
-            case LESS_THAN -> stored != null && compareValues(stored, filterValue) < 0;
-            case LESS_THAN_OR_EQUAL -> stored != null && compareValues(stored, filterValue) <= 0;
-            case GREATER_THAN -> stored != null && compareValues(stored, filterValue) > 0;
-            case GREATER_THAN_OR_EQUAL -> stored != null && compareValues(stored, filterValue) >= 0;
+            case LESS_THAN -> filterComparison.isPresent() && filterComparison.getAsInt() < 0;
+            case LESS_THAN_OR_EQUAL -> filterComparison.isPresent() && filterComparison.getAsInt() <= 0;
+            case GREATER_THAN -> filterComparison.isPresent() && filterComparison.getAsInt() > 0;
+            case GREATER_THAN_OR_EQUAL -> filterComparison.isPresent() && filterComparison.getAsInt() >= 0;
             case ARRAY_CONTAINS -> stored != null && "array".equals(stored.getType())
                     && stored.getArrayValue() != null
                     && stored.getArrayValue().stream().anyMatch(sv -> sv.matchesEqual(filterValue));
@@ -595,6 +599,48 @@ public class FirestoreService {
                     && filterValue.getArrayValue().getValuesList().stream()
                         .anyMatch(fv -> stored.getArrayValue().stream().anyMatch(sv -> sv.matchesEqual(fv)));
             default -> true;
+        };
+    }
+
+    /**
+     * Compares values for inequality filters. Unlike ordering and cursor comparison, an
+     * unsupported type pairing is explicitly incomparable and therefore cannot match an
+     * inclusive inequality merely because the ordering comparator returned zero.
+     */
+    private OptionalInt compareFilterValues(StoredValue stored, Value proto) {
+        return switch (proto.getValueTypeCase()) {
+            case INTEGER_VALUE -> {
+                if ("integer".equals(stored.getType()) && stored.getIntegerValue() != null)
+                    yield OptionalInt.of(Long.compare(stored.getIntegerValue(), proto.getIntegerValue()));
+                if ("double".equals(stored.getType()) && stored.getDoubleValue() != null)
+                    yield OptionalInt.of(Double.compare(stored.getDoubleValue(), (double) proto.getIntegerValue()));
+                yield OptionalInt.empty();
+            }
+            case DOUBLE_VALUE -> {
+                if ("double".equals(stored.getType()) && stored.getDoubleValue() != null)
+                    yield OptionalInt.of(Double.compare(stored.getDoubleValue(), proto.getDoubleValue()));
+                if ("integer".equals(stored.getType()) && stored.getIntegerValue() != null)
+                    yield OptionalInt.of(Double.compare((double) stored.getIntegerValue(), proto.getDoubleValue()));
+                yield OptionalInt.empty();
+            }
+            case STRING_VALUE -> {
+                if ("string".equals(stored.getType()) && stored.getStringValue() != null)
+                    yield OptionalInt.of(stored.getStringValue().compareTo(proto.getStringValue()));
+                yield OptionalInt.empty();
+            }
+            case TIMESTAMP_VALUE -> {
+                if ("timestamp".equals(stored.getType()) && stored.getStringValue() != null) {
+                    try {
+                        Instant a = Instant.parse(stored.getStringValue());
+                        Instant b = Instant.ofEpochSecond(
+                                proto.getTimestampValue().getSeconds(),
+                                proto.getTimestampValue().getNanos());
+                        yield OptionalInt.of(a.compareTo(b));
+                    } catch (Exception ignored) {}
+                }
+                yield OptionalInt.empty();
+            }
+            default -> OptionalInt.empty();
         };
     }
 

--- a/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
+++ b/src/main/java/io/floci/gcp/services/firestore/FirestoreService.java
@@ -355,8 +355,8 @@ public class FirestoreService {
         if ("__name__".equals(path)) {
             return a.getName().compareTo(b.getName());
         }
-        StoredValue va = a.getFields() != null ? a.getFields().get(path) : null;
-        StoredValue vb = b.getFields() != null ? b.getFields().get(path) : null;
+        StoredValue va = resolveFieldPath(a, path);
+        StoredValue vb = resolveFieldPath(b, path);
         if (va == null && vb == null) {
             return 0;
         }
@@ -421,7 +421,7 @@ public class FirestoreService {
             String target = value.hasReferenceValue() ? value.getReferenceValue() : value.getStringValue();
             return doc.getName().compareTo(target);
         }
-        StoredValue stored = doc.getFields() != null ? doc.getFields().get(path) : null;
+        StoredValue stored = resolveFieldPath(doc, path);
         if (stored == null) {
             return -1;
         }
@@ -571,7 +571,7 @@ public class FirestoreService {
 
     private boolean matchesFieldFilter(StoredDocument doc, StructuredQuery.FieldFilter ff) {
         String path = ff.getField().getFieldPath();
-        StoredValue stored = doc.getFields() != null ? doc.getFields().get(path) : null;
+        StoredValue stored = resolveFieldPath(doc, path);
         Value filterValue = ff.getValue();
 
         return switch (ff.getOp()) {
@@ -637,7 +637,7 @@ public class FirestoreService {
 
     private boolean matchesUnaryFilter(StoredDocument doc, StructuredQuery.UnaryFilter uf) {
         String path = uf.getField().getFieldPath();
-        StoredValue stored = doc.getFields() != null ? doc.getFields().get(path) : null;
+        StoredValue stored = resolveFieldPath(doc, path);
         return switch (uf.getOp()) {
             case IS_NULL -> stored != null && "null".equals(stored.getType());
             case IS_NOT_NULL -> stored != null && !"null".equals(stored.getType());
@@ -650,6 +650,22 @@ public class FirestoreService {
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private StoredValue resolveFieldPath(StoredDocument doc, String path) {
+        if (doc.getFields() == null) {
+            return null;
+        }
+
+        String[] segments = path.split("\\.", -1);
+        StoredValue value = doc.getFields().get(segments[0]);
+        for (int i = 1; i < segments.length; i++) {
+            if (value == null || !"map".equals(value.getType()) || value.getMapValue() == null) {
+                return null;
+            }
+            value = value.getMapValue().get(segments[i]);
+        }
+        return value;
+    }
 
     private Map<String, StoredValue> convertFields(Map<String, Value> protoFields) {
         Map<String, StoredValue> result = new LinkedHashMap<>();

--- a/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -126,6 +127,94 @@ class FirestoreServiceTest {
 
         assertEquals(List.of(DB + "/documents/customers/matching"),
                 results.stream().map(StoredDocument::getName).toList());
+    }
+
+    @Test
+    void nestedInclusiveInequalitiesRejectIncompatibleTypes() {
+        service.applyWrite(nestedValueDocument("number", "threshold",
+                Value.newBuilder().setIntegerValue(10).build()), Instant.now());
+        service.applyWrite(nestedValueDocument("string", "threshold",
+                Value.newBuilder().setStringValue("10").build()), Instant.now());
+        service.applyWrite(nestedValueDocument("boolean", "threshold",
+                Value.newBuilder().setBooleanValue(true).build()), Instant.now());
+
+        for (StructuredQuery.FieldFilter.Operator operator : List.of(
+                StructuredQuery.FieldFilter.Operator.LESS_THAN_OR_EQUAL,
+                StructuredQuery.FieldFilter.Operator.GREATER_THAN_OR_EQUAL)) {
+            List<StoredDocument> results = runNestedFilter(
+                    "billing.threshold", operator, Value.newBuilder().setIntegerValue(10).build());
+
+            assertEquals(List.of(DB + "/documents/customers/number"),
+                    results.stream().map(StoredDocument::getName).toList());
+        }
+    }
+
+    @Test
+    void nestedInclusiveInequalitiesPreserveNumericCrossComparison() {
+        service.applyWrite(nestedValueDocument("integer", "threshold",
+                Value.newBuilder().setIntegerValue(10).build()), Instant.now());
+        service.applyWrite(nestedValueDocument("double", "threshold",
+                Value.newBuilder().setDoubleValue(10.0).build()), Instant.now());
+        service.applyWrite(nestedValueDocument("different", "threshold",
+                Value.newBuilder().setDoubleValue(11.0).build()), Instant.now());
+
+        List<StoredDocument> results = runNestedFilter(
+                "billing.threshold",
+                StructuredQuery.FieldFilter.Operator.GREATER_THAN_OR_EQUAL,
+                Value.newBuilder().setDoubleValue(10.0).build());
+
+        assertEquals(Set.of(
+                        DB + "/documents/customers/integer",
+                        DB + "/documents/customers/double",
+                        DB + "/documents/customers/different"),
+                Set.copyOf(results.stream().map(StoredDocument::getName).toList()));
+    }
+
+    @Test
+    void nestedInclusiveInequalitiesPreserveSameTypeStringComparison() {
+        service.applyWrite(nestedValueDocument("alpha", "tier",
+                Value.newBuilder().setStringValue("alpha").build()), Instant.now());
+        service.applyWrite(nestedValueDocument("beta", "tier",
+                Value.newBuilder().setStringValue("beta").build()), Instant.now());
+        service.applyWrite(nestedValueDocument("number", "tier",
+                Value.newBuilder().setIntegerValue(0).build()), Instant.now());
+
+        List<StoredDocument> results = runNestedFilter(
+                "billing.tier",
+                StructuredQuery.FieldFilter.Operator.LESS_THAN_OR_EQUAL,
+                Value.newBuilder().setStringValue("beta").build());
+
+        assertEquals(List.of(
+                        DB + "/documents/customers/alpha",
+                        DB + "/documents/customers/beta"),
+                results.stream().map(StoredDocument::getName).toList());
+    }
+
+    private List<StoredDocument> runNestedFilter(String fieldPath,
+            StructuredQuery.FieldFilter.Operator operator, Value value) {
+        StructuredQuery query = StructuredQuery.newBuilder()
+                .addFrom(StructuredQuery.CollectionSelector.newBuilder()
+                        .setCollectionId("customers").build())
+                .setWhere(StructuredQuery.Filter.newBuilder()
+                        .setFieldFilter(StructuredQuery.FieldFilter.newBuilder()
+                                .setField(StructuredQuery.FieldReference.newBuilder()
+                                        .setFieldPath(fieldPath))
+                                .setOp(operator)
+                                .setValue(value)))
+                .build();
+        return service.runQuery(DB + "/documents", query);
+    }
+
+    private Write nestedValueDocument(String id, String field, Value value) {
+        Value billing = Value.newBuilder()
+                .setMapValue(MapValue.newBuilder().putFields(field, value))
+                .build();
+        return Write.newBuilder()
+                .setUpdate(Document.newBuilder()
+                        .setName(DB + "/documents/customers/" + id)
+                        .putFields("billing", billing)
+                        .build())
+                .build();
     }
 
     private Write nestedBillingDocument(String id, String stripeCustomerId) {

--- a/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/firestore/FirestoreServiceTest.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.firestore;
 
 import com.google.firestore.v1.Document;
+import com.google.firestore.v1.MapValue;
 import com.google.firestore.v1.Precondition;
 import com.google.firestore.v1.StructuredQuery;
 import com.google.firestore.v1.Value;
@@ -97,6 +98,48 @@ class FirestoreServiceTest {
 
         List<StoredDocument> results = service.runQuery(DB + "/documents", query);
         assertEquals(2, results.size());
+    }
+
+    @Test
+    void runQueryMatchesNestedMapFieldPath() {
+        service.applyWrite(nestedBillingDocument("matching", "cus_matching"), Instant.now());
+        service.applyWrite(nestedBillingDocument("different", "cus_different"), Instant.now());
+        service.applyWrite(Write.newBuilder()
+                .setUpdate(Document.newBuilder()
+                        .setName(DB + "/documents/customers/missing")
+                        .putFields("name", Value.newBuilder().setStringValue("No billing field").build())
+                        .build())
+                .build(), Instant.now());
+
+        StructuredQuery query = StructuredQuery.newBuilder()
+                .addFrom(StructuredQuery.CollectionSelector.newBuilder()
+                        .setCollectionId("customers").build())
+                .setWhere(StructuredQuery.Filter.newBuilder()
+                        .setFieldFilter(StructuredQuery.FieldFilter.newBuilder()
+                                .setField(StructuredQuery.FieldReference.newBuilder()
+                                        .setFieldPath("billing.stripe_customer_id"))
+                                .setOp(StructuredQuery.FieldFilter.Operator.EQUAL)
+                                .setValue(Value.newBuilder().setStringValue("cus_matching"))))
+                .build();
+
+        List<StoredDocument> results = service.runQuery(DB + "/documents", query);
+
+        assertEquals(List.of(DB + "/documents/customers/matching"),
+                results.stream().map(StoredDocument::getName).toList());
+    }
+
+    private Write nestedBillingDocument(String id, String stripeCustomerId) {
+        Value billing = Value.newBuilder()
+                .setMapValue(MapValue.newBuilder()
+                        .putFields("stripe_customer_id",
+                                Value.newBuilder().setStringValue(stripeCustomerId).build()))
+                .build();
+        return Write.newBuilder()
+                .setUpdate(Document.newBuilder()
+                        .setName(DB + "/documents/customers/" + id)
+                        .putFields("billing", billing)
+                        .build())
+                .build();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- resolve simple dotted Firestore field paths by traversing stored map values
- use the same lookup for filters, ordering, cursors, and unary filters
- add service-level and Java SDK regression coverage for billing.stripe_customer_id equality queries, including missing-field behavior

## Reproduction
Before this change, querying billing.stripe_customer_id returned no documents because the evaluator looked for the complete dotted string as a top-level key.

## Validation
- focused Firestore tests: 23 passed
- full Maven suite under Java 25: 750 passed, 0 failures, 0 errors
- Java Firestore SDK compatibility regression: passed against the built image
- linux/arm64 image built: sha256:42ae0756c5df361920e483e00de463b819e13087c1a5af34886c13048474a9d3

## Scope
This change covers simple dotted field paths used for nested maps. Firestore quoted/backtick field-path segments for literal field names containing dots remain outside this focused fix; this PR does not claim support for those escaped paths.