### PR TITLE
feat(firebaseauth): add projects.createSessionCookie

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirebaseAuthTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/FirebaseAuthTest.java
@@ -7,6 +7,7 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
+import com.google.firebase.auth.SessionCookieOptions;
 import com.google.firebase.auth.UserRecord;
 import com.google.firebase.internal.EmulatorCredentials;
 import com.google.firebase.internal.FirebaseProcessEnvironment;
@@ -24,6 +25,7 @@ import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -127,6 +129,20 @@ class FirebaseAuthTest {
 
     @Test
     @Order(4)
+    void createAndVerifySessionCookie() throws Exception {
+        String cookie = auth.createSessionCookie(signedInIdToken,
+                SessionCookieOptions.builder().setExpiresIn(TimeUnit.HOURS.toMillis(1)).build());
+
+        FirebaseToken decoded = auth.verifySessionCookie(cookie, true);
+        assertThat(decoded.getUid()).isEqualTo(UID);
+        assertThat(decoded.getClaims().get("premium")).isEqualTo(true);
+        assertThat(decoded.getClaims().get("role")).isEqualTo("tester");
+        assertThat(decoded.getClaims().get("iss"))
+                .isEqualTo("https://session.firebase.google.com/" + PROJECT_ID);
+    }
+
+    @Test
+    @Order(5)
     void listUsersContainsCreatedUser() throws Exception {
         List<String> uids = new ArrayList<>();
         auth.listUsers(null).iterateAll().forEach(user -> uids.add(user.getUid()));
@@ -135,7 +151,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void revokeRefreshTokensInvalidatesIdToken() throws Exception {
         Thread.sleep(1100);
         auth.revokeRefreshTokens(UID);
@@ -145,7 +161,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void deleteUserRemovesAccount() throws Exception {
         auth.deleteUser(UID);
 

--- a/docs/services/firebase-auth.md
+++ b/docs/services/firebase-auth.md
@@ -21,6 +21,7 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
 | `POST` | `/identitytoolkit.googleapis.com/v1/accounts:signUp` \| `:signInWithPassword` \| `:signInWithCustomToken` \| `:lookup` \| `:update` \| `:delete` (client, `?key=` any non-empty API key) |
 | `POST` | `/identitytoolkit.googleapis.com/v1/projects/{project}/accounts[:lookup\|:update\|:delete\|:batchDelete]` (admin, `Authorization: Bearer owner`) |
 | `GET` | `/identitytoolkit.googleapis.com/v1/projects/{project}/accounts:batchGet` (admin listUsers) |
+| `POST` | `/identitytoolkit.googleapis.com/v1/projects/{project}:createSessionCookie` (admin, `Authorization: Bearer owner`) |
 | `POST` | `/securetoken.googleapis.com/v1/token` (refresh; JSON or form-urlencoded) |
 | `DELETE` | `/emulator/v1/projects/{project}/accounts` (test helper: delete all users) |
 
@@ -36,6 +37,13 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
   fail with `TOKEN_EXPIRED` (wall-clock `exp` is intentionally not enforced, like the emulator).
 - Custom tokens: Admin SDK JWTs (signed or unsigned) and the emulator's strict-JSON form
   (`{"uid": "...", "claims": {...}}`) are both accepted.
+- Session cookies: `createSessionCookie` re-issues a verified ID token's payload with a fresh
+  `iat`/`exp` window and `iss=https://session.firebase.google.com/{project}`. `validDuration`
+  is in **seconds** and must fall in `[300, 1209600]` (5 minutes – 14 days), else
+  `INVALID_DURATION`. Like the official emulator, a value that is not a non-zero number —
+  absent, `0`, or a string such as `"3600s"` — silently falls back to the 14-day maximum
+  rather than being rejected. There is no verification endpoint: the Admin SDKs verify
+  session cookies locally, and `checkRevoked` goes through `accounts:lookup`.
 
 ## Quick Start
 
@@ -55,6 +63,11 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
     String customToken = auth.createCustomToken("alice");
     // client exchanges it at accounts:signInWithCustomToken, then:
     FirebaseToken decoded = auth.verifyIdToken(idToken);
+
+    // server-rendered apps: swap the ID token for an HttpOnly session cookie
+    String cookie = auth.createSessionCookie(idToken,
+            SessionCookieOptions.builder().setExpiresIn(TimeUnit.HOURS.toMillis(1)).build());
+    FirebaseToken session = auth.verifySessionCookie(cookie, true);
     ```
 
 === "REST"
@@ -68,6 +81,11 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
     # refresh
     curl -X POST 'http://localhost:4588/securetoken.googleapis.com/v1/token?key=fake-api-key' \
       -d 'grant_type=refresh_token&refresh_token=<refreshToken>'
+
+    # session cookie (validDuration is seconds, not a duration string)
+    curl -X POST 'http://localhost:4588/identitytoolkit.googleapis.com/v1/projects/floci-local:createSessionCookie' \
+      -H 'Content-Type: application/json' -H 'Authorization: Bearer owner' \
+      -d '{"idToken":"<idToken>","validDuration":3600}'
     ```
 
 ## Scope and deviations
@@ -76,9 +94,10 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
   (`floci-gcp.default-project-id`), mirroring the official emulator's single-project model.
 - Phase 1 covers email/password, anonymous, and custom-token flows plus the admin user CRUD
   surface (create/lookup/update/delete/batchGet/batchDelete). Not yet implemented: OOB codes
-  (email verification / password reset), email-link, IdP, phone, MFA, passkeys, tenants,
-  session cookies, and the legacy v3 `relyingparty` paths — these return 404 (the official
-  emulator returns 501 for unimplemented operations).
+  (email verification / password reset), email-link, IdP, phone, MFA, passkeys, tenants
+  (including the tenant-scoped `projects/{p}/tenants/{t}:createSessionCookie`), and the
+  legacy v3 `relyingparty` paths — these return 404 (the official emulator returns 501 for
+  unimplemented operations).
 - Passwords are stored in the emulator's literal `fakeHash:salt=...:password=...` format —
   a dev fixture, not a security boundary, identical to the official emulator.
 - `securetoken` responses report `project_id: "12345"`, the emulator's hardcoded project number.

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthController.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthController.java
@@ -156,6 +156,15 @@ public class FirebaseAuthController {
         return json(service.batchDelete(project, safe(body)));
     }
 
+    @POST
+    @Path("/projects/{project}:createSessionCookie")
+    public Response createSessionCookie(@HeaderParam("Authorization") String authorization,
+                                        @PathParam("project") String project,
+                                        Map<String, Object> body) {
+        requirePrivileged(authorization);
+        return json(service.createSessionCookie(project, safe(body)));
+    }
+
     // ── auth model (matches the Auth emulator) ────────────────────────────────
 
     static boolean isPrivileged(String authorization) {

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
@@ -46,6 +46,8 @@ public class FirebaseAuthService {
     private static final String ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private static final int PASSWORD_MIN_LENGTH = 6;
     private static final long TOKEN_EXPIRES_IN_SECONDS = 3600;
+    private static final long SESSION_COOKIE_MIN_VALID_DURATION = 5 * 60;
+    private static final long SESSION_COOKIE_MAX_VALID_DURATION = 14 * 24 * 60 * 60;
     private static final String PROJECT_NUMBER = "12345";
     static final String CUSTOM_TOKEN_AUDIENCE =
             "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit";
@@ -486,6 +488,43 @@ public class FirebaseAuthService {
         return response;
     }
 
+    // ── session cookies ───────────────────────────────────────────────────────
+
+    public Map<String, Object> createSessionCookie(String project, Map<String, Object> body) {
+        String idToken = str(body.get("idToken"));
+        check(idToken != null && !idToken.isEmpty(), "MISSING_ID_TOKEN");
+
+        long validDuration = sessionCookieDuration(body.get("validDuration"));
+        check(validDuration >= SESSION_COOKIE_MIN_VALID_DURATION
+                && validDuration <= SESSION_COOKIE_MAX_VALID_DURATION, "INVALID_DURATION");
+
+        Map<String, Object> payload = new LinkedHashMap<>(verifyIdToken(project, idToken).payload());
+        long iat = Instant.now().getEpochSecond();
+        payload.put("iat", iat);
+        payload.put("exp", iat + validDuration);
+        payload.put("iss", "https://session.firebase.google.com/" + str(payload.get("aud")));
+
+        LOG.debugf("firebaseauth createSessionCookie project=%s localId=%s validDuration=%d",
+                project, payload.get("user_id"), validDuration);
+        return Map.of("sessionCookie", FirebaseJwt.sign(payload));
+    }
+
+    private static long sessionCookieDuration(Object validDuration) {
+        if (validDuration instanceof Number number) {
+            return number.longValue() == 0 ? SESSION_COOKIE_MAX_VALID_DURATION : number.longValue();
+        }
+        String text = str(validDuration);
+        if (text == null || text.isBlank()) {
+            return SESSION_COOKIE_MAX_VALID_DURATION;
+        }
+        try {
+            long parsed = (long) Double.parseDouble(text.trim());
+            return parsed == 0 ? SESSION_COOKIE_MAX_VALID_DURATION : parsed;
+        } catch (NumberFormatException e) {
+            return SESSION_COOKIE_MAX_VALID_DURATION;
+        }
+    }
+
     // ── securetoken grantToken ────────────────────────────────────────────────
 
     public Map<String, Object> grantToken(String project, String grantType, String refreshToken) {
@@ -619,7 +658,13 @@ public class FirebaseAuthService {
         return FirebaseJwt.sign(payload);
     }
 
+    record VerifiedIdToken(StoredUser user, Map<String, Object> payload) {}
+
     StoredUser parseIdToken(String project, String idToken) {
+        return verifyIdToken(project, idToken).user();
+    }
+
+    VerifiedIdToken verifyIdToken(String project, String idToken) {
         Map<String, Object> payload = FirebaseJwt.decodePayload(idToken);
         check(payload != null, "INVALID_ID_TOKEN");
         StoredUser user = getUser(project, str(payload.get("user_id")));
@@ -628,7 +673,7 @@ public class FirebaseAuthService {
             check(iat.longValue() >= Long.parseLong(user.getValidSince()), "TOKEN_EXPIRED");
         }
         check(!user.isDisabled(), "USER_DISABLED");
-        return user;
+        return new VerifiedIdToken(user, payload);
     }
 
     // ── claims validation ─────────────────────────────────────────────────────

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
@@ -25,7 +25,8 @@ class FirebaseAuthRestIntegrationTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String CLIENT = "/identitytoolkit.googleapis.com/v1/accounts";
-    private static final String ADMIN = "/identitytoolkit.googleapis.com/v1/projects/test-project/accounts";
+    private static final String PROJECT = "/identitytoolkit.googleapis.com/v1/projects/test-project";
+    private static final String ADMIN = String.format("%s/accounts", PROJECT);
 
     @Test
     void signUpSignInAndRefreshRoundtrip() throws Exception {
@@ -396,6 +397,168 @@ class FirebaseAuthRestIntegrationTest {
         Map<String, Object> payload = decodeSegment(idToken, 1);
         assertEquals("anonymous", payload.get("provider_id"));
         assertEquals("anonymous", ((Map<?, ?>) payload.get("firebase")).get("sign_in_provider"));
+    }
+
+    @Test
+    void createSessionCookieMintsCookieWithSessionIssuer() throws Exception {
+        Map<String, Object> signUp = signUpClient("cookie@example.com");
+        String idToken = (String) signUp.get("idToken");
+
+        String cookie = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("idToken", idToken, "validDuration", 3600))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then()
+                .statusCode(200)
+                .body("sessionCookie", notNullValue())
+                .extract().path("sessionCookie");
+
+        Map<String, Object> header = decodeSegment(cookie, 0);
+        Map<String, Object> payload = decodeSegment(cookie, 1);
+        assertEquals("none", header.get("alg"));
+        assertTrue(cookie.endsWith("."));
+        assertEquals("https://session.firebase.google.com/test-project", payload.get("iss"));
+        assertEquals("test-project", payload.get("aud"));
+        assertEquals(signUp.get("localId"), payload.get("sub"));
+        assertEquals(signUp.get("localId"), payload.get("user_id"));
+        assertEquals("cookie@example.com", payload.get("email"));
+        assertEquals("password", ((Map<?, ?>) payload.get("firebase")).get("sign_in_provider"));
+        assertEquals(3600L, num(payload.get("exp")) - num(payload.get("iat")));
+
+        Map<String, Object> idPayload = decodeSegment(idToken, 1);
+        assertEquals(idPayload.get("auth_time"), payload.get("auth_time"));
+    }
+
+    @Test
+    void createSessionCookieDefaultsToFourteenDaysForNonNumericDuration() throws Exception {
+        String idToken = (String) signUpClient("cookie-default@example.com").get("idToken");
+
+        for (Object duration : new Object[]{"3600s", 0, "not-a-number"}) {
+            String cookie = given()
+                    .urlEncodingEnabled(false)
+                    .contentType("application/json")
+                    .header("Authorization", "Bearer owner")
+                    .body(Map.of("idToken", idToken, "validDuration", duration))
+                    .when().post(PROJECT + ":createSessionCookie")
+                    .then().statusCode(200)
+                    .extract().path("sessionCookie");
+            Map<String, Object> payload = decodeSegment(cookie, 1);
+            assertEquals(14L * 24 * 60 * 60, num(payload.get("exp")) - num(payload.get("iat")));
+        }
+
+        String cookie = given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("idToken", idToken))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then().statusCode(200)
+                .extract().path("sessionCookie");
+        Map<String, Object> payload = decodeSegment(cookie, 1);
+        assertEquals(14L * 24 * 60 * 60, num(payload.get("exp")) - num(payload.get("iat")));
+    }
+
+    @Test
+    void createSessionCookieRejectsBadRequests() {
+        String idToken = (String) signUpClient("cookie-errors@example.com").get("idToken");
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("validDuration", 3600))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("MISSING_ID_TOKEN"));
+
+        for (Object duration : new Object[]{299, -1, 14 * 24 * 60 * 60 + 1}) {
+            given()
+                    .urlEncodingEnabled(false)
+                    .contentType("application/json")
+                    .header("Authorization", "Bearer owner")
+                    .body(Map.of("idToken", idToken, "validDuration", duration))
+                    .when().post(PROJECT + ":createSessionCookie")
+                    .then()
+                    .statusCode(400)
+                    .body("error.message", equalTo("INVALID_DURATION"));
+        }
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("idToken", "garbage", "validDuration", 1))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("INVALID_DURATION"));
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("idToken", "garbage", "validDuration", 3600))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("INVALID_ID_TOKEN"));
+    }
+
+    @Test
+    void createSessionCookieRequiresPrivilegedCaller() {
+        String idToken = (String) signUpClient("cookie-auth@example.com").get("idToken");
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body(Map.of("idToken", idToken, "validDuration", 3600))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then()
+                .statusCode(401)
+                .body("error.status", equalTo("UNAUTHENTICATED"));
+    }
+
+    @Test
+    void createSessionCookieRespectsRevocation() {
+        Map<String, Object> signUp = signUpClient("cookie-revoked@example.com");
+        String idToken = (String) signUp.get("idToken");
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("localId", signUp.get("localId"), "validSince", "9999999999"))
+                .when().post(ADMIN + ":update")
+                .then().statusCode(200);
+
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .header("Authorization", "Bearer owner")
+                .body(Map.of("idToken", idToken, "validDuration", 3600))
+                .when().post(PROJECT + ":createSessionCookie")
+                .then()
+                .statusCode(400)
+                .body("error.message", equalTo("TOKEN_EXPIRED"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> signUpClient(String email) {
+        return given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body(Map.of("email", email, "password", "secret123"))
+                .when().post(CLIENT + ":signUp")
+                .then().statusCode(200)
+                .extract().as(Map.class);
+    }
+
+    private static long num(Object value) {
+        return ((Number) value).longValue();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

- Adds `projects.createSessionCookie` to the Firebase Auth emulation: exchanges a verified ID token for a session cookie, [mirroring the official Firebase Auth emulator](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/operations.ts#L680-L710).

- The ID token payload is re-signed with a fresh `iat`/`exp` window and `iss=https://session.firebase.google.com/{aud}`, so the Admin SDKs' `verifySessionCookie` accepts it in emulator mode.

- `validDuration` follows the emulator's `Number(v) || MAX` semantics.
  -  A value that is not a non-zero number - i.e. it's absent, `0`, or a non-numeric string such as `"3600s"` falls back to the 14-day maximum instead of being rejected. 
  - Values outside `[300, 1209600]` fail with `INVALID_DURATION`, checked before the ID token is parsed, matching upstream ordering.

- No verification endpoint is needed: the Admin SDKs verify session cookies locally, and `checkRevoked` goes through `accounts:lookup`.

- `parseIdToken` is split so callers can reach the raw claims; behavior for existing callers is unchanged.

Closes #133

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

**SDK verified against:** `com.google.firebase:firebase-admin` **9.9.0** (Java), pinned in `compatibility-tests/sdk-test-java/pom.xml`.

**gcloud CLI:** is not applicable here as gcloud exposes no Identity Toolkit `createSessionCookie` surface, and `compatibility-tests/sdk-test-gcloud` contains no Firebase cases.

**Wire protocol reference:** matched against the official Firebase Auth emulator at [`firebase-tools@96d0f83`](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/operations.ts#L680-L710). The `Number(v) || MAX` `validDuration` coercion, the `INVALID_DURATION` check ordering ahead of ID token parsing, and the `iss` derivation from `payload.aud`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Tests

In-repo REST integration tests (`FirebaseAuthRestIntegrationTest`) cover the success path, `validDuration` coercion, out-of-range rejection, privileged-caller enforcement and revocation:

```
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Java SDK compatibility suite (`compatibility-tests/sdk-test-java`, firebase-admin 9.9.0):

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
