### PR TITLE
feat(iam): add project and Secret Manager policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | Databases | Cloud SQL for PostgreSQL |
 | Analytics | BigQuery (Phase 1) |
 | Observability | Cloud Logging, Cloud Monitoring |
-| API management | Service Usage, Cloud Resource Manager (minimal `projects.get`) |
+| API management | Service Usage, Cloud Resource Manager (`projects.get` and IAM policy mixins) |
 
 <details>
 <summary>Detailed service notes</summary>
@@ -213,7 +213,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Pub/Sub** | gRPC + REST JSON | Topics, subscriptions, publish, pull, streaming pull, push delivery, snapshots, seek, field masks on update, subscription filters (attribute filter language) |
 | **Firestore** | gRPC | Documents, collections, queries (all operators), field transforms, aggregation (COUNT), transactions, batch writes, real-time listeners (`listen` stream) |
 | **Datastore** | HTTP/protobuf | Entities, structured queries, GQL queries, aggregation (COUNT), transactions, GQL named/positional bindings |
-| **Secret Manager** | gRPC | Secrets, versioning, access, `versions/latest` alias, disable/enable/destroy, IAM bindings |
+| **Secret Manager** | gRPC + REST JSON | Secrets, versioning, access, `versions/latest` alias, disable/enable/destroy, IAM bindings |
 | **Cloud Logging** | gRPC + REST JSON | Structured log ingestion (`WriteLogEntries`), read-back (`ListLogEntries`) with a practical filter subset (logName, severity, resource.type, timestamp, labels), `ListLogs`, `DeleteLog`; text/JSON payloads |
 | **Cloud KMS** | gRPC + REST JSON | Key rings, crypto keys, key versions, symmetric encrypt/decrypt (AES-256-GCM), asymmetric sign (EC P-256, RSA PKCS1) and decrypt (RSA-OAEP), `GetPublicKey`, `GenerateRandomBytes`, CRC32C integrity fields |
 | **IAM** | REST JSON | Service accounts, RSA-2048 key pairs (JSON key file format), policy bindings, `SignBlob` (V4 signed URLs) |
@@ -227,7 +227,7 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 | **Cloud Tasks** | gRPC | Queues (rate limits, retry config, pause/resume/purge), tasks (HTTP and App Engine targets, schedule time), `RunTask`; control plane only, tasks are tracked but not dispatched |
 | **Cloud Scheduler** | gRPC + REST JSON | Cron jobs with Pub/Sub, HTTP, and App Engine targets; `Pause`/`Resume`/`RunJob`; unix-cron + time zones; background tick fires due jobs (Pub/Sub publishes into the local backend) |
 | **Cloud Monitoring** | gRPC + REST JSON | Metric descriptors (create/get/list/delete), monitored resource descriptors, time series write (`CreateTimeSeries` with GCP validation rules) and read (`ListTimeSeries` with alignment/reduction subset and pagination) |
-| **Service Usage** | REST JSON | Enable/disable/list a project's services (`serviceusage.googleapis.com` v1) with done LROs; accept-and-succeed state store for Terraform `google_project_service`, Pulumi, and `gcloud services`; includes a minimal Cloud Resource Manager v1 `projects.get` for provider project lookups |
+| **Service Usage** | REST JSON | Enable/disable/list a project's services (`serviceusage.googleapis.com` v1) with done LROs; accept-and-succeed state store for Terraform `google_project_service`, Pulumi, and `gcloud services`; includes Cloud Resource Manager v1 `projects.get` and project IAM policy mixins for provider project lookups |
 | **Firebase Auth (Identity Platform)** | REST JSON | Identity Toolkit v1 wire-compatible with the official Auth emulator: email/password, anonymous and custom-token sign-in, unsigned emulator JWTs `firebase-admin` verifies, token refresh + revocation, admin user CRUD/list via `FIREBASE_AUTH_EMULATOR_HOST` |
 | **BigQuery (Phase 1)** | REST JSON | Datasets and tables CRUD with schema normalization, schema-validated `tabledata.insertAll`/`tabledata.list`, query jobs (`jobs.query`, `jobs.insert`, `getQueryResults`) over a SQL subset (`SELECT *`/columns/`COUNT(*)`, `WHERE =`, `LIMIT`) |
 

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -48,6 +48,19 @@ resource "google_secret_manager_secret_version" "compat" {
   secret_data = "floci-gcp-opentofu-compat-test-secret-value"
 }
 
+resource "google_secret_manager_secret_iam_member" "accessor" {
+  project   = var.project
+  secret_id = google_secret_manager_secret.compat.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.compat.email}"
+}
+
+resource "google_project_iam_member" "publisher" {
+  project = var.project
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.compat.email}"
+}
+
 # ── Cloud Run ────────────────────────────────────────────────────────────────
 resource "terraform_data" "cloud_run_replacement" {
   input = var.cloud_run_replace_token

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -333,7 +333,19 @@ setup() {
     [[ "$result" != *'roles/pubsub.subscriber'* ]]
 }
 
+@test "OpenTofu: Secret Manager IAM policy holds accessor grant" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/secrets/floci-compat-secret-tofu:getIamPolicy")
+    [[ "$result" == *'roles/secretmanager.secretAccessor'* ]]
+    [[ "$result" == *'floci-compat-sa-tofu@'* ]]
+}
+
+@test "OpenTofu: project IAM policy holds publisher grant" {
+    result=$(gcp_curl -X POST -H 'Content-Type: application/json' -d '{}' "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}:getIamPolicy")
+    [[ "$result" == *'roles/pubsub.publisher'* ]]
+    [[ "$result" == *'floci-compat-sa-tofu@'* ]]
+}
+
 @test "OpenTofu: all managed resources tracked in state" {
     count=$(tofu state list 2>/dev/null | wc -l | tr -d ' ')
-    [ "$count" -ge 18 ]
+    [ "$count" -ge 20 ]
 }

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -48,6 +48,19 @@ resource "google_secret_manager_secret_version" "compat" {
   secret_data = "floci-gcp-compat-test-secret-value"
 }
 
+resource "google_secret_manager_secret_iam_member" "accessor" {
+  project   = var.project
+  secret_id = google_secret_manager_secret.compat.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.compat.email}"
+}
+
+resource "google_project_iam_member" "publisher" {
+  project = var.project
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.compat.email}"
+}
+
 # ── Cloud Run ────────────────────────────────────────────────────────────────
 resource "terraform_data" "cloud_run_replacement" {
   input = var.cloud_run_replace_token

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -333,9 +333,21 @@ setup() {
     [[ "$result" != *'roles/pubsub.subscriber'* ]]
 }
 
+@test "Terraform: Secret Manager IAM policy holds accessor grant" {
+    result=$(gcp_curl "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}/secrets/floci-compat-secret:getIamPolicy")
+    [[ "$result" == *'roles/secretmanager.secretAccessor'* ]]
+    [[ "$result" == *'floci-compat-sa@'* ]]
+}
+
+@test "Terraform: project IAM policy holds publisher grant" {
+    result=$(gcp_curl -X POST -H 'Content-Type: application/json' -d '{}' "${FLOCI_ENDPOINT}/v1/projects/${FLOCI_PROJECT}:getIamPolicy")
+    [[ "$result" == *'roles/pubsub.publisher'* ]]
+    [[ "$result" == *'floci-compat-sa@'* ]]
+}
+
 # ── State Integrity ───────────────────────────────────────────────────────────
 
 @test "Terraform: all managed resources tracked in state" {
     count=$(terraform state list 2>/dev/null | wc -l | tr -d ' ')
-    [ "$count" -ge 18 ]
+    [ "$count" -ge 20 ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | **Pub/Sub** | gRPC + REST | Topics, subscriptions, publish, pull, streaming pull, push delivery, snapshots, seek, subscription filters |
 | **Firestore** | gRPC | Documents, collections, queries, field transforms, aggregation, transactions, real-time listeners |
 | **Datastore** | HTTP/protobuf | Entities, structured queries, GQL queries, aggregation, transactions |
-| **Secret Manager** | gRPC | Secrets, versions, access, disable/enable/destroy, IAM bindings |
+| **Secret Manager** | gRPC + REST | Secrets, versions, access, disable/enable/destroy, IAM bindings |
 | **Cloud Logging** | gRPC + REST | Structured log ingestion (`WriteLogEntries`), read-back (`ListLogEntries`) with filter subset, `ListLogs`, `DeleteLog` |
 | **Cloud KMS** | gRPC + REST | Key rings, crypto keys, versions, symmetric encrypt/decrypt, asymmetric sign/decrypt, `GenerateRandomBytes` |
 | **IAM** | REST | Service accounts, RSA-2048 keys, policy bindings, SignBlob (V4 signed URLs) |
@@ -36,7 +36,7 @@ floci-gcp is a fast, free, and open-source local GCP emulator built for develope
 | **Firebase Auth (Identity Platform)** | REST | Identity Toolkit v1 sign-up/sign-in, emulator JWTs, admin user CRUD |
 | **Eventarc** | REST | Trigger CRUD; delivers CloudEvents from Pub/Sub and GCS events to Cloud Run and HTTP endpoints |
 | **IAM Credentials** | REST | `generateAccessToken` for service-account impersonation (shape-only stub tokens) |
-| **Resource Manager** | REST | Minimal `projects.get` for provider project lookups |
+| **Resource Manager** | REST | `projects.get` and project IAM policy mixins for provider project lookups |
 
 ## Why floci-gcp?
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -10,7 +10,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Pub/Sub](pubsub.md) | gRPC + REST JSON | `google.pubsub.v1.Publisher`, `google.pubsub.v1.Subscriber`, `/v1/projects/{project}/topics` |
 | [Firestore](firestore.md) | gRPC | `google.firestore.v1.Firestore` |
 | [Datastore](datastore.md) | HTTP/protobuf | `/v1/projects/{project}:{method}` |
-| [Secret Manager](secret-manager.md) | gRPC | `google.cloud.secretmanager.v1.SecretManagerService` |
+| [Secret Manager](secret-manager.md) | gRPC + REST JSON | `google.cloud.secretmanager.v1.SecretManagerService`, `/v1/projects/{project}/secrets` |
 | [Cloud Logging](logging.md) | gRPC + REST JSON | `google.logging.v2.LoggingServiceV2`, `/v2/entries:write`, `/v2/entries:list` |
 | [Cloud KMS](kms.md) | gRPC + REST JSON | `google.cloud.kms.v1.KeyManagementService`, `/v1/projects/{project}/locations/{location}/keyRings` |
 | [IAM](iam.md) | REST JSON | `/v1/projects/{project}/serviceAccounts` |
@@ -25,7 +25,7 @@ floci-gcp emulates GCP services on a single port (`4588`). All services use real
 | [Cloud Scheduler](scheduler.md) | gRPC + REST JSON | `google.cloud.scheduler.v1.CloudScheduler`, `/v1/projects/{project}/locations/{location}/jobs` |
 | [Cloud Monitoring](cloud-monitoring.md) | gRPC + REST JSON | `google.monitoring.v3.MetricService`, `/v3/projects/{project}` |
 | [Service Usage](service-usage.md) | REST JSON | `/v1/projects/{project}/services` |
-| [Resource Manager](service-usage.md#cloud-resource-manager-companion) | REST JSON | `/v1/projects/{projectId}` (minimal `projects.get`) |
+| [Resource Manager](service-usage.md#cloud-resource-manager-companion) | REST JSON | `/v1/projects/{projectId}`, IAM policy mixins |
 | [Eventarc](eventarc.md) | REST JSON | `/v1/projects/{project}/locations/{location}/triggers` |
 | [Firebase Auth](firebase-auth.md) | REST JSON | `/identitytoolkit.googleapis.com/v1/accounts:*`, `/securetoken.googleapis.com/v1/token` |
 | [BigQuery (Phase 1)](bigquery.md) | REST JSON | `/bigquery/v2/projects/{project}` |

--- a/docs/services/secret-manager.md
+++ b/docs/services/secret-manager.md
@@ -172,6 +172,11 @@ gcloud secrets add-iam-policy-binding my-secret \
     --role="roles/secretmanager.secretAccessor"
 ```
 
+Secret-level IAM policies persist across `GetIamPolicy` / `SetIamPolicy` calls,
+including etag-based read-modify-write flows used by Terraform and OpenTofu.
+Deleting a secret clears its policy. Policies are stored but not enforced: a
+caller that would be denied by IAM in GCP can still access emulator resources.
+
 ## Supported Operations
 
 - `CreateSecret`

--- a/docs/services/secret-manager.md
+++ b/docs/services/secret-manager.md
@@ -174,8 +174,11 @@ gcloud secrets add-iam-policy-binding my-secret \
 
 Secret-level IAM policies persist across `GetIamPolicy` / `SetIamPolicy` calls,
 including etag-based read-modify-write flows used by Terraform and OpenTofu.
-Deleting a secret clears its policy. Policies are stored but not enforced: a
-caller that would be denied by IAM in GCP can still access emulator resources.
+Deleting a secret clears its versions and policy. Cleanup intent is persisted
+before deletion, so interrupted cleanup is resumed before the emulator serves
+requests after restart or recreates the same secret name. Policies are stored
+but not enforced: a caller that would be denied by IAM in GCP can still access
+emulator resources.
 
 ## Supported Operations
 

--- a/docs/services/service-usage.md
+++ b/docs/services/service-usage.md
@@ -43,10 +43,17 @@ floci-gcp therefore serves a minimal Cloud Resource Manager v1 surface:
 | Method | Path |
 |---|---|
 | `GET` | `/v1/projects/{projectId}` |
+| `POST` | `/v1/projects/{projectId}:getIamPolicy` |
+| `POST` | `/v1/projects/{projectId}:setIamPolicy` |
+| `POST` | `/v1/projects/{projectId}:testIamPermissions` |
 
 Every project ID resolves to an `ACTIVE` project with a stable synthetic
 `projectNumber` (the emulator's multi-tenancy is keyed by project ID; projects are never
 created or deleted).
+
+Project-level IAM policies are stored with stable empty-policy and rotating write
+etags for Terraform/OpenTofu read-modify-write flows. IAM bindings are not
+enforced by the emulator; they do not restrict access to emulated resources.
 
 ## Quick Start
 

--- a/src/main/java/io/floci/gcp/services/iam/IamController.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamController.java
@@ -40,7 +40,7 @@ public class IamController {
         IamPath p = parsePath(rest);
         LOG.debugf("IAM POST %s project=%s id=%s method=%s", rest, p.project(), p.identifier(), p.customMethod());
 
-        if (p.customMethod() != null) {
+        if (p.customMethod() != null && "serviceAccounts".equals(p.resourceType()) && p.identifier() != null) {
             return handleCustomMethod(p, body);
         }
 

--- a/src/main/java/io/floci/gcp/services/iam/IamService.java
+++ b/src/main/java/io/floci/gcp/services/iam/IamService.java
@@ -216,6 +216,7 @@ public class IamService {
         synchronized (policyLock(key)) {
             deleteResource.run();
             policyStore.delete(key);
+            policyStore.flush();
         }
     }
 

--- a/src/main/java/io/floci/gcp/services/resourcemanager/ResourceManagerController.java
+++ b/src/main/java/io/floci/gcp/services/resourcemanager/ResourceManagerController.java
@@ -25,6 +25,10 @@ public class ResourceManagerController {
 
     @GET
     public Response getProject(@PathParam("project") String project) {
+        if (project.endsWith(":getIamPolicy") || project.endsWith(":setIamPolicy")
+                || project.endsWith(":testIamPermissions")) {
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
         Map<String, Object> body = service.getProject(project);
         return Response.ok(body).build();
     }

--- a/src/main/java/io/floci/gcp/services/resourcemanager/ResourceManagerIamController.java
+++ b/src/main/java/io/floci/gcp/services/resourcemanager/ResourceManagerIamController.java
@@ -1,0 +1,78 @@
+package io.floci.gcp.services.resourcemanager;
+
+import io.floci.gcp.services.iam.IamPolicyCodec;
+import io.floci.gcp.services.iam.IamService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Map;
+
+@Path("/v1/projects")
+@ApplicationScoped
+@Produces(MediaType.APPLICATION_JSON)
+public class ResourceManagerIamController {
+
+    private final IamService iamService;
+
+    @Inject
+    public ResourceManagerIamController(IamService iamService) {
+        this.iamService = iamService;
+    }
+
+    @POST
+    @Path("/{project}:getIamPolicy")
+    public Response getIamPolicy(@PathParam("project") String project, Map<String, Object> body) {
+        return Response.ok(iamService.getPolicy(projectName(project))).build();
+    }
+
+    @GET
+    @Path("/{project}:getIamPolicy")
+    public Response getIamPolicyWithGet() {
+        return methodNotAllowed();
+    }
+
+    @POST
+    @Path("/{project}:setIamPolicy")
+    @SuppressWarnings("unchecked")
+    public Response setIamPolicy(@PathParam("project") String project, Map<String, Object> body) {
+        Map<String, Object> policy = body != null ? (Map<String, Object>) body.get("policy") : null;
+        return Response.ok(iamService.setPolicy(projectName(project), IamPolicyCodec.fromJsonMap(policy))).build();
+    }
+
+    @GET
+    @Path("/{project}:setIamPolicy")
+    public Response setIamPolicyWithGet() {
+        return methodNotAllowed();
+    }
+
+    @POST
+    @Path("/{project}:testIamPermissions")
+    @SuppressWarnings("unchecked")
+    public Response testIamPermissions(@PathParam("project") String project, Map<String, Object> body) {
+        List<String> permissions = body != null ? (List<String>) body.get("permissions") : List.of();
+        return Response.ok(Map.of("permissions", iamService.testPermissions(
+                projectName(project), permissions != null ? permissions : List.of()))).build();
+    }
+
+    @GET
+    @Path("/{project}:testIamPermissions")
+    public Response testIamPermissionsWithGet() {
+        return methodNotAllowed();
+    }
+
+    private static Response methodNotAllowed() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+    }
+
+    private static String projectName(String project) {
+        return "projects/" + project;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/resourcemanager/ResourceManagerService.java
+++ b/src/main/java/io/floci/gcp/services/resourcemanager/ResourceManagerService.java
@@ -5,6 +5,7 @@ import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.ServiceDescriptor;
 import io.floci.gcp.core.common.ServiceProtocol;
 import io.floci.gcp.core.common.ServiceRegistry;
+import io.floci.gcp.services.iam.IamService;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -27,24 +28,28 @@ public class ResourceManagerService {
 
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
+    private final IamService iamService;
 
     @Inject
-    public ResourceManagerService(ServiceRegistry serviceRegistry, EmulatorConfig config) {
+    public ResourceManagerService(ServiceRegistry serviceRegistry, EmulatorConfig config, IamService iamService) {
         this.serviceRegistry = serviceRegistry;
         this.config = config;
+        this.iamService = iamService;
     }
 
-    ResourceManagerService(EmulatorConfig config) {
+    ResourceManagerService(EmulatorConfig config, IamService iamService) {
         this.serviceRegistry = null;
         this.config = config;
+        this.iamService = iamService;
     }
 
     void onStart(@Observes StartupEvent ev) {
         serviceRegistry.register(ServiceDescriptor.builder("resourcemanager")
                 .enabled(config.services().resourcemanager().enabled())
                 .protocol(ServiceProtocol.REST)
-                .resourceClasses(ResourceManagerController.class)
+                .resourceClasses(ResourceManagerController.class, ResourceManagerIamController.class)
                 .build());
+        iamService.registerPolicyResourceResolver("projects/*", this::requireProjectForPolicy);
     }
 
     public Map<String, Object> getProject(String projectId) {
@@ -58,6 +63,10 @@ public class ResourceManagerService {
         project.put("name", projectId);
         project.put("createTime", createTime(projectId));
         return project;
+    }
+
+    private void requireProjectForPolicy(String resource) {
+        getProject(resource.substring("projects/".length()));
     }
 
     static String projectNumber(String projectId) {

--- a/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerController.java
+++ b/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerController.java
@@ -220,25 +220,40 @@ public class SecretManagerController extends SecretManagerServiceGrpc.SecretMana
     @Override
     public void setIamPolicy(SetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
         LOG.debugf("setIamPolicy resource=%s", request.getResource());
-        responseObserver.onNext(request.getPolicy());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(service.setIamPolicy(request.getResource(), request.getPolicy()));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("setIamPolicy failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
     }
 
     @Override
     public void getIamPolicy(GetIamPolicyRequest request, StreamObserver<Policy> responseObserver) {
         LOG.debugf("getIamPolicy resource=%s", request.getResource());
-        responseObserver.onNext(Policy.getDefaultInstance());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(service.getIamPolicy(request.getResource()));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("getIamPolicy failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
     }
 
     @Override
     public void testIamPermissions(TestIamPermissionsRequest request,
             StreamObserver<TestIamPermissionsResponse> responseObserver) {
         LOG.debugf("testIamPermissions resource=%s", request.getResource());
-        responseObserver.onNext(TestIamPermissionsResponse.newBuilder()
-                .addAllPermissions(request.getPermissionsList())
-                .build());
-        responseObserver.onCompleted();
+        try {
+            responseObserver.onNext(TestIamPermissionsResponse.newBuilder()
+                    .addAllPermissions(service.testIamPermissions(request.getResource(), request.getPermissionsList()))
+                    .build());
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            LOG.warnf("testIamPermissions failed: %s", e.getMessage());
+            GcpGrpcController.grpcError(responseObserver, e);
+        }
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerHttpController.java
+++ b/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerHttpController.java
@@ -1,6 +1,8 @@
 package io.floci.gcp.services.secretmanager;
 
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.services.iam.IamPolicyCodec;
+import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.secretmanager.model.StoredSecret;
 import io.floci.gcp.services.secretmanager.model.StoredSecretVersion;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -36,6 +38,9 @@ public class SecretManagerHttpController {
 
     @Inject
     SecretManagerService service;
+
+    @Inject
+    IamService iamService;
 
     // ── Secrets ────────────────────────────────────────────────────────────────
 
@@ -224,14 +229,20 @@ public class SecretManagerHttpController {
         }
     }
 
-    // ── IAM stubs (called by Terraform for IAM-aware resources) ───────────────
+    // ── IAM ───────────────────────────────────────────────────────────────────
 
     @GET
     @Path("/{secretId}:getIamPolicy")
     public Response getIamPolicy(@PathParam("project") String project,
                                  @PathParam("secretId") String secretId) {
         LOG.debugf("REST getIamPolicy project=%s secretId=%s", project, secretId);
-        return Response.ok(Map.of("version", 1, "bindings", List.of(), "etag", "")).build();
+        return Response.ok(iamService.getPolicy(secretName(project, secretId))).build();
+    }
+
+    @POST
+    @Path("/{secretId}:getIamPolicy")
+    public Response getIamPolicyWithPost() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
     }
 
     @POST
@@ -241,9 +252,14 @@ public class SecretManagerHttpController {
                                  @PathParam("secretId") String secretId,
                                  Map<String, Object> body) {
         LOG.debugf("REST setIamPolicy project=%s secretId=%s", project, secretId);
-        Map<String, Object> policy = (body != null && body.containsKey("policy"))
-                ? (Map<String, Object>) body.get("policy") : Map.of();
-        return Response.ok(policy).build();
+        Map<String, Object> policy = body != null ? (Map<String, Object>) body.get("policy") : null;
+        return Response.ok(iamService.setPolicy(secretName(project, secretId), IamPolicyCodec.fromJsonMap(policy))).build();
+    }
+
+    @GET
+    @Path("/{secretId}:setIamPolicy")
+    public Response setIamPolicyWithGet() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
     }
 
     @POST
@@ -253,11 +269,22 @@ public class SecretManagerHttpController {
                                        @PathParam("secretId") String secretId,
                                        Map<String, Object> body) {
         LOG.debugf("REST testIamPermissions project=%s secretId=%s", project, secretId);
-        List<?> permissions = (body != null) ? (List<?>) body.get("permissions") : List.of();
-        return Response.ok(Map.of("permissions", permissions != null ? permissions : List.of())).build();
+        List<String> permissions = body != null ? (List<String>) body.get("permissions") : List.of();
+        return Response.ok(Map.of("permissions", iamService.testPermissions(
+                secretName(project, secretId), permissions != null ? permissions : List.of()))).build();
+    }
+
+    @GET
+    @Path("/{secretId}:testIamPermissions")
+    public Response testIamPermissionsWithGet() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
     }
 
     // ── JSON builders ──────────────────────────────────────────────────────────
+
+    private static String secretName(String project, String secretId) {
+        return "projects/" + project + "/secrets/" + secretId;
+    }
 
     private static Map<String, Object> toSecretJson(StoredSecret stored) {
         Map<String, Object> response = new LinkedHashMap<>();

--- a/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
+++ b/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
@@ -105,8 +105,10 @@ public class SecretManagerService {
 
     public StoredSecret getSecret(String name) {
         LOG.debugf("getSecret name=%s", name);
-        requireSecretExists(name);
-        return secretStore.get(name).orElseThrow();
+        synchronized (secretLock(name)) {
+            requireSecretExists(name);
+            return secretStore.get(name).orElseThrow();
+        }
     }
 
     private void requireSecretExists(String name) {
@@ -126,8 +128,10 @@ public class SecretManagerService {
 
     public StoredSecret updateSecret(String name) {
         LOG.debugf("updateSecret name=%s", name);
-        requireSecretExists(name);
-        return secretStore.get(name).orElseThrow();
+        synchronized (secretLock(name)) {
+            requireSecretExists(name);
+            return secretStore.get(name).orElseThrow();
+        }
     }
 
     public void deleteSecret(String name) {
@@ -176,6 +180,8 @@ public class SecretManagerService {
                     .forEach(v -> versionStore.delete(v.getName()));
             secretStore.delete(name);
         });
+        versionStore.flush();
+        secretStore.flush();
     }
 
     public Policy getIamPolicy(String resource) {
@@ -209,31 +215,37 @@ public class SecretManagerService {
     public StoredSecretVersion getSecretVersion(String versionedName) {
         LOG.debugf("getSecretVersion name=%s", versionedName);
         String secretName = secretNameForVersion(versionedName);
-        requireSecretExists(secretName);
-        return resolveVersion(versionedName);
+        synchronized (secretLock(secretName)) {
+            requireSecretExists(secretName);
+            return resolveVersion(versionedName);
+        }
     }
 
     public List<StoredSecretVersion> listSecretVersions(String secretName) {
         LOG.debugf("listSecretVersions secret=%s", secretName);
-        if (pendingDeletionStore.get(secretName).isPresent()) {
-            return List.of();
+        synchronized (secretLock(secretName)) {
+            if (pendingDeletionStore.get(secretName).isPresent()) {
+                return List.of();
+            }
+            String prefix = secretName + "/versions/";
+            return versionStore.scan(k -> k.startsWith(prefix));
         }
-        String prefix = secretName + "/versions/";
-        return versionStore.scan(k -> k.startsWith(prefix));
     }
 
     public StoredSecretVersion accessSecretVersion(String versionedName) {
         LOG.debugf("accessSecretVersion name=%s", versionedName);
         String secretName = secretNameForVersion(versionedName);
-        requireSecretExists(secretName);
-        StoredSecretVersion version = resolveVersion(versionedName);
-        if ("DESTROYED".equals(version.getState())) {
-            throw GcpException.notFound("Secret version is destroyed: " + version.getName());
+        synchronized (secretLock(secretName)) {
+            requireSecretExists(secretName);
+            StoredSecretVersion version = resolveVersion(versionedName);
+            if ("DESTROYED".equals(version.getState())) {
+                throw GcpException.notFound("Secret version is destroyed: " + version.getName());
+            }
+            if ("DISABLED".equals(version.getState())) {
+                throw GcpException.invalidArgument("Secret version is disabled: " + version.getName());
+            }
+            return version;
         }
-        if ("DISABLED".equals(version.getState())) {
-            throw GcpException.invalidArgument("Secret version is disabled: " + version.getName());
-        }
-        return version;
     }
 
     public StoredSecretVersion disableSecretVersion(String versionedName) {

--- a/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
+++ b/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
@@ -33,6 +33,7 @@ public class SecretManagerService {
 
     private final StorageBackend<String, StoredSecret> secretStore;
     private final StorageBackend<String, StoredSecretVersion> versionStore;
+    private final StorageBackend<String, String> pendingDeletionStore;
 
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
@@ -50,12 +51,16 @@ public class SecretManagerService {
                 new TypeReference<Map<String, StoredSecret>>() {});
         this.versionStore = storageFactory.createGlobal("secretmanager-versions", "secretmanager-versions.json",
                 new TypeReference<Map<String, StoredSecretVersion>>() {});
+        this.pendingDeletionStore = storageFactory.createGlobal("secretmanager-deletions", "secretmanager-deletions.json",
+                new TypeReference<Map<String, String>>() {});
     }
 
     SecretManagerService(StorageBackend<String, StoredSecret> secretStore,
-            StorageBackend<String, StoredSecretVersion> versionStore, IamService iamService) {
+            StorageBackend<String, StoredSecretVersion> versionStore,
+            StorageBackend<String, String> pendingDeletionStore, IamService iamService) {
         this.secretStore = secretStore;
         this.versionStore = versionStore;
+        this.pendingDeletionStore = pendingDeletionStore;
         this.serviceRegistry = null;
         this.config = null;
         this.grpcServerManager = null;
@@ -64,6 +69,7 @@ public class SecretManagerService {
     }
 
     void onStart(@Observes StartupEvent ev) {
+        resumePendingDeletions();
         serviceRegistry.register(ServiceDescriptor.builder("secretmanager")
                 .enabled(config.services().secretmanager().enabled())
                 .storageKey("secretmanager")
@@ -83,6 +89,7 @@ public class SecretManagerService {
     public StoredSecret createSecret(String project, String secretId, String replicationType) {
         String name = "projects/" + project + "/secrets/" + secretId;
         LOG.infof("createSecret name=%s", name);
+        resumePendingDeletion(name);
         if (secretStore.get(name).isPresent()) {
             throw GcpException.alreadyExists("Secret already exists: " + name);
         }
@@ -93,6 +100,9 @@ public class SecretManagerService {
 
     public StoredSecret getSecret(String name) {
         LOG.debugf("getSecret name=%s", name);
+        if (pendingDeletionStore.get(name).isPresent()) {
+            throw GcpException.notFound("Secret not found: " + name);
+        }
         return secretStore.get(name)
                 .orElseThrow(() -> GcpException.notFound("Secret not found: " + name));
     }
@@ -114,6 +124,37 @@ public class SecretManagerService {
         if (secretStore.get(name).isEmpty()) {
             throw GcpException.notFound("Secret not found: " + name);
         }
+        pendingDeletionStore.put(name, name);
+        pendingDeletionStore.flush();
+        completeDeletion(name);
+        clearPendingDeletion(name);
+    }
+
+    /**
+     * Completes deletions that were durably marked before an interrupted delete.
+     * A deletion marker is written before any of the independently persisted
+     * secret, version, and IAM policy records change, so replaying this work is
+     * safe and prevents a recreated secret from inheriting stale state.
+     */
+    void resumePendingDeletions() {
+        pendingDeletionStore.scan(key -> true).forEach(this::resumePendingDeletion);
+    }
+
+    private void resumePendingDeletion(String name) {
+        if (pendingDeletionStore.get(name).isEmpty()) {
+            return;
+        }
+        LOG.warnf("Resuming interrupted deletion for secret %s", name);
+        completeDeletion(name);
+        clearPendingDeletion(name);
+    }
+
+    private void clearPendingDeletion(String name) {
+        pendingDeletionStore.delete(name);
+        pendingDeletionStore.flush();
+    }
+
+    private void completeDeletion(String name) {
         iamService.deleteResourceAndPolicy(name, () -> {
             String versionPrefix = name + "/versions/";
             versionStore.scan(k -> k.startsWith(versionPrefix))

--- a/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
+++ b/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.secretmanager;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.iam.v1.Policy;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.ServiceDescriptor;
@@ -9,6 +10,9 @@ import io.floci.gcp.core.common.ServiceRegistry;
 import io.floci.gcp.core.storage.StorageBackend;
 import io.floci.gcp.core.storage.StorageFactory;
 import io.floci.gcp.lifecycle.GrpcServerManager;
+import io.floci.gcp.services.iam.IamService;
+import io.floci.gcp.services.iam.IamPolicyCodec;
+import io.floci.gcp.services.iam.model.StoredPolicy;
 import io.floci.gcp.services.secretmanager.model.StoredSecret;
 import io.floci.gcp.services.secretmanager.model.StoredSecretVersion;
 import io.quarkus.runtime.StartupEvent;
@@ -33,13 +37,15 @@ public class SecretManagerService {
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
     private final GrpcServerManager grpcServerManager;
+    private final IamService iamService;
 
     @Inject
     public SecretManagerService(ServiceRegistry serviceRegistry, EmulatorConfig config,
-            StorageFactory storageFactory, GrpcServerManager grpcServerManager) {
+            StorageFactory storageFactory, GrpcServerManager grpcServerManager, IamService iamService) {
         this.serviceRegistry = serviceRegistry;
         this.config = config;
         this.grpcServerManager = grpcServerManager;
+        this.iamService = iamService;
         this.secretStore = storageFactory.createGlobal("secretmanager-secrets", "secretmanager-secrets.json",
                 new TypeReference<Map<String, StoredSecret>>() {});
         this.versionStore = storageFactory.createGlobal("secretmanager-versions", "secretmanager-versions.json",
@@ -47,12 +53,14 @@ public class SecretManagerService {
     }
 
     SecretManagerService(StorageBackend<String, StoredSecret> secretStore,
-            StorageBackend<String, StoredSecretVersion> versionStore) {
+            StorageBackend<String, StoredSecretVersion> versionStore, IamService iamService) {
         this.secretStore = secretStore;
         this.versionStore = versionStore;
         this.serviceRegistry = null;
         this.config = null;
         this.grpcServerManager = null;
+        this.iamService = iamService;
+        registerPolicyResolver();
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -63,6 +71,11 @@ public class SecretManagerService {
                 .resourceClasses(SecretManagerController.class)
                 .build());
         grpcServerManager.bind(new SecretManagerController(this));
+        registerPolicyResolver();
+    }
+
+    private void registerPolicyResolver() {
+        iamService.registerPolicyResourceResolver("projects/*/secrets/*", this::getSecret);
     }
 
     // ── Secrets ────────────────────────────────────────────────────────────────
@@ -101,10 +114,25 @@ public class SecretManagerService {
         if (secretStore.get(name).isEmpty()) {
             throw GcpException.notFound("Secret not found: " + name);
         }
-        String versionPrefix = name + "/versions/";
-        versionStore.scan(k -> k.startsWith(versionPrefix))
-                .forEach(v -> versionStore.delete(v.getName()));
-        secretStore.delete(name);
+        iamService.deleteResourceAndPolicy(name, () -> {
+            String versionPrefix = name + "/versions/";
+            versionStore.scan(k -> k.startsWith(versionPrefix))
+                    .forEach(v -> versionStore.delete(v.getName()));
+            secretStore.delete(name);
+        });
+    }
+
+    public Policy getIamPolicy(String resource) {
+        return IamPolicyCodec.toProtoPolicy(iamService.getPolicy(resource));
+    }
+
+    public Policy setIamPolicy(String resource, Policy policy) {
+        StoredPolicy stored = IamPolicyCodec.toStoredPolicy(policy);
+        return IamPolicyCodec.toProtoPolicy(iamService.setPolicy(resource, stored));
+    }
+
+    public List<String> testIamPermissions(String resource, List<String> permissions) {
+        return iamService.testPermissions(resource, permissions);
     }
 
     // ── Versions ───────────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
+++ b/src/main/java/io/floci/gcp/services/secretmanager/SecretManagerService.java
@@ -25,15 +25,18 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 @ApplicationScoped
 public class SecretManagerService {
 
     private static final Logger LOG = Logger.getLogger(SecretManagerService.class);
+    private static final int SECRET_LOCK_COUNT = 256;
 
     private final StorageBackend<String, StoredSecret> secretStore;
     private final StorageBackend<String, StoredSecretVersion> versionStore;
     private final StorageBackend<String, String> pendingDeletionStore;
+    private final Object[] secretLocks = createSecretLocks();
 
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
@@ -81,7 +84,7 @@ public class SecretManagerService {
     }
 
     private void registerPolicyResolver() {
-        iamService.registerPolicyResourceResolver("projects/*/secrets/*", this::getSecret);
+        iamService.registerPolicyResourceResolver("projects/*/secrets/*", this::requireSecretExists);
     }
 
     // ── Secrets ────────────────────────────────────────────────────────────────
@@ -89,22 +92,30 @@ public class SecretManagerService {
     public StoredSecret createSecret(String project, String secretId, String replicationType) {
         String name = "projects/" + project + "/secrets/" + secretId;
         LOG.infof("createSecret name=%s", name);
-        resumePendingDeletion(name);
-        if (secretStore.get(name).isPresent()) {
-            throw GcpException.alreadyExists("Secret already exists: " + name);
+        synchronized (secretLock(name)) {
+            resumePendingDeletion(name);
+            if (secretStore.get(name).isPresent()) {
+                throw GcpException.alreadyExists("Secret already exists: " + name);
+            }
+            StoredSecret secret = new StoredSecret(name, Instant.now().toString(), replicationType);
+            secretStore.put(name, secret);
+            return secret;
         }
-        StoredSecret secret = new StoredSecret(name, Instant.now().toString(), replicationType);
-        secretStore.put(name, secret);
-        return secret;
     }
 
     public StoredSecret getSecret(String name) {
         LOG.debugf("getSecret name=%s", name);
+        requireSecretExists(name);
+        return secretStore.get(name).orElseThrow();
+    }
+
+    private void requireSecretExists(String name) {
         if (pendingDeletionStore.get(name).isPresent()) {
             throw GcpException.notFound("Secret not found: " + name);
         }
-        return secretStore.get(name)
-                .orElseThrow(() -> GcpException.notFound("Secret not found: " + name));
+        if (secretStore.get(name).isEmpty()) {
+            throw GcpException.notFound("Secret not found: " + name);
+        }
     }
 
     public List<StoredSecret> listSecrets(String project) {
@@ -115,19 +126,21 @@ public class SecretManagerService {
 
     public StoredSecret updateSecret(String name) {
         LOG.debugf("updateSecret name=%s", name);
-        return secretStore.get(name)
-                .orElseThrow(() -> GcpException.notFound("Secret not found: " + name));
+        requireSecretExists(name);
+        return secretStore.get(name).orElseThrow();
     }
 
     public void deleteSecret(String name) {
         LOG.infof("deleteSecret name=%s", name);
-        if (secretStore.get(name).isEmpty()) {
-            throw GcpException.notFound("Secret not found: " + name);
+        synchronized (secretLock(name)) {
+            if (secretStore.get(name).isEmpty()) {
+                throw GcpException.notFound("Secret not found: " + name);
+            }
+            pendingDeletionStore.put(name, name);
+            pendingDeletionStore.flush();
+            completeDeletion(name);
+            clearPendingDeletion(name);
         }
-        pendingDeletionStore.put(name, name);
-        pendingDeletionStore.flush();
-        completeDeletion(name);
-        clearPendingDeletion(name);
     }
 
     /**
@@ -141,12 +154,14 @@ public class SecretManagerService {
     }
 
     private void resumePendingDeletion(String name) {
-        if (pendingDeletionStore.get(name).isEmpty()) {
-            return;
+        synchronized (secretLock(name)) {
+            if (pendingDeletionStore.get(name).isEmpty()) {
+                return;
+            }
+            LOG.warnf("Resuming interrupted deletion for secret %s", name);
+            completeDeletion(name);
+            clearPendingDeletion(name);
         }
-        LOG.warnf("Resuming interrupted deletion for secret %s", name);
-        completeDeletion(name);
-        clearPendingDeletion(name);
     }
 
     private void clearPendingDeletion(String name) {
@@ -180,30 +195,37 @@ public class SecretManagerService {
 
     public StoredSecretVersion addSecretVersion(String secretName, byte[] payload, Long dataCrc32c) {
         LOG.infof("addSecretVersion secret=%s", secretName);
-        if (secretStore.get(secretName).isEmpty()) {
-            throw GcpException.notFound("Secret not found: " + secretName);
+        synchronized (secretLock(secretName)) {
+            requireSecretExists(secretName);
+            int versionNumber = nextVersionNumber(secretName);
+            String versionName = secretName + "/versions/" + versionNumber;
+            StoredSecretVersion version = new StoredSecretVersion(versionName, versionNumber,
+                    Instant.now().toString(), payload, dataCrc32c);
+            versionStore.put(versionName, version);
+            return version;
         }
-        int versionNumber = nextVersionNumber(secretName);
-        String versionName = secretName + "/versions/" + versionNumber;
-        StoredSecretVersion version = new StoredSecretVersion(versionName, versionNumber,
-                Instant.now().toString(), payload, dataCrc32c);
-        versionStore.put(versionName, version);
-        return version;
     }
 
     public StoredSecretVersion getSecretVersion(String versionedName) {
         LOG.debugf("getSecretVersion name=%s", versionedName);
+        String secretName = secretNameForVersion(versionedName);
+        requireSecretExists(secretName);
         return resolveVersion(versionedName);
     }
 
     public List<StoredSecretVersion> listSecretVersions(String secretName) {
         LOG.debugf("listSecretVersions secret=%s", secretName);
+        if (pendingDeletionStore.get(secretName).isPresent()) {
+            return List.of();
+        }
         String prefix = secretName + "/versions/";
         return versionStore.scan(k -> k.startsWith(prefix));
     }
 
     public StoredSecretVersion accessSecretVersion(String versionedName) {
         LOG.debugf("accessSecretVersion name=%s", versionedName);
+        String secretName = secretNameForVersion(versionedName);
+        requireSecretExists(secretName);
         StoredSecretVersion version = resolveVersion(versionedName);
         if ("DESTROYED".equals(version.getState())) {
             throw GcpException.notFound("Secret version is destroyed: " + version.getName());
@@ -216,28 +238,21 @@ public class SecretManagerService {
 
     public StoredSecretVersion disableSecretVersion(String versionedName) {
         LOG.infof("disableSecretVersion name=%s", versionedName);
-        StoredSecretVersion version = resolveVersion(versionedName);
-        version.setState("DISABLED");
-        versionStore.put(version.getName(), version);
-        return version;
+        return updateSecretVersion(versionedName, version -> version.setState("DISABLED"));
     }
 
     public StoredSecretVersion enableSecretVersion(String versionedName) {
         LOG.infof("enableSecretVersion name=%s", versionedName);
-        StoredSecretVersion version = resolveVersion(versionedName);
-        version.setState("ENABLED");
-        versionStore.put(version.getName(), version);
-        return version;
+        return updateSecretVersion(versionedName, version -> version.setState("ENABLED"));
     }
 
     public StoredSecretVersion destroySecretVersion(String versionedName) {
         LOG.infof("destroySecretVersion name=%s", versionedName);
-        StoredSecretVersion version = resolveVersion(versionedName);
-        version.setState("DESTROYED");
-        version.setPayload(null);
-        version.setDestroyTime(Instant.now().toString());
-        versionStore.put(version.getName(), version);
-        return version;
+        return updateSecretVersion(versionedName, version -> {
+            version.setState("DESTROYED");
+            version.setPayload(null);
+            version.setDestroyTime(Instant.now().toString());
+        });
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
@@ -258,5 +273,36 @@ public class SecretManagerService {
         }
         return versionStore.get(versionedName)
                 .orElseThrow(() -> GcpException.notFound("Version not found: " + versionedName));
+    }
+
+    private StoredSecretVersion updateSecretVersion(String versionedName, Consumer<StoredSecretVersion> update) {
+        String secretName = secretNameForVersion(versionedName);
+        synchronized (secretLock(secretName)) {
+            requireSecretExists(secretName);
+            StoredSecretVersion version = resolveVersion(versionedName);
+            update.accept(version);
+            versionStore.put(version.getName(), version);
+            return version;
+        }
+    }
+
+    private static Object[] createSecretLocks() {
+        Object[] locks = new Object[SECRET_LOCK_COUNT];
+        for (int i = 0; i < locks.length; i++) {
+            locks[i] = new Object();
+        }
+        return locks;
+    }
+
+    private Object secretLock(String secretName) {
+        return secretLocks[Math.floorMod(secretName.hashCode(), secretLocks.length)];
+    }
+
+    private String secretNameForVersion(String versionedName) {
+        int versionIndex = versionedName.indexOf("/versions/");
+        if (versionIndex < 0) {
+            throw GcpException.notFound("Version not found: " + versionedName);
+        }
+        return versionedName.substring(0, versionIndex);
     }
 }

--- a/src/test/java/io/floci/gcp/services/iam/IamServices.java
+++ b/src/test/java/io/floci/gcp/services/iam/IamServices.java
@@ -1,6 +1,10 @@
 package io.floci.gcp.services.iam;
 
 import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.services.iam.model.StoredPolicy;
+import io.floci.gcp.services.iam.model.StoredServiceAccount;
+import io.floci.gcp.services.iam.model.StoredServiceAccountKey;
 
 /** Test factory granting other packages access to the package-private constructor. */
 public final class IamServices {
@@ -9,5 +13,11 @@ public final class IamServices {
 
     public static IamService inMemory() {
         return new IamService(new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>());
+    }
+
+    public static IamService withStores(StorageBackend<String, StoredServiceAccount> serviceAccounts,
+            StorageBackend<String, StoredServiceAccountKey> serviceAccountKeys,
+            StorageBackend<String, StoredPolicy> policies) {
+        return new IamService(serviceAccounts, serviceAccountKeys, policies);
     }
 }

--- a/src/test/java/io/floci/gcp/services/resourcemanager/ResourceManagerRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/resourcemanager/ResourceManagerRestIntegrationTest.java
@@ -30,4 +30,52 @@ class ResourceManagerRestIntegrationTest {
                 .statusCode(200)
                 .body("projectNumber", equalTo(projectNumber));
     }
+
+    @Test
+    void projectIamPolicyUsesPostForEveryMixinMethod() {
+        String base = "/v1/projects/crm-iam-test";
+
+        String etag = given().urlEncodingEnabled(false).contentType("application/json")
+                .body("{\"policy\":{\"bindings\":[{\"role\":\"roles/pubsub.publisher\",\"members\":[\"user:publisher@example.com\"]}]}}")
+                .when().post(base + ":setIamPolicy")
+                .then().statusCode(200)
+                .body("bindings[0].role", equalTo("roles/pubsub.publisher"))
+                .extract().path("etag");
+
+        given().urlEncodingEnabled(false).contentType("application/json").body("{}")
+                .when().post(base + ":getIamPolicy")
+                .then().statusCode(200)
+                .body("etag", equalTo(etag))
+                .body("bindings[0].members[0]", equalTo("user:publisher@example.com"));
+
+        given().urlEncodingEnabled(false).contentType("application/json")
+                .body("{\"permissions\":[\"resourcemanager.projects.get\",\"resourcemanager.projects.delete\"]}")
+                .when().post(base + ":testIamPermissions")
+                .then().statusCode(200)
+                .body("permissions[0]", equalTo("resourcemanager.projects.get"))
+                .body("permissions[1]", equalTo("resourcemanager.projects.delete"));
+
+        given().urlEncodingEnabled(false).when().get(base + ":getIamPolicy").then().statusCode(405);
+        given().urlEncodingEnabled(false).when().get(base + ":setIamPolicy").then().statusCode(405);
+        given().urlEncodingEnabled(false).when().get(base + ":testIamPermissions").then().statusCode(405);
+    }
+
+    @Test
+    void staleProjectIamWriteLeavesCurrentPolicyIntact() {
+        String base = "/v1/projects/crm-iam-etag-test";
+
+        given().urlEncodingEnabled(false).contentType("application/json")
+                .body("{\"policy\":{\"bindings\":[{\"role\":\"roles/viewer\",\"members\":[\"user:reader@example.com\"]}]}}")
+                .when().post(base + ":setIamPolicy").then().statusCode(200);
+
+        given().urlEncodingEnabled(false).contentType("application/json")
+                .body("{\"policy\":{\"etag\":\"stale\",\"bindings\":[]}}")
+                .when().post(base + ":setIamPolicy")
+                .then().statusCode(409).body("error.status", equalTo("ABORTED"));
+
+        given().urlEncodingEnabled(false).contentType("application/json").body("{}")
+                .when().post(base + ":getIamPolicy")
+                .then().statusCode(200)
+                .body("bindings[0].role", equalTo("roles/viewer"));
+    }
 }

--- a/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerDeletionRecoveryPersistenceTest.java
+++ b/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerDeletionRecoveryPersistenceTest.java
@@ -1,0 +1,129 @@
+package io.floci.gcp.services.secretmanager;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.HybridStorage;
+import io.floci.gcp.core.storage.PersistentStorage;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.WalStorage;
+import io.floci.gcp.services.iam.IamServices;
+import io.floci.gcp.services.iam.model.StoredPolicy;
+import io.floci.gcp.services.iam.model.StoredServiceAccount;
+import io.floci.gcp.services.iam.model.StoredServiceAccountKey;
+import io.floci.gcp.services.secretmanager.model.StoredSecret;
+import io.floci.gcp.services.secretmanager.model.StoredSecretVersion;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SecretManagerDeletionRecoveryPersistenceTest {
+
+    @TempDir
+    Path storagePath;
+
+    @ParameterizedTest
+    @EnumSource(StorageMode.class)
+    void resumesInterruptedDeletionAfterRestart(StorageMode mode) {
+        String resource = "projects/p1/secrets/persisted-delete";
+        try (Stores first = new Stores(storagePath, mode)) {
+            SecretManagerService service = first.service();
+            service.createSecret("p1", "persisted-delete", "automatic");
+            service.addSecretVersion(resource, new byte[]{1}, null);
+            service.setIamPolicy(resource, Policy.newBuilder()
+                    .addBindings(Binding.newBuilder()
+                            .setRole("roles/secretmanager.secretAccessor")
+                            .addMembers("user:reader@example.com"))
+                    .build());
+            first.flushResourceState();
+
+            // This is the durable state immediately before the deletion cleanup begins.
+            first.pendingDeletions.put(resource, resource);
+            first.pendingDeletions.flush();
+        }
+
+        try (Stores restarted = new Stores(storagePath, mode)) {
+            SecretManagerService service = restarted.service();
+            service.resumePendingDeletions();
+
+            assertThrows(GcpException.class, () -> service.getSecret(resource));
+            assertTrue(service.listSecretVersions(resource).isEmpty());
+
+            service.createSecret("p1", "persisted-delete", "automatic");
+            assertTrue(service.getIamPolicy(resource).getBindingsList().isEmpty());
+        }
+    }
+
+    private enum StorageMode {
+        PERSISTENT, WAL, HYBRID
+    }
+
+    private static final class Stores implements AutoCloseable {
+        private static final long FLUSH_INTERVAL_MS = 60_000L;
+
+        private final List<StorageBackend<?, ?>> backends = new ArrayList<>();
+        private final StorageBackend<String, StoredSecret> secrets;
+        private final StorageBackend<String, StoredSecretVersion> versions;
+        private final StorageBackend<String, String> pendingDeletions;
+        private final StorageBackend<String, StoredPolicy> policies;
+        private final SecretManagerService service;
+
+        private Stores(Path storagePath, StorageMode mode) {
+            secrets = create(storagePath, mode, "secrets", new TypeReference<Map<String, StoredSecret>>() {});
+            versions = create(storagePath, mode, "versions", new TypeReference<Map<String, StoredSecretVersion>>() {});
+            pendingDeletions = create(storagePath, mode, "deletions", new TypeReference<Map<String, String>>() {});
+            StorageBackend<String, StoredServiceAccount> serviceAccounts = create(storagePath, mode, "service-accounts",
+                    new TypeReference<Map<String, StoredServiceAccount>>() {});
+            StorageBackend<String, StoredServiceAccountKey> serviceAccountKeys = create(storagePath, mode, "service-account-keys",
+                    new TypeReference<Map<String, StoredServiceAccountKey>>() {});
+            policies = create(storagePath, mode, "policies", new TypeReference<Map<String, StoredPolicy>>() {});
+            service = new SecretManagerService(secrets, versions, pendingDeletions,
+                    IamServices.withStores(serviceAccounts, serviceAccountKeys, policies));
+        }
+
+        private SecretManagerService service() {
+            return service;
+        }
+
+        private void flushResourceState() {
+            secrets.flush();
+            versions.flush();
+            policies.flush();
+        }
+
+        private <T> StorageBackend<String, T> create(Path storagePath, StorageMode mode, String name,
+                TypeReference<Map<String, T>> type) {
+            StorageBackend<String, T> backend = switch (mode) {
+                case PERSISTENT -> new PersistentStorage<>(storagePath.resolve(name + ".json"), type);
+                case WAL -> new WalStorage<>(storagePath.resolve(name + "-snapshot.json"),
+                        storagePath.resolve(name + ".wal"), type, FLUSH_INTERVAL_MS);
+                case HYBRID -> new HybridStorage<>(storagePath.resolve(name + ".json"), type, FLUSH_INTERVAL_MS);
+            };
+            backend.load();
+            backends.add(backend);
+            return backend;
+        }
+
+        @Override
+        public void close() {
+            for (StorageBackend<?, ?> backend : backends) {
+                if (backend instanceof HybridStorage<?, ?> hybrid) {
+                    hybrid.shutdown();
+                } else if (backend instanceof WalStorage<?, ?> wal) {
+                    wal.shutdown();
+                } else {
+                    backend.flush();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerRestIntegrationTest.java
@@ -1,0 +1,82 @@
+package io.floci.gcp.services.secretmanager;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class SecretManagerRestIntegrationTest {
+
+    @Test
+    void iamPolicyUsesGetForReadAndPostForWrites() {
+        String project = "secret-iam-rest-it";
+        String base = "/v1/projects/" + project + "/secrets/iam-target";
+
+        given().contentType("application/json")
+                .body("{\"replication\": {\"automatic\": {}}}")
+                .queryParam("secretId", "iam-target")
+                .when().post("/v1/projects/" + project + "/secrets")
+                .then().statusCode(200);
+
+        String etag = given().urlEncodingEnabled(false)
+                .contentType("application/json")
+                .body("""
+                        {"policy":{"bindings":[{"role":"roles/secretmanager.secretAccessor",
+                        "members":["user:reader@example.com"]}]}}
+                        """)
+                .when().post(base + ":setIamPolicy")
+                .then().statusCode(200)
+                .body("bindings[0].role", equalTo("roles/secretmanager.secretAccessor"))
+                .extract().path("etag");
+
+        given().urlEncodingEnabled(false)
+                .when().get(base + ":getIamPolicy")
+                .then().statusCode(200)
+                .body("etag", equalTo(etag))
+                .body("bindings[0].members[0]", equalTo("user:reader@example.com"));
+
+        given().urlEncodingEnabled(false).contentType("application/json")
+                .body("{\"permissions\":[\"secretmanager.secrets.get\"]}")
+                .when().post(base + ":testIamPermissions")
+                .then().statusCode(200)
+                .body("permissions[0]", equalTo("secretmanager.secrets.get"));
+
+        given().urlEncodingEnabled(false).contentType("application/json").body("{}")
+                .when().post(base + ":getIamPolicy")
+                .then().statusCode(405);
+        given().urlEncodingEnabled(false).when().get(base + ":setIamPolicy")
+                .then().statusCode(405);
+        given().urlEncodingEnabled(false).when().get(base + ":testIamPermissions")
+                .then().statusCode(405);
+    }
+
+    @Test
+    void iamPolicyDoesNotSurviveSecretDeletion() {
+        String project = "secret-iam-delete-it";
+        String base = "/v1/projects/" + project + "/secrets/iam-target";
+
+        given().contentType("application/json")
+                .body("{\"replication\": {\"automatic\": {}}}")
+                .queryParam("secretId", "iam-target")
+                .when().post("/v1/projects/" + project + "/secrets")
+                .then().statusCode(200);
+        given().urlEncodingEnabled(false).contentType("application/json")
+                .body("{\"policy\":{\"bindings\":[{\"role\":\"roles/secretmanager.viewer\",\"members\":[\"user:reader@example.com\"]}]}}")
+                .when().post(base + ":setIamPolicy").then().statusCode(200);
+
+        given().when().delete(base).then().statusCode(200);
+        given().urlEncodingEnabled(false).when().get(base + ":getIamPolicy")
+                .then().statusCode(404).body("error.status", equalTo("NOT_FOUND"));
+
+        given().contentType("application/json")
+                .body("{\"replication\": {\"automatic\": {}}}")
+                .queryParam("secretId", "iam-target")
+                .when().post("/v1/projects/" + project + "/secrets")
+                .then().statusCode(200);
+        given().urlEncodingEnabled(false).when().get(base + ":getIamPolicy")
+                .then().statusCode(200).body("bindings", empty());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
@@ -4,6 +4,7 @@ import com.google.iam.v1.Binding;
 import com.google.iam.v1.Policy;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.iam.IamServices;
 import io.floci.gcp.services.secretmanager.model.StoredSecret;
 import io.floci.gcp.services.secretmanager.model.StoredSecretVersion;
@@ -18,13 +19,18 @@ import static org.junit.jupiter.api.Assertions.*;
 class SecretManagerServiceTest {
 
     private SecretManagerService service;
+    private InMemoryStorage<String, StoredSecret> secretStore;
+    private InMemoryStorage<String, StoredSecretVersion> versionStore;
+    private InMemoryStorage<String, String> pendingDeletionStore;
+    private IamService iamService;
 
     @BeforeEach
     void setUp() {
-        service = new SecretManagerService(
-                new InMemoryStorage<>(),
-                new InMemoryStorage<>(),
-                IamServices.inMemory());
+        secretStore = new InMemoryStorage<>();
+        versionStore = new InMemoryStorage<>();
+        pendingDeletionStore = new InMemoryStorage<>();
+        iamService = IamServices.inMemory();
+        service = new SecretManagerService(secretStore, versionStore, pendingDeletionStore, iamService);
     }
 
     @Test
@@ -158,6 +164,30 @@ class SecretManagerServiceTest {
 
         service.createSecret("p1", "iam-target", "automatic");
         assertTrue(service.getIamPolicy(resource).getBindingsList().isEmpty());
+    }
+
+    @Test
+    void resumesInterruptedDeletionBeforeRecreatingSecret() {
+        String resource = "projects/p1/secrets/interrupted-delete";
+        service.createSecret("p1", "interrupted-delete", "automatic");
+        service.addSecretVersion(resource, new byte[]{1}, null);
+        service.setIamPolicy(resource, Policy.newBuilder()
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/secretmanager.secretAccessor")
+                        .addMembers("user:reader@example.com"))
+                .build());
+
+        // Simulate a process stopping after durable deletion intent is recorded.
+        pendingDeletionStore.put(resource, resource);
+        SecretManagerService restarted = new SecretManagerService(
+                secretStore, versionStore, pendingDeletionStore, iamService);
+
+        restarted.resumePendingDeletions();
+        assertThrows(GcpException.class, () -> restarted.getSecret(resource));
+        assertTrue(restarted.listSecretVersions(resource).isEmpty());
+
+        restarted.createSecret("p1", "interrupted-delete", "automatic");
+        assertTrue(restarted.getIamPolicy(resource).getBindingsList().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
@@ -6,6 +6,7 @@ import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.storage.InMemoryStorage;
 import io.floci.gcp.services.iam.IamService;
 import io.floci.gcp.services.iam.IamServices;
+import io.floci.gcp.services.iam.model.StoredPolicy;
 import io.floci.gcp.services.secretmanager.model.StoredSecret;
 import io.floci.gcp.services.secretmanager.model.StoredSecretVersion;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -232,6 +234,25 @@ class SecretManagerServiceTest {
     }
 
     @Test
+    void flushesDeletedStateBeforeClearingDeletionIntent() {
+        String resource = "projects/p1/secrets/flush-order";
+        List<String> flushes = new CopyOnWriteArrayList<>();
+        RecordingStorage<StoredSecret> secrets = new RecordingStorage<>("secrets", flushes);
+        RecordingStorage<StoredSecretVersion> versions = new RecordingStorage<>("versions", flushes);
+        RecordingStorage<String> deletions = new RecordingStorage<>("deletions", flushes);
+        RecordingStorage<StoredPolicy> policies = new RecordingStorage<>("policies", flushes);
+        SecretManagerService flushService = new SecretManagerService(secrets, versions, deletions,
+                IamServices.withStores(new InMemoryStorage<>(), new InMemoryStorage<>(), policies));
+        flushService.createSecret("p1", "flush-order", "automatic");
+        flushService.addSecretVersion(resource, new byte[]{1}, null);
+        flushService.setIamPolicy(resource, Policy.getDefaultInstance());
+
+        flushService.deleteSecret(resource);
+
+        assertEquals(List.of("deletions", "policies", "versions", "secrets", "deletions"), flushes);
+    }
+
+    @Test
     void testIamPermissionsEchoesRequestedPermissionsForExistingSecret() {
         String resource = "projects/p1/secrets/permission-target";
         service.createSecret("p1", "permission-target", "automatic");
@@ -269,6 +290,21 @@ class SecretManagerServiceTest {
 
         void releaseFlush() {
             allowFirstFlush.countDown();
+        }
+    }
+
+    private static final class RecordingStorage<T> extends InMemoryStorage<String, T> {
+        private final String name;
+        private final List<String> flushes;
+
+        private RecordingStorage(String name, List<String> flushes) {
+            this.name = name;
+            this.flushes = flushes;
+        }
+
+        @Override
+        public void flush() {
+            flushes.add(name);
         }
     }
 }

--- a/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
@@ -1,7 +1,10 @@
 package io.floci.gcp.services.secretmanager;
 
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.Policy;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.iam.IamServices;
 import io.floci.gcp.services.secretmanager.model.StoredSecret;
 import io.floci.gcp.services.secretmanager.model.StoredSecretVersion;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +23,8 @@ class SecretManagerServiceTest {
     void setUp() {
         service = new SecretManagerService(
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>());
+                new InMemoryStorage<>(),
+                IamServices.inMemory());
     }
 
     @Test
@@ -129,5 +133,40 @@ class SecretManagerServiceTest {
         List<StoredSecret> secrets = service.listSecrets("p1");
         assertEquals(2, secrets.size());
         assertTrue(secrets.stream().allMatch(s -> s.getName().startsWith("projects/p1")));
+    }
+
+    @Test
+    void iamPolicyRoundTripsRejectsStaleEtagAndIsClearedOnDelete() {
+        String resource = "projects/p1/secrets/iam-target";
+        service.createSecret("p1", "iam-target", "automatic");
+
+        Policy saved = service.setIamPolicy(resource, Policy.newBuilder()
+                .addBindings(Binding.newBuilder()
+                        .setRole("roles/secretmanager.secretAccessor")
+                        .addMembers("user:reader@example.com"))
+                .build());
+
+        assertEquals("roles/secretmanager.secretAccessor", service.getIamPolicy(resource)
+                .getBindings(0).getRole());
+        assertThrows(GcpException.class, () -> service.setIamPolicy(resource, Policy.newBuilder()
+                .setEtag(com.google.protobuf.ByteString.copyFromUtf8("stale"))
+                .build()));
+        assertEquals(saved.getEtag(), service.getIamPolicy(resource).getEtag());
+
+        service.deleteSecret(resource);
+        assertThrows(GcpException.class, () -> service.getIamPolicy(resource));
+
+        service.createSecret("p1", "iam-target", "automatic");
+        assertTrue(service.getIamPolicy(resource).getBindingsList().isEmpty());
+    }
+
+    @Test
+    void testIamPermissionsEchoesRequestedPermissionsForExistingSecret() {
+        String resource = "projects/p1/secrets/permission-target";
+        service.createSecret("p1", "permission-target", "automatic");
+
+        assertEquals(List.of("secretmanager.secrets.get", "secretmanager.secrets.delete"),
+                service.testIamPermissions(resource,
+                        List.of("secretmanager.secrets.get", "secretmanager.secrets.delete")));
     }
 }

--- a/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/secretmanager/SecretManagerServiceTest.java
@@ -13,6 +13,12 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -191,6 +197,41 @@ class SecretManagerServiceTest {
     }
 
     @Test
+    void serializesDeleteWithConcurrentRecreateAndVersionMutation() throws Exception {
+        String resource = "projects/p1/secrets/racing-delete";
+        BlockingFlushStorage deletionStore = new BlockingFlushStorage();
+        SecretManagerService racingService = new SecretManagerService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), deletionStore, IamServices.inMemory());
+        racingService.createSecret("p1", "racing-delete", "automatic");
+
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        try {
+            Future<?> delete = executor.submit(() -> racingService.deleteSecret(resource));
+            assertTrue(deletionStore.awaitFirstFlush());
+
+            Future<StoredSecret> recreate = executor.submit(
+                    () -> racingService.createSecret("p1", "racing-delete", "automatic"));
+            Future<StoredSecretVersion> addVersion = executor.submit(
+                    () -> racingService.addSecretVersion(resource, new byte[]{1}, null));
+            assertFalse(recreate.isDone());
+            assertFalse(addVersion.isDone());
+
+            deletionStore.releaseFlush();
+            delete.get(5, TimeUnit.SECONDS);
+            assertEquals(resource, recreate.get(5, TimeUnit.SECONDS).getName());
+            try {
+                StoredSecretVersion added = addVersion.get(5, TimeUnit.SECONDS);
+                assertEquals(resource + "/versions/1", added.getName());
+            } catch (ExecutionException e) {
+                assertInstanceOf(GcpException.class, e.getCause());
+            }
+            assertEquals(resource, racingService.getSecret(resource).getName());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void testIamPermissionsEchoesRequestedPermissionsForExistingSecret() {
         String resource = "projects/p1/secrets/permission-target";
         service.createSecret("p1", "permission-target", "automatic");
@@ -198,5 +239,36 @@ class SecretManagerServiceTest {
         assertEquals(List.of("secretmanager.secrets.get", "secretmanager.secrets.delete"),
                 service.testIamPermissions(resource,
                         List.of("secretmanager.secrets.get", "secretmanager.secrets.delete")));
+    }
+
+    private static final class BlockingFlushStorage extends InMemoryStorage<String, String> {
+        private final CountDownLatch firstFlushStarted = new CountDownLatch(1);
+        private final CountDownLatch allowFirstFlush = new CountDownLatch(1);
+        private boolean firstFlush = true;
+
+        @Override
+        public synchronized void flush() {
+            if (!firstFlush) {
+                return;
+            }
+            firstFlush = false;
+            firstFlushStarted.countDown();
+            try {
+                if (!allowFirstFlush.await(5, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Timed out waiting to release deletion flush");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("Interrupted while waiting to release deletion flush", e);
+            }
+        }
+
+        boolean awaitFirstFlush() throws InterruptedException {
+            return firstFlushStarted.await(5, TimeUnit.SECONDS);
+        }
+
+        void releaseFlush() {
+            allowFirstFlush.countDown();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements real IAM policy support for Cloud Resource Manager projects and Secret Manager secrets.

Fixes #143.

## Changes

- Persist Secret Manager IAM policies across REST and gRPC calls.
- Add project-level Cloud Resource Manager IAM policy mixins.
- Reuse shared IAM etag, conflict, locking, and cleanup behavior.
- Persist Secret Manager deletion intent and resume incomplete cleanup before startup serves requests or a secret name is recreated.
- Add Terraform/OpenTofu coverage and document the non-enforcement boundary.

## Validation

- `./mvnw test`
- `./mvnw test -Dtest=SecretManagerServiceTest,SecretManagerRestIntegrationTest`
- Terraform targeted apply, no-op plan, and destroy
- OpenTofu targeted apply, no-op plan, and destroy