### PR TITLE
docs: correct GcpGrpcController guidance and gRPC service list in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ floci-gcp follows a layered design:
 - `ServiceRegistry`
 - `StorageBackend` + `StorageFactory`
 - `GcpException` + `GcpExceptionMapper`
-- `GcpGrpcController` — base class for gRPC service implementations
+- `GcpGrpcController` — shared gRPC error-mapping helper (static `grpcError`); not a base class
 - `ProjectContextFilter` — extracts GCP project ID from request path or headers
 - `RequestContext` — `@RequestScoped` holder for the current project ID
 - `GcpResourceNames` — utilities for parsing and building GCP resource name strings
@@ -101,7 +101,7 @@ floci-gcp must implement real GCP wire protocols.
 
 | Protocol | Services | Transport | Implementation |
 |----------|----------|-----------|----------------|
-| gRPC | Pub/Sub, Firestore, Datastore, Secret Manager | HTTP/2 + proto3 | `GcpGrpcController` subclass |
+| gRPC | Pub/Sub, Firestore, Datastore, Secret Manager, Cloud Tasks, Cloud Scheduler, Cloud KMS, Cloud Logging, Cloud Monitoring, IAM, GCS | HTTP/2 + proto3 | Generated `*Grpc.*ImplBase` subclass + `GcpGrpcController.grpcError` |
 | REST JSON | GCS (management), IAM, Secret Manager (REST) | HTTP/1.1 or HTTP/2 | JAX-RS |
 | REST XML | GCS (object operations) | HTTP/1.1 or HTTP/2 | JAX-RS + `XmlBuilder` |
 
@@ -292,7 +292,7 @@ If a change affects request parsing, response shape, error handling, persistence
 
 - Services should throw `GcpException`
 - REST flows use `GcpExceptionMapper` → `{"error": {"code": N, "message": "...", "status": "..."}}`
-- gRPC flows use `GcpGrpcController.error(observer, t)` → `StatusRuntimeException`
+- gRPC flows use `GcpGrpcController.grpcError(observer, t)` → `StatusRuntimeException`
 - Controller return types must remain reflection-safe
 
 ---
@@ -315,7 +315,7 @@ When adding functionality:
 
 1. Create a package under `services/`
 2. Add:
-   - Controller (extends `GcpGrpcController` for gRPC, or JAX-RS resource for REST)
+   - Controller (extends the generated `*Grpc.*ImplBase` for gRPC, or JAX-RS resource for REST)
    - Service
    - `model/`
 3. Register the service in `ServiceRegistry`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ floci-gcp must implement real GCP wire protocols.
 
 | Protocol | Services | Transport | Implementation |
 |----------|----------|-----------|----------------|
-| gRPC | Pub/Sub, Firestore, Datastore, Secret Manager, Cloud Tasks, Cloud Scheduler, Cloud KMS, Cloud Logging, Cloud Monitoring, IAM, GCS | HTTP/2 + proto3 | Generated `*Grpc.*ImplBase` subclass + `GcpGrpcController.grpcError` |
+| gRPC | Pub/Sub, Firestore, Datastore, Secret Manager, Cloud Tasks, Cloud Scheduler, Cloud KMS, Cloud Logging, Cloud Monitoring, IAM, GCS | HTTP/2 + proto3 | Generated `*Grpc.*ImplBase` subclass (Datastore implements `BindableService` directly) + `GcpGrpcController.grpcError` |
 | REST JSON | GCS (management), IAM, Secret Manager (REST) | HTTP/1.1 or HTTP/2 | JAX-RS |
 | REST XML | GCS (object operations) | HTTP/1.1 or HTTP/2 | JAX-RS + `XmlBuilder` |
 
@@ -315,7 +315,7 @@ When adding functionality:
 
 1. Create a package under `services/`
 2. Add:
-   - Controller (extends the generated `*Grpc.*ImplBase` for gRPC, or JAX-RS resource for REST)
+   - Controller (extends the generated `*Grpc.*ImplBase`, or implements `BindableService`, for gRPC; JAX-RS resource for REST)
    - Service
    - `model/`
 3. Register the service in `ServiceRegistry`


### PR DESCRIPTION
## Summary

`AGENTS.md` describes `GcpGrpcController` as a base class that gRPC controllers extend. Nothing in the repo does that, and nothing ever has on `main`: `git grep "extends GcpGrpcController" -- src/main/java` returns no matches. Every gRPC controller extends its generated `*Grpc.*ImplBase` and calls the **static** `GcpGrpcController.grpcError(observer, t)` for shared error mapping.

#136 corrected the same claim in `docs/contributing.md`; this brings `AGENTS.md` in line so the two agree.

Four lines change, carrying five fixes:

| Line | Was | Now |
|---|---|---|
| 66 | "base class for gRPC service implementations" | shared error-mapping helper (static `grpcError`); not a base class |
| 104 | `` `GcpGrpcController` subclass ``, and a Services list naming 4 services | generated `*Grpc.*ImplBase` subclass + `GcpGrpcController.grpcError`, and all 11 services |
| 295 | `` GcpGrpcController.error(observer, t) `` | `` GcpGrpcController.grpcError(observer, t) `` |
| 318 | "extends `GcpGrpcController` for gRPC" | "extends the generated `*Grpc.*ImplBase` for gRPC" |

Line 295 needed a real change rather than a reword: `error(observer, t)` is a `protected` instance method, reachable only from a subclass, and there are none. Zero callers use it; 12 files call the static `grpcError`.

The line 104 Services list was also stale, naming Pub/Sub, Firestore, Datastore and Secret Manager when eleven services serve gRPC today. Enumerated from the controllers on `main`: Pub/Sub, Firestore, Datastore, Secret Manager, Cloud Tasks, Cloud Scheduler, Cloud KMS, Cloud Logging, Cloud Monitoring, IAM, GCS.

One nuance not captured in the table cell: ten of those extend a generated `*Grpc.*ImplBase`, while Datastore uses `implements BindableService`. Calling that out here rather than crowding the row; happy to add it if reviewers prefer.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

N/A. Documentation only, no emulated surface touched: no controller, service, model, wire shape or error mapping changes.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

No Java changed, so `./mvnw test` is unaffected and no integration test applies. Verified instead by enumerating the actual controllers on `main` @071393a, confirming no class extends `GcpGrpcController` and that `grpcError` is the sole error-mapping entry point in use.
