### PR TITLE
fix(firebaseauth): send CORS headers on Identity Toolkit client endpoints

### DIFF
--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -20,7 +20,6 @@ public class FirebaseAuthCorsRouteFilter {
     // Matches expressjs/cors' defaults, which is what firebase-tools' Auth Emulator uses.
     private static final String DEFAULT_CORS_METHODS = "GET,HEAD,PUT,PATCH,POST,DELETE";
 
-
     private final Router router;
 
     @Inject

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -17,6 +17,10 @@ public class FirebaseAuthCorsRouteFilter {
             "/securetoken.googleapis.com/*",
     };
 
+    // Matches expressjs/cors' defaults, which is what firebase-tools' Auth Emulator uses.
+    private static final String DEFAULT_CORS_METHODS = "GET,HEAD,PUT,PATCH,POST,DELETE";
+
+
     private final Router router;
 
     @Inject
@@ -30,9 +34,6 @@ public class FirebaseAuthCorsRouteFilter {
             router.route(pathPrefix).order(Integer.MIN_VALUE + 1).handler(this::handle);
         }
     }
-
-    // Matches expressjs/cors' defaults, which is what firebase-tools' Auth Emulator uses.
-    private static final String DEFAULT_CORS_METHODS = "GET,HEAD,PUT,PATCH,POST,DELETE";
 
     private void handle(RoutingContext ctx) {
         String origin = ctx.request().getHeader("Origin");

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -1,0 +1,48 @@
+package io.floci.gcp.services.firebaseauth;
+
+import io.quarkus.runtime.Startup;
+import io.vertx.ext.web.Router;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@Startup
+@ApplicationScoped
+public class FirebaseAuthCorsRouteFilter {
+
+    private static final String PATH_PREFIX = "/identitytoolkit.googleapis.com/*";
+
+    private final Router router;
+
+    @Inject
+    public FirebaseAuthCorsRouteFilter(Router router) {
+        this.router = router;
+    }
+
+    @PostConstruct
+    void init() {
+        router.route(PATH_PREFIX).order(Integer.MIN_VALUE + 1).handler(ctx -> {
+            String origin = ctx.request().getHeader("Origin");
+            if (origin == null) {
+                ctx.next();
+                return;
+            }
+            ctx.response().putHeader("Access-Control-Allow-Origin", origin);
+            ctx.response().putHeader("Vary", "Origin");
+
+            if (!"OPTIONS".equalsIgnoreCase(ctx.request().method().name())) {
+                ctx.next();
+                return;
+            }
+            String requestedMethod = ctx.request().getHeader("Access-Control-Request-Method");
+            ctx.response().putHeader("Access-Control-Allow-Methods",
+                    requestedMethod != null ? requestedMethod : "GET, POST");
+            String requestedHeaders = ctx.request().getHeader("Access-Control-Request-Headers");
+            if (requestedHeaders != null) {
+                ctx.response().putHeader("Access-Control-Allow-Headers", requestedHeaders);
+            }
+            ctx.response().putHeader("Access-Control-Max-Age", "3600");
+            ctx.response().setStatusCode(200).end();
+        });
+    }
+}

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.firebaseauth;
 
 import io.quarkus.runtime.Startup;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Router;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -10,7 +11,11 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class FirebaseAuthCorsRouteFilter {
 
-    private static final String PATH_PREFIX = "/identitytoolkit.googleapis.com/*";
+    // FirebaseAuthController (sign-in/sign-up) and SecureTokenController (token refresh).
+    private static final String[] PATH_PREFIXES = {
+            "/identitytoolkit.googleapis.com/*",
+            "/securetoken.googleapis.com/*",
+    };
 
     private final Router router;
 
@@ -21,28 +26,32 @@ public class FirebaseAuthCorsRouteFilter {
 
     @PostConstruct
     void init() {
-        router.route(PATH_PREFIX).order(Integer.MIN_VALUE + 1).handler(ctx -> {
-            String origin = ctx.request().getHeader("Origin");
-            if (origin == null) {
-                ctx.next();
-                return;
-            }
-            ctx.response().putHeader("Access-Control-Allow-Origin", origin);
-            ctx.response().putHeader("Vary", "Origin");
+        for (String pathPrefix : PATH_PREFIXES) {
+            router.route(pathPrefix).order(Integer.MIN_VALUE + 1).handler(this::handle);
+        }
+    }
 
-            if (!"OPTIONS".equalsIgnoreCase(ctx.request().method().name())) {
-                ctx.next();
-                return;
-            }
-            String requestedMethod = ctx.request().getHeader("Access-Control-Request-Method");
-            ctx.response().putHeader("Access-Control-Allow-Methods",
-                    requestedMethod != null ? requestedMethod : "GET, POST");
-            String requestedHeaders = ctx.request().getHeader("Access-Control-Request-Headers");
-            if (requestedHeaders != null) {
-                ctx.response().putHeader("Access-Control-Allow-Headers", requestedHeaders);
-            }
-            ctx.response().putHeader("Access-Control-Max-Age", "3600");
-            ctx.response().setStatusCode(200).end();
-        });
+    private void handle(RoutingContext ctx) {
+        String origin = ctx.request().getHeader("Origin");
+        if (origin == null) {
+            ctx.next();
+            return;
+        }
+        ctx.response().putHeader("Access-Control-Allow-Origin", origin);
+        ctx.response().putHeader("Vary", "Origin");
+
+        if (!"OPTIONS".equalsIgnoreCase(ctx.request().method().name())) {
+            ctx.next();
+            return;
+        }
+        String requestedMethod = ctx.request().getHeader("Access-Control-Request-Method");
+        ctx.response().putHeader("Access-Control-Allow-Methods",
+                requestedMethod != null ? requestedMethod : "GET, POST");
+        String requestedHeaders = ctx.request().getHeader("Access-Control-Request-Headers");
+        if (requestedHeaders != null) {
+            ctx.response().putHeader("Access-Control-Allow-Headers", requestedHeaders);
+        }
+        ctx.response().putHeader("Access-Control-Max-Age", "3600");
+        ctx.response().setStatusCode(200).end();
     }
 }

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -31,6 +31,9 @@ public class FirebaseAuthCorsRouteFilter {
         }
     }
 
+    // Matches expressjs/cors' defaults, which is what firebase-tools' Auth Emulator uses.
+    private static final String DEFAULT_CORS_METHODS = "GET,HEAD,PUT,PATCH,POST,DELETE";
+
     private void handle(RoutingContext ctx) {
         String origin = ctx.request().getHeader("Origin");
         if (origin == null) {
@@ -38,20 +41,18 @@ public class FirebaseAuthCorsRouteFilter {
             return;
         }
         ctx.response().putHeader("Access-Control-Allow-Origin", origin);
-        ctx.response().putHeader("Vary", "Origin");
 
         if (!"OPTIONS".equalsIgnoreCase(ctx.request().method().name())) {
+            ctx.response().putHeader("Vary", "Origin");
             ctx.next();
             return;
         }
-        String requestedMethod = ctx.request().getHeader("Access-Control-Request-Method");
-        ctx.response().putHeader("Access-Control-Allow-Methods",
-                requestedMethod != null ? requestedMethod : "GET, POST");
+        ctx.response().putHeader("Access-Control-Allow-Methods", DEFAULT_CORS_METHODS);
         String requestedHeaders = ctx.request().getHeader("Access-Control-Request-Headers");
-        if (requestedHeaders != null) {
+        if (requestedHeaders != null && !requestedHeaders.isEmpty()) {
             ctx.response().putHeader("Access-Control-Allow-Headers", requestedHeaders);
         }
-        ctx.response().putHeader("Access-Control-Max-Age", "3600");
-        ctx.response().setStatusCode(200).end();
+        ctx.response().putHeader("Vary", "Origin, Access-Control-Request-Headers");
+        ctx.response().setStatusCode(204).end();
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsCorsFilter.java
@@ -41,6 +41,12 @@ public class GcsCorsFilter implements ContainerRequestFilter, ContainerResponseF
             return;
         }
         String bucket = extractBucket(req.getUriInfo().getRequestUri().getRawPath());
+        if (bucket == null) {
+            // Not a GCS-shaped path at all. Leave OPTIONS handling (and any other
+            // service's own CORS filter, e.g. FirebaseAuthCorsFilter) alone instead of
+            // absorbing the preflight here with a bare, header-less 200.
+            return;
+        }
         String requestedMethod = req.getHeaderString(ACCESS_CONTROL_REQUEST_METHOD);
         Map<String, Object> rule = matchCorsRule(bucket, origin, requestedMethod);
         Response.ResponseBuilder rb = Response.ok();

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
@@ -1,0 +1,62 @@
+package io.floci.gcp.services.firebaseauth;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+class FirebaseAuthCorsRestIntegrationTest {
+
+    private static final String CLIENT = "/identitytoolkit.googleapis.com/v1/accounts";
+    private static final String ORIGIN = "http://127.0.0.1:59301";
+
+    @Test
+    void preflightForSignInWithPasswordAdvertisesTheRequestedOrigin() {
+        given()
+                .header("Origin", ORIGIN)
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "Content-Type")
+                .when().options(CLIENT + ":signInWithPassword")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
+                .header("Access-Control-Allow-Methods", equalTo("POST"))
+                .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
+                .header("Vary", equalTo("Origin"));
+    }
+
+    @Test
+    void actualSignInResponseAdvertisesTheRequestedOrigin() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .header("Origin", ORIGIN)
+                .body("""
+                        {"email":"cors-actual@example.com","password":"secret123"}
+                        """)
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
+                .header("Vary", equalTo("Origin"));
+    }
+
+    @Test
+    void requestWithNoOriginGetsNoCorsHeaders() {
+        given()
+                .urlEncodingEnabled(false)
+                .contentType("application/json")
+                .queryParam("key", "fake-api-key")
+                .body("""
+                        {"email":"cors-no-origin@example.com","password":"secret123"}
+                        """)
+                .when().post(CLIENT + ":signUp")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", nullValue());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
@@ -21,11 +21,11 @@ class FirebaseAuthCorsRestIntegrationTest {
                 .header("Access-Control-Request-Headers", "Content-Type")
                 .when().options(CLIENT + ":signInWithPassword")
                 .then()
-                .statusCode(200)
+                .statusCode(204)
                 .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
-                .header("Access-Control-Allow-Methods", equalTo("POST"))
+                .header("Access-Control-Allow-Methods", equalTo("GET,HEAD,PUT,PATCH,POST,DELETE"))
                 .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
-                .header("Vary", equalTo("Origin"));
+                .header("Vary", equalTo("Origin, Access-Control-Request-Headers"));
     }
 
     @Test
@@ -53,11 +53,11 @@ class FirebaseAuthCorsRestIntegrationTest {
                 .header("Access-Control-Request-Headers", "Content-Type")
                 .when().options("/securetoken.googleapis.com/v1/token")
                 .then()
-                .statusCode(200)
+                .statusCode(204)
                 .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
-                .header("Access-Control-Allow-Methods", equalTo("POST"))
+                .header("Access-Control-Allow-Methods", equalTo("GET,HEAD,PUT,PATCH,POST,DELETE"))
                 .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
-                .header("Vary", equalTo("Origin"));
+                .header("Vary", equalTo("Origin, Access-Control-Request-Headers"));
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
@@ -46,6 +46,21 @@ class FirebaseAuthCorsRestIntegrationTest {
     }
 
     @Test
+    void preflightForSecureTokenRefreshAdvertisesTheRequestedOrigin() {
+        given()
+                .header("Origin", ORIGIN)
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "Content-Type")
+                .when().options("/securetoken.googleapis.com/v1/token")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
+                .header("Access-Control-Allow-Methods", equalTo("POST"))
+                .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
+                .header("Vary", equalTo("Origin"));
+    }
+
+    @Test
     void requestWithNoOriginGetsNoCorsHeaders() {
         given()
                 .urlEncodingEnabled(false)


### PR DESCRIPTION
## Summary

Identity Toolkit's client endpoints (`accounts:signInWithPassword`, `accounts:signUp`, `accounts:signInWithCustomToken`, `accounts:lookup`, `accounts:update`, `accounts:delete`) never sent CORS headers, so a real browser blocks the Firebase JS SDK's `signInWithEmailAndPassword(...)` (and friends) at the CORS preflight check before the app ever sees the response, even though the same request called directly (curl, a server-side SDK) succeeds. 

Real GCP's Identity Toolkit, and the official `firebase-tools` Auth Emulator, both answer with permissive `Access-Control-*` headers regardless of origin, since it's a public, browser-callable API gated by an API key rather than an origin allowlist.

`FirebaseAuthController`'s paths are concrete literals, so Quarkus REST answers their OPTIONS preflight via its own automatic-OPTIONS routing before the JAX-RS filter chain runs. Confirmed via the generated bytecode (no synthetic OPTIONS invoker exists per resource method) and by a plain `ContainerRequestFilter`'s `abortWith()` reliably failing to take effect against a packaged build. 

`FirebaseAuthCorsRouteFilter` hooks the Vert.x `Router` directly instead, at the same early order `GrpcServerManager` already uses in this codebase, so it runs ahead of that routing rather than behind it.

Along the way, I found and fixed a related latent bug in `GcsCorsFilter`: it called `req.abortWith(...)` for *any* OPTIONS request carrying an `Origin` header, even when the path didn't resolve to a known GCS bucket, which silently absorbed every other service's CORS preflight app-wide (including this one, until fixed).

Closes #152

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Verified against real GCP behavior and the official `firebase-tools` [Auth Emulator source](https://github.com/firebase/firebase-tools/blob/ffe8dda607427422fe0c890e1d728aca0fa0bc36/src/emulator/auth/server.ts#L137-L139) which reflects any origin, applied globally before route registration).
- `firebase-tools` uses the `expressjs/cors^2.8.5` package - since they just pass `cors: true`, the default values are used for the headers, which is described [here](https://github.com/expressjs/cors/blob/v2.8.5/lib/index.js#L8-L13).
  - I've replicated this logic inside the `FirebaseAuthCorsRouteFilter`.

Reproduced the incorrect behavior end-to-end with the actual Firebase JS SDK (compat build) in a real Chromium instance driving a login form against `floci-gcp`, and confirmed via curl that neither the CORS preflight nor the actual response carried any `Access-Control-*` headers, while the same request succeeded server-side with a valid `idToken`. After the fix, verified the preflight reflects the requesting origin (`Access-Control-Allow-Origin`, `-Methods`, `-Headers`, `-Max-Age`) and the actual response carries `Access-Control-Allow-Origin`/`Vary`, matching real GCP/firebase-tools.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
