### PR TITLE
fix(firebaseauth): match Number() coercion for session cookie validDuration

### DIFF
--- a/docs/services/firebase-auth.md
+++ b/docs/services/firebase-auth.md
@@ -40,10 +40,14 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
 - Session cookies: `createSessionCookie` re-issues a verified ID token's payload with a fresh
   `iat`/`exp` window and `iss=https://session.firebase.google.com/{project}`. `validDuration`
   is in **seconds** and must fall in `[300, 1209600]` (5 minutes – 14 days), else
-  `INVALID_DURATION`. Like the official emulator, a value that is not a non-zero number —
-  absent, `0`, or a string such as `"3600s"` — silently falls back to the 14-day maximum
-  rather than being rejected. There is no verification endpoint: the Admin SDKs verify
-  session cookies locally, and `checkRevoked` goes through `accounts:lookup`.
+  `INVALID_DURATION`. Like the official emulator, the value is first put through JavaScript
+  `Number()` coercion and then `|| MAX`, so anything coercing to `NaN` or `0` - absent,
+  `0`, `false`, `""`, or a string such as `"3600s"` silently falls back to the 14-day
+  maximum, while anything coercing to another number (`0.5`, `true`, `"0x10"`) reaches the
+  range check and is rejected there. Radix prefixes (`"0x1000"`) and exponent notation
+  (`"3.6e3"`) are read the way `Number()` reads them. There is no verification endpoint:
+  the Admin SDKs verify session cookies locally, and `checkRevoked` goes through
+  `accounts:lookup`.
 
 ## Quick Start
 

--- a/docs/services/firebase-auth.md
+++ b/docs/services/firebase-auth.md
@@ -45,9 +45,9 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
   `false`, `""`, or a string such as `"3600s"`) silently falls back to the 14-day maximum,
   while anything coercing to another number (`0.5`, `true`, `"0x10"`) reaches the range
   check and is rejected there. Radix prefixes (`"0x1000"`), exponent notation (`"3.6e3"`)
-  and ECMAScript whitespace (which includes NBSP) are read the way `Number()` reads them. There is no verification endpoint as
-  the Admin SDKs verify session cookies locally, and `checkRevoked` goes through
-  `accounts:lookup`.
+  and ECMAScript whitespace (which includes NBSP) are read the way `Number()` reads them.
+  There is no verification endpoint as the Admin SDKs verify session cookies locally, and
+  `checkRevoked` goes through `accounts:lookup`.
 
 ## Quick Start
 

--- a/docs/services/firebase-auth.md
+++ b/docs/services/firebase-auth.md
@@ -41,11 +41,11 @@ the API hostname as a **path**, which floci-gcp serves directly on its single po
   `iat`/`exp` window and `iss=https://session.firebase.google.com/{project}`. `validDuration`
   is in **seconds** and must fall in `[300, 1209600]` (5 minutes – 14 days), else
   `INVALID_DURATION`. Like the official emulator, the value is first put through JavaScript
-  `Number()` coercion and then `|| MAX`, so anything coercing to `NaN` or `0` - absent,
-  `0`, `false`, `""`, or a string such as `"3600s"` silently falls back to the 14-day
-  maximum, while anything coercing to another number (`0.5`, `true`, `"0x10"`) reaches the
-  range check and is rejected there. Radix prefixes (`"0x1000"`) and exponent notation
-  (`"3.6e3"`) are read the way `Number()` reads them. There is no verification endpoint:
+  `Number()` coercion and then `|| MAX`, so anything coercing to `NaN` or `0` (absent, `0`,
+  `false`, `""`, or a string such as `"3600s"`) silently falls back to the 14-day maximum,
+  while anything coercing to another number (`0.5`, `true`, `"0x10"`) reaches the range
+  check and is rejected there. Radix prefixes (`"0x1000"`), exponent notation (`"3.6e3"`)
+  and ECMAScript whitespace (which includes NBSP) are read the way `Number()` reads them. There is no verification endpoint as
   the Admin SDKs verify session cookies locally, and `checkRevoked` goes through
   `accounts:lookup`.
 

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static io.floci.gcp.services.firebaseauth.FirebaseAuthException.badRequest;
 import static io.floci.gcp.services.firebaseauth.FirebaseAuthException.check;
@@ -48,6 +50,10 @@ public class FirebaseAuthService {
     private static final long TOKEN_EXPIRES_IN_SECONDS = 3600;
     private static final long SESSION_COOKIE_MIN_VALID_DURATION = 5 * 60;
     private static final long SESSION_COOKIE_MAX_VALID_DURATION = 14 * 24 * 60 * 60;
+    private static final Pattern JS_DECIMAL_LITERAL =
+            Pattern.compile("[+-]?(Infinity|(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?)");
+    private static final Pattern JS_RADIX_LITERAL =
+            Pattern.compile("0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+");
     private static final String PROJECT_NUMBER = "12345";
     static final String CUSTOM_TOKEN_AUDIENCE =
             "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit";
@@ -494,35 +500,62 @@ public class FirebaseAuthService {
         String idToken = str(body.get("idToken"));
         check(idToken != null && !idToken.isEmpty(), "MISSING_ID_TOKEN");
 
-        long validDuration = sessionCookieDuration(body.get("validDuration"));
+        double validDuration = sessionCookieDuration(body.get("validDuration"));
         check(validDuration >= SESSION_COOKIE_MIN_VALID_DURATION
                 && validDuration <= SESSION_COOKIE_MAX_VALID_DURATION, "INVALID_DURATION");
 
         Map<String, Object> payload = new LinkedHashMap<>(verifyIdToken(project, idToken).payload());
         long iat = Instant.now().getEpochSecond();
         payload.put("iat", iat);
-        payload.put("exp", iat + validDuration);
+        payload.put("exp", iat + (long) validDuration);
         payload.put("iss", "https://session.firebase.google.com/" + str(payload.get("aud")));
 
-        LOG.debugf("firebaseauth createSessionCookie project=%s localId=%s validDuration=%d",
+        LOG.debugf("firebaseauth createSessionCookie project=%s localId=%s validDuration=%s",
                 project, payload.get("user_id"), validDuration);
         return Map.of("sessionCookie", FirebaseJwt.sign(payload));
     }
 
-    private static long sessionCookieDuration(Object validDuration) {
-        if (validDuration instanceof Number number) {
-            return number.longValue() == 0 ? SESSION_COOKIE_MAX_VALID_DURATION : number.longValue();
+    /**
+     * The emulator computes {@code Number(validDuration) || SESSION_COOKIE_MAX_VALID_DURATION},
+     * so anything coercing to {@code NaN} or {@code 0} — absent, {@code null}, {@code false},
+     * {@code ""}, {@code "3600s"} — falls back to the maximum, while any other value is passed
+     * through to the range check and rejected there if out of bounds.
+     */
+    private static double sessionCookieDuration(Object validDuration) {
+        double coerced = jsNumber(validDuration);
+        return Double.isNaN(coerced) || coerced == 0 ? SESSION_COOKIE_MAX_VALID_DURATION : coerced;
+    }
+
+    /**
+     * ECMAScript {@code Number(value)} coercion, returning {@code NaN} where JavaScript does.
+     * {@link Double#parseDouble} is not a substitute: it accepts Java's {@code d}/{@code f} type
+     * suffixes ({@code "3600d"}) that JavaScript rejects, and rejects the {@code 0x}/{@code 0b}/
+     * {@code 0o} radix prefixes that JavaScript accepts.
+     */
+    private static double jsNumber(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
         }
-        String text = str(validDuration);
-        if (text == null || text.isBlank()) {
-            return SESSION_COOKIE_MAX_VALID_DURATION;
+        if (value instanceof Boolean bool) {
+            return bool ? 1 : 0;
         }
-        try {
-            long parsed = (long) Double.parseDouble(text.trim());
-            return parsed == 0 ? SESSION_COOKIE_MAX_VALID_DURATION : parsed;
-        } catch (NumberFormatException e) {
-            return SESSION_COOKIE_MAX_VALID_DURATION;
+        String text = str(value);
+        if (text == null) {
+            return Double.NaN;
         }
+        String trimmed = text.trim();
+        if (trimmed.isEmpty()) {
+            return 0;
+        }
+        if (JS_RADIX_LITERAL.matcher(trimmed).matches()) {
+            int radix = switch (Character.toLowerCase(trimmed.charAt(1))) {
+                case 'x' -> 16;
+                case 'b' -> 2;
+                default -> 8;
+            };
+            return new BigInteger(trimmed.substring(2), radix).doubleValue();
+        }
+        return JS_DECIMAL_LITERAL.matcher(trimmed).matches() ? Double.parseDouble(trimmed) : Double.NaN;
     }
 
     // ── securetoken grantToken ────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthService.java
@@ -16,7 +16,6 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -27,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static io.floci.gcp.services.firebaseauth.FirebaseAuthException.badRequest;
 import static io.floci.gcp.services.firebaseauth.FirebaseAuthException.check;
@@ -50,10 +48,6 @@ public class FirebaseAuthService {
     private static final long TOKEN_EXPIRES_IN_SECONDS = 3600;
     private static final long SESSION_COOKIE_MIN_VALID_DURATION = 5 * 60;
     private static final long SESSION_COOKIE_MAX_VALID_DURATION = 14 * 24 * 60 * 60;
-    private static final Pattern JS_DECIMAL_LITERAL =
-            Pattern.compile("[+-]?(Infinity|(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?)");
-    private static final Pattern JS_RADIX_LITERAL =
-            Pattern.compile("0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+");
     private static final String PROJECT_NUMBER = "12345";
     static final String CUSTOM_TOKEN_AUDIENCE =
             "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit";
@@ -522,40 +516,8 @@ public class FirebaseAuthService {
      * through to the range check and rejected there if out of bounds.
      */
     private static double sessionCookieDuration(Object validDuration) {
-        double coerced = jsNumber(validDuration);
+        double coerced = JsNumber.of(validDuration);
         return Double.isNaN(coerced) || coerced == 0 ? SESSION_COOKIE_MAX_VALID_DURATION : coerced;
-    }
-
-    /**
-     * ECMAScript {@code Number(value)} coercion, returning {@code NaN} where JavaScript does.
-     * {@link Double#parseDouble} is not a substitute: it accepts Java's {@code d}/{@code f} type
-     * suffixes ({@code "3600d"}) that JavaScript rejects, and rejects the {@code 0x}/{@code 0b}/
-     * {@code 0o} radix prefixes that JavaScript accepts.
-     */
-    private static double jsNumber(Object value) {
-        if (value instanceof Number number) {
-            return number.doubleValue();
-        }
-        if (value instanceof Boolean bool) {
-            return bool ? 1 : 0;
-        }
-        String text = str(value);
-        if (text == null) {
-            return Double.NaN;
-        }
-        String trimmed = text.trim();
-        if (trimmed.isEmpty()) {
-            return 0;
-        }
-        if (JS_RADIX_LITERAL.matcher(trimmed).matches()) {
-            int radix = switch (Character.toLowerCase(trimmed.charAt(1))) {
-                case 'x' -> 16;
-                case 'b' -> 2;
-                default -> 8;
-            };
-            return new BigInteger(trimmed.substring(2), radix).doubleValue();
-        }
-        return JS_DECIMAL_LITERAL.matcher(trimmed).matches() ? Double.parseDouble(trimmed) : Double.NaN;
     }
 
     // ── securetoken grantToken ────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/firebaseauth/JsNumber.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/JsNumber.java
@@ -3,6 +3,16 @@ package io.floci.gcp.services.firebaseauth;
 import java.math.BigInteger;
 import java.util.regex.Pattern;
 
+/**
+ * ECMAScript {@code Number(value)} coercion, returning {@code NaN} wherever JavaScript does.
+ *
+ * <p>The Firebase Auth emulator is written in TypeScript and leans on JavaScript's implicit
+ * conversions for request fields, so reproducing its behaviour means reproducing {@code Number()}
+ * rather than reaching for the nearest Java equivalent. {@link Double#parseDouble} is not that
+ * equivalent: it accepts Java's {@code d}/{@code f} type suffixes ({@code "3600d"}) that
+ * JavaScript rejects, and rejects the {@code 0x}/{@code 0b}/{@code 0o} radix prefixes that
+ * JavaScript accepts.
+ */
 final class JsNumber {
 
     /** {@code StrDecimalLiteral}, without the type suffixes {@link Double#parseDouble} allows. */
@@ -19,6 +29,12 @@ final class JsNumber {
      * Coerces a JSON-decoded value the way {@code Number(value)} would. Absent values arrive as
      * {@code null}: {@code Number(undefined)} is {@code NaN} and {@code Number(null)} is
      * {@code 0}, both falsy, so callers applying a {@code ||} fallback cannot tell them apart.
+     *
+     * <p>Arrays and objects are not put through {@code ToPrimitive} and always yield {@code NaN}.
+     * Bare {@code Number()} would read {@code [3600]} as {@code 3600}, but the emulator never
+     * evaluates it: the fields this coercion backs are typed {@code string} in its OpenAPI schema,
+     * and its request validator coerces only numbers to strings, so a structured value is
+     * rejected as {@code INVALID_ARGUMENT} before the operation runs.
      */
     static double of(Object value) {
         if (value instanceof Number number) {

--- a/src/main/java/io/floci/gcp/services/firebaseauth/JsNumber.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/JsNumber.java
@@ -1,0 +1,74 @@
+package io.floci.gcp.services.firebaseauth;
+
+import java.math.BigInteger;
+import java.util.regex.Pattern;
+
+final class JsNumber {
+
+    /** {@code StrDecimalLiteral}, without the type suffixes {@link Double#parseDouble} allows. */
+    private static final Pattern DECIMAL_LITERAL =
+            Pattern.compile("[+-]?(Infinity|(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?)");
+
+    /** {@code NonDecimalIntegerLiteral}, which unlike the decimal form takes no sign. */
+    private static final Pattern RADIX_LITERAL =
+            Pattern.compile("0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+");
+
+    private JsNumber() {}
+
+    /**
+     * Coerces a JSON-decoded value the way {@code Number(value)} would. Absent values arrive as
+     * {@code null}: {@code Number(undefined)} is {@code NaN} and {@code Number(null)} is
+     * {@code 0}, both falsy, so callers applying a {@code ||} fallback cannot tell them apart.
+     */
+    static double of(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof Boolean bool) {
+            return bool ? 1 : 0;
+        }
+        if (!(value instanceof String text)) {
+            return Double.NaN;
+        }
+        String trimmed = trim(text);
+        if (trimmed.isEmpty()) {
+            return 0;
+        }
+        if (RADIX_LITERAL.matcher(trimmed).matches()) {
+            int radix = switch (Character.toLowerCase(trimmed.charAt(1))) {
+                case 'x' -> 16;
+                case 'b' -> 2;
+                default -> 8;
+            };
+            return new BigInteger(trimmed.substring(2), radix).doubleValue();
+        }
+        return DECIMAL_LITERAL.matcher(trimmed).matches() ? Double.parseDouble(trimmed) : Double.NaN;
+    }
+
+    /**
+     * Strips ECMAScript {@code StrWhiteSpace}, which {@link String#trim} (chars {@code <= U+0020})
+     * and {@link String#strip} both miss: {@link Character#isWhitespace} deliberately excludes the
+     * non-breaking spaces, so {@code "\u00a03600"} would otherwise coerce to {@code NaN}.
+     */
+    private static String trim(String text) {
+        int start = 0;
+        int end = text.length();
+        while (start < end && isWhitespace(text.charAt(start))) {
+            start++;
+        }
+        while (end > start && isWhitespace(text.charAt(end - 1))) {
+            end--;
+        }
+        return text.substring(start, end);
+    }
+
+    /** {@code WhiteSpace} and {@code LineTerminator} as ECMAScript defines them, all in the BMP. */
+    private static boolean isWhitespace(char c) {
+        return switch (c) {
+            case '\t', '\n', '\u000B', '\f', '\r', '\u2028', '\u2029', '\uFEFF' -> true;
+            // Zs: U+0020, U+00A0, U+1680, U+2000-U+200A, U+202F, U+205F, U+3000. Deliberately
+            // not U+200B, which is Cf and which Number() does not strip.
+            default -> Character.getType(c) == Character.SPACE_SEPARATOR;
+        };
+    }
+}

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
@@ -481,7 +481,8 @@ class FirebaseAuthRestIntegrationTest {
 
         // Number(v) is NaN or 0, so `|| MAX` applies. Double.parseDouble would accept the
         // d/f type suffixes and JavaScript does not; JavaScript rejects a signed 0x literal.
-        for (Object duration : new Object[]{"3600d", "3600f", "-0x10", false, ""}) {
+        // "\u200b" is Cf, not whitespace, so Number() leaves it in place and yields NaN.
+        for (Object duration : new Object[]{"3600d", "3600f", "-0x10", false, "", "\u200b3600"}) {
             String cookie = given()
                     .urlEncodingEnabled(false)
                     .contentType("application/json")
@@ -499,7 +500,12 @@ class FirebaseAuthRestIntegrationTest {
         for (Map.Entry<Object, Long> expected : List.of(
                 Map.entry((Object) "0x1000", 4096L),
                 Map.entry((Object) "3.6e3", 3600L),
-                Map.entry((Object) " 3600 ", 3600L))) {
+                Map.entry((Object) " 3600 ", 3600L),
+                // ECMAScript StrWhiteSpace goes beyond String.trim()'s <= U+0020, and beyond
+                // String.strip(): Character.isWhitespace excludes the non-breaking spaces.
+                Map.entry((Object) "\u00a03600\u00a0", 3600L),
+                Map.entry((Object) "\u30003600", 3600L),
+                Map.entry((Object) "\u20283600\ufeff", 3600L))) {
             String cookie = given()
                     .urlEncodingEnabled(false)
                     .contentType("application/json")

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthRestIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
@@ -458,6 +459,59 @@ class FirebaseAuthRestIntegrationTest {
                 .extract().path("sessionCookie");
         Map<String, Object> payload = decodeSegment(cookie, 1);
         assertEquals(14L * 24 * 60 * 60, num(payload.get("exp")) - num(payload.get("iat")));
+    }
+
+    @Test
+    void createSessionCookieCoercesDurationLikeJavaScriptNumber() throws Exception {
+        String idToken = (String) signUpClient("cookie-coercion@example.com").get("idToken");
+
+        // Number(v) is non-zero but outside [300, 1209600], so the range check rejects it
+        // rather than the coercion silently falling back to the 14-day maximum.
+        for (Object duration : new Object[]{0.5, true, "0x10", "0b1010", "1e-3"}) {
+            given()
+                    .urlEncodingEnabled(false)
+                    .contentType("application/json")
+                    .header("Authorization", "Bearer owner")
+                    .body(Map.of("idToken", idToken, "validDuration", duration))
+                    .when().post(PROJECT + ":createSessionCookie")
+                    .then()
+                    .statusCode(400)
+                    .body("error.message", equalTo("INVALID_DURATION"));
+        }
+
+        // Number(v) is NaN or 0, so `|| MAX` applies. Double.parseDouble would accept the
+        // d/f type suffixes and JavaScript does not; JavaScript rejects a signed 0x literal.
+        for (Object duration : new Object[]{"3600d", "3600f", "-0x10", false, ""}) {
+            String cookie = given()
+                    .urlEncodingEnabled(false)
+                    .contentType("application/json")
+                    .header("Authorization", "Bearer owner")
+                    .body(Map.of("idToken", idToken, "validDuration", duration))
+                    .when().post(PROJECT + ":createSessionCookie")
+                    .then().statusCode(200)
+                    .extract().path("sessionCookie");
+            Map<String, Object> payload = decodeSegment(cookie, 1);
+            assertEquals(14L * 24 * 60 * 60, num(payload.get("exp")) - num(payload.get("iat")));
+        }
+
+        // Number(v) lands in range and is used as-is, including the radix prefixes and
+        // exponent notation JavaScript accepts.
+        for (Map.Entry<Object, Long> expected : List.of(
+                Map.entry((Object) "0x1000", 4096L),
+                Map.entry((Object) "3.6e3", 3600L),
+                Map.entry((Object) " 3600 ", 3600L))) {
+            String cookie = given()
+                    .urlEncodingEnabled(false)
+                    .contentType("application/json")
+                    .header("Authorization", "Bearer owner")
+                    .body(Map.of("idToken", idToken, "validDuration", expected.getKey()))
+                    .when().post(PROJECT + ":createSessionCookie")
+                    .then().statusCode(200)
+                    .extract().path("sessionCookie");
+            Map<String, Object> payload = decodeSegment(cookie, 1);
+            assertEquals(expected.getValue().longValue(),
+                    num(payload.get("exp")) - num(payload.get("iat")));
+        }
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/firebaseauth/JsNumberTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/JsNumberTest.java
@@ -1,0 +1,85 @@
+package io.floci.gcp.services.firebaseauth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every expectation here is what {@code Number(value)} returns in a JavaScript engine, since the
+ * Firebase Auth emulator relies on that coercion for request fields.
+ */
+class JsNumberTest {
+
+    @Test
+    void coercesNumbersAndBooleans() {
+        assertEquals(3600, JsNumber.of(3600));
+        assertEquals(0.5, JsNumber.of(0.5));
+        assertEquals(0, JsNumber.of(0));
+        assertEquals(1, JsNumber.of(true));
+        assertEquals(0, JsNumber.of(false));
+    }
+
+    @Test
+    void coercesBlankAndAbsentValues() {
+        assertTrue(Double.isNaN(JsNumber.of(null)));
+        assertEquals(0, JsNumber.of(""));
+        assertEquals(0, JsNumber.of("   "));
+        assertEquals(0, JsNumber.of("\u00a0\u3000"));
+    }
+
+    @Test
+    void stripsEcmaScriptWhitespaceRatherThanJavaWhitespace() {
+        assertEquals(3600, JsNumber.of(" 3600 "));
+        assertEquals(3600, JsNumber.of("\t3600\n"));
+        // String.trim() stops at U+0020 and Character.isWhitespace excludes the non-breaking
+        // spaces, so these are the cases a naive trim gets wrong.
+        assertEquals(3600, JsNumber.of("\u00a03600\u00a0"));
+        assertEquals(3600, JsNumber.of("\u30003600"));
+        assertEquals(3600, JsNumber.of("\u20283600\ufeff"));
+        assertEquals(3600, JsNumber.of("\u205f3600\u202f"));
+        // U+200B is Cf, not whitespace: Number() leaves it in place and yields NaN.
+        assertTrue(Double.isNaN(JsNumber.of("\u200b3600")));
+    }
+
+    @Test
+    void readsRadixLiteralsThatParseDoubleRejects() {
+        assertEquals(16, JsNumber.of("0x10"));
+        assertEquals(4096, JsNumber.of("0x1000"));
+        assertEquals(10, JsNumber.of("0b1010"));
+        assertEquals(15, JsNumber.of("0o17"));
+        // A sign is not permitted on a non-decimal literal.
+        assertTrue(Double.isNaN(JsNumber.of("-0x10")));
+    }
+
+    @Test
+    void rejectsJavaTypeSuffixesThatParseDoubleAccepts() {
+        assertTrue(Double.isNaN(JsNumber.of("3600d")));
+        assertTrue(Double.isNaN(JsNumber.of("3600f")));
+        assertTrue(Double.isNaN(JsNumber.of("3600s")));
+        assertTrue(Double.isNaN(JsNumber.of("0x1p3")));
+    }
+
+    @Test
+    void readsDecimalLiterals() {
+        assertEquals(1000, JsNumber.of("1e3"));
+        assertEquals(3600, JsNumber.of("3.6e3"));
+        assertEquals(0.001, JsNumber.of("1e-3"));
+        assertEquals(0.5, JsNumber.of(".5"));
+        assertEquals(300, JsNumber.of("300."));
+        assertEquals(300, JsNumber.of("+300"));
+        assertEquals(Double.POSITIVE_INFINITY, JsNumber.of("Infinity"));
+        assertEquals(Double.NEGATIVE_INFINITY, JsNumber.of("-Infinity"));
+        assertTrue(Double.isNaN(JsNumber.of("NaN")));
+        assertTrue(Double.isNaN(JsNumber.of("not-a-number")));
+    }
+
+    @Test
+    void treatsStructuredValuesAsNotANumber() {
+        assertTrue(Double.isNaN(JsNumber.of(Map.of("a", 1))));
+        assertTrue(Double.isNaN(JsNumber.of(List.of(1, 2))));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #141, which added `projects.createSessionCookie`. Four `validDuration` inputs did not match the emulator's coercion.

The emulator computes [`Number(validDuration) || SESSION_COOKIE_MAX_VALID_DURATION`](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/operations.ts#L685), so a value falls back to the 14-day maximum **only** when it coerces to `NaN` or `0`. Anything else reaches the `[300, 1209600]` range check. Divergence ran in both directions:

| `validDuration` | Emulator | Before | After |
|---|---|---|---|
| `0.5` | `INVALID_DURATION` | 14 days | `INVALID_DURATION` |
| `true` | `INVALID_DURATION` | 14 days | `INVALID_DURATION` |
| `"0x10"` | `INVALID_DURATION` | 14 days | `INVALID_DURATION` |
| `"3600d"` | 14 days | 3600s | 14 days |
| `"\u00a03600"` (NBSP) | 3600s | 14 days | 3600s |

Causes, in order: `Number#longValue()` truncated `0.5` to `0` and took the `|| MAX` branch; `Boolean` is not a `java.lang.Number`, so `true` fell through to string parsing; `Double.parseDouble` rejects `0x` literals without a `p` exponent; and `Double.parseDouble` *accepts* Java's `d`/`f` type suffixes, which JavaScript does not.

The NBSP case came out of review: `String.trim()` only strips chars `<= U+0020`, so any of the Unicode `Zs` characters left the string unparseable. `String.strip()` is not the fix either — `Character.isWhitespace('\u00a0')` is `false` by design — so trimming follows ECMAScript `StrWhiteSpace` explicitly (`Zs` plus TAB, VT, FF, LF, CR, LS, PS, ZWNBSP, and deliberately *not* U+200B, which is `Cf` and which `Number()` leaves in place).

Coercion goes through a `JsNumber` helper implementing ECMAScript `Number()` — radix prefixes (`0x`/`0b`/`0o`, unsigned as in JS), exponent notation, `Infinity`, booleans, blank strings — and `validDuration` is carried as a `double`, so fractional values are range-checked instead of being truncated before the check.

No SDK sends any of these shapes, so this is a fidelity fix rather than a user-facing bug: `firebase-admin` always sends an integer.

### Placement

The coercion lives in its own `JsNumber` class rather than in `FirebaseAuthService`, following `FirebaseJwt` in this package and the `*Parser`/`*Codec` helpers in the other services: a package-private `final class` with a private constructor and static entry points, which is also what `AGENTS.md` asks for under "prefer package-private constructors for testability". `FirebaseAuthService` keeps only the `|| MAX` fallback and the range check, the parts specific to `createSessionCookie`.

### Structured values (arrays/objects) are deliberately not `ToPrimitive`-converted

Bare `Number([3600])` is `3600`, so it looks like this helper should return `3600` too. It should not, because the emulator never evaluates it.

`validDuration` is typed `string` in the emulator's OpenAPI schema ([`schema.ts`](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/schema.ts#L2063-L2073)), and every request body is validated against that schema by exegesis before the operation runs. The validator's only repair pass coerces `typeof value === "number"` to a string and maps enum indices to names ([`server.ts`](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/server.ts#L588-L632)); `typeof [] === "object"`, so an array matches neither repair, the ajv `type: string` error stands, and it surfaces as `Invalid JSON payload received…` / `INVALID_ARGUMENT` ([`server.ts`](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/server.ts#L248-L258)).

So for `[3600]` the emulator returns **400 `INVALID_ARGUMENT`**, never a 3600-second cookie. Teaching `JsNumber` to unwrap arrays would produce a `200` and a valid cookie where the real emulator refuses the request, which is further from the emulator, not closer.

floci-gcp has no request-schema validation layer in any service, so the closest available behavior for a structurally invalid duration is the `|| MAX` fallback, which is also what this endpoint did before this PR. Adding type rejection for `validDuration` alone would be inconsistent with the rest of the codebase; adding it project-wide is a much larger change than this PR. Happy to open that as a separate issue if maintainers want it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Matched against the official Firebase Auth emulator at [`firebase-tools@96d0f83`](https://github.com/firebase/firebase-tools/blob/96d0f83bd74410cb472b312bcbfab4dd03a4baeb/src/emulator/auth/operations.ts#L680-L710). Behavior was cross-checked case by case against ECMAScript `Number()` semantics, including the cases that were already correct (`null`, `""`, `"NaN"`, `"Infinity"`, `"1e3"`, whitespace-padded values, `"-0x10"`).

SDK coverage is unchanged from #141: `com.google.firebase:firebase-admin` 9.9.0 via `compatibility-tests/sdk-test-java`. gcloud CLI is not applicable — it exposes no Identity Toolkit `createSessionCookie` surface.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Tests

`JsNumberTest` gives the helper direct unit coverage: 7 tests over the numeric/boolean, blank, whitespace, radix, type-suffix, decimal-literal and structured-value cases, each expectation being what a JavaScript engine returns for `Number(value)`.

At the HTTP level, `createSessionCookieCoercesDurationLikeJavaScriptNumber` covers all three outcomes — coerces-and-rejects (`0.5`, `true`, `"0x10"`, `"0b1010"`, `"1e-3"`), coerces-to-falsy-so-MAX (`"3600d"`, `"3600f"`, `"-0x10"`, `false`, `""`), and coerces-into-range (`"0x1000"` → 4096, `"3.6e3"` → 3600, `" 3600 "` → 3600). Confirmed to fail against the previous implementation and pass with this one.

Full suite:

Both the NBSP assertion and the original four-case test were confirmed to fail against the implementation each one fixes.

Full suite:

```
Tests run: 855, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
