### PR TITLE
docs: document the release train and lead with the four-cloud family

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,16 +59,16 @@ floci-gcp follows a layered design:
 
 ### Core Infrastructure
 
-- `EmulatorConfig` — `@ConfigMapping(prefix = "floci-gcp")` SmallRye Config interface
+- `EmulatorConfig`: `@ConfigMapping(prefix = "floci-gcp")` SmallRye Config interface
 - `ServiceRegistry`
 - `StorageBackend` + `StorageFactory`
 - `GcpException` + `GcpExceptionMapper`
-- `GcpGrpcController` — shared gRPC error-mapping helper (static `grpcError`); not a base class
-- `ProjectContextFilter` — extracts GCP project ID from request path or headers
-- `RequestContext` — `@RequestScoped` holder for the current project ID
-- `GcpResourceNames` — utilities for parsing and building GCP resource name strings
+- `GcpGrpcController`: shared gRPC error-mapping helper (static `grpcError`); not a base class
+- `ProjectContextFilter`: extracts GCP project ID from request path or headers
+- `RequestContext`: `@RequestScoped` holder for the current project ID
+- `GcpResourceNames`: utilities for parsing and building GCP resource name strings
 - `EmulatorLifecycle`
-- `XmlBuilder` + `XmlParser` — used by GCS (REST XML)
+- `XmlBuilder` + `XmlParser`: used by GCS (REST XML)
 
 ---
 
@@ -127,7 +127,7 @@ Resolution order in `ProjectContextFilter`:
 ### Important exceptions
 
 - GCS uses REST XML for object operations and REST JSON for bucket management; keep them aligned
-- gRPC services use pre-compiled stubs from `grpc-google-cloud-*-java` artifacts — do not introduce raw `.proto` codegen
+- gRPC services use pre-compiled stubs from `grpc-google-cloud-*-java` artifacts. Do not introduce raw `.proto` codegen
 - Management APIs should be validated with GCP SDK clients, not only handcrafted HTTP requests
 
 ---
@@ -176,7 +176,7 @@ When adding storage-related behavior:
 
 Configuration lives under `floci-gcp.*`.
 
-`EmulatorConfig` is a `@ConfigMapping(prefix = "floci-gcp")` SmallRye Config interface. Nested config groups are inner interfaces. Defaults use `@WithDefault`. Do **not** use `@ApplicationScoped` + `@ConfigProperty` for config — use `@ConfigMapping` instead.
+`EmulatorConfig` is a `@ConfigMapping(prefix = "floci-gcp")` SmallRye Config interface. Nested config groups are inner interfaces. Defaults use `@WithDefault`. Do **not** use `@ApplicationScoped` + `@ConfigProperty` for config. Use `@ConfigMapping` instead.
 
 When adding config:
 
@@ -214,19 +214,19 @@ Critical areas:
 
 ## Compatibility Project
 
-Compatibility tests live in `./compatibility-tests/` and validate floci-gcp against real GCP tooling — SDK clients and Infrastructure-as-Code providers — not just handcrafted HTTP.
+Compatibility tests live in `./compatibility-tests/` and validate floci-gcp against real GCP tooling (SDK clients and Infrastructure-as-Code providers), not just handcrafted HTTP.
 
 ### Layout
 
 Each subdirectory is a self-contained suite with its own `Dockerfile`:
 
-- `sdk-test-java` — GCP SDK for Java. **Default / reference suite**; preferred for management-plane validation.
-- `sdk-test-node` — GCP SDK for Node.js
-- `sdk-test-python` — GCP SDK for Python
-- `sdk-test-go` — GCP SDK for Go
-- `sdk-test-gcloud` — gcloud CLI (bats-based)
-- `compat-terraform` — Terraform `hashicorp/google` provider (bats-based)
-- `compat-opentofu` — OpenTofu `hashicorp/google` provider (bats-based)
+- `sdk-test-java`: GCP SDK for Java. **Default / reference suite**; preferred for management-plane validation.
+- `sdk-test-node`: GCP SDK for Node.js
+- `sdk-test-python`: GCP SDK for Python
+- `sdk-test-go`: GCP SDK for Go
+- `sdk-test-gcloud`: gcloud CLI (bats-based)
+- `compat-terraform`: Terraform `hashicorp/google` provider (bats-based)
+- `compat-opentofu`: OpenTofu `hashicorp/google` provider (bats-based)
 
 `justfile` provides per-suite recipes (`just test-java`, `just test-terraform`, …) for running a suite locally against a running floci-gcp instance.
 
@@ -245,11 +245,11 @@ The endpoint is passed via env: `FLOCI_GCP_ENDPOINT` for the SDK suites; `FLOCI_
 
 1. Give the suite directory a `Dockerfile` whose entrypoint runs the tests and writes JUnit XML to `/results`.
 2. Add the directory name to the `matrix.test` list in `compatibility.yml`.
-3. Keep test output visible — do not silence the runner (e.g. avoid `mvn test -q`); a hanging test must be diagnosable from the streamed log.
+3. Keep test output visible: do not silence the runner (e.g. avoid `mvn test -q`); a hanging test must be diagnosable from the streamed log.
 
 ### IaC suites (Terraform / OpenTofu)
 
-- Configure the google provider with `*_custom_endpoint` values pointing each service at the emulator. **Custom endpoints must include the API version** — e.g. `secret_manager_custom_endpoint = "${var.endpoint}/v1/"` and `storage_custom_endpoint = "${var.endpoint}/storage/v1/"`. Omitting the version makes the provider hit an unversioned path and the emulator returns `405`/`404`.
+- Configure the google provider with `*_custom_endpoint` values pointing each service at the emulator. **Custom endpoints must include the API version**, e.g. `secret_manager_custom_endpoint = "${var.endpoint}/v1/"` and `storage_custom_endpoint = "${var.endpoint}/storage/v1/"`. Omitting the version makes the provider hit an unversioned path and the emulator returns `405`/`404`.
 - Auth is bypassed with a fake `GOOGLE_OAUTH_ACCESS_TOKEN`; the emulator ignores it.
 - Only REST-exposed services are reachable via Terraform custom endpoints (GCS, IAM, Secret Manager). gRPC-only services (Pub/Sub, Firestore, Datastore) are not, without REST transcoding.
 
@@ -329,11 +329,11 @@ When adding functionality:
 
 If the service launches real Docker containers (sidecars / data planes), it
 **must** expose a single root-level `mock` flag on its `*ServiceConfig`
-(`boolean mock();`) that keeps the service metadata-only without Docker —
+(`boolean mock();`) that keeps the service metadata-only without Docker.
 mirroring `kafka.mock`, `cloudsql.mock`, and `cloudrun.mock` (env var
 `FLOCI_GCP_SERVICES_<SVC>_MOCK`). Gate every container interaction in the
 service layer on `!mock()` (keep the Docker driver/manager class free of the
-flag). Do not add a separate `enabled`-style opt-in for the container path — the
+flag). Do not add a separate `enabled`-style opt-in for the container path: the
 `mock` flag is the only toggle, defaulting to `false` (`kafka.mock`,
 `cloudsql.mock`, `cloudrun.mock` all default `false`). Always set `mock: true`
 in `src/test/resources/application.yml` so the suite never starts containers.
@@ -424,7 +424,7 @@ Treat release workflows as critical infrastructure.
 - Forgetting YAML updates
 - Producing inconsistent resource names (must match `projects/{project}/...` pattern)
 - Testing only with raw HTTP (use SDK clients)
-- Using `@ApplicationScoped` + `@ConfigProperty` for config — use `@ConfigMapping` interfaces instead
+- Using `@ApplicationScoped` + `@ConfigProperty` for config. Use `@ConfigMapping` interfaces instead
 - Introducing unnecessary new patterns
 
 ---
@@ -443,7 +443,7 @@ If a task would require broad architectural changes, stop and surface the tradeo
 
 ## GCP SDK Source as Reference
 
-Don't try to look into jars from `~/.m2/repository` — they are not source code. Refer to the actual GCP SDK source code for accurate behavior and protocol details.
+Don't try to look into jars from `~/.m2/repository`: they are not source code. Refer to the actual GCP SDK source code for accurate behavior and protocol details.
 
 The proto definitions for each gRPC service are the authoritative source for request/response shapes and field semantics.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,10 @@ in `src/test/resources/application.yml` so the suite never starts containers.
 
 ---
 
+## Documentation Style
+
+- No em-dashes anywhere, in any content. Use colons, commas, or periods.
+
 ## Logging
 
 - Use JBoss Logging

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 </p>
 
 <p align="center">
-  <strong>Light, fluffy, and always free — GCP Local Emulator</strong><br />
+  <strong>Any Cloud. Locally.</strong><br />
+  Light, fluffy, and always free: the GCP local emulator<br />
   No account. No auth token. No feature gates. Just <code>docker compose up</code>.
 </p>
 
@@ -35,7 +36,14 @@ floci-gcp is a free, open-source local GCP emulator for development, testing, an
 
 It gives you GCP-shaped services on your machine without requiring a cloud account, auth token, or paid feature gates. Point your GCP SDK, gcloud CLI, Terraform, or test suite at `http://localhost:4588` and keep your existing workflows.
 
-floci-gcp is named after [floccus](https://en.wikipedia.org/wiki/Cirrocumulus_floccus), the cloud formation that looks like popcorn.
+floci-gcp is the GCP member of the [Floci](https://github.com/floci-io) emulator family, named after [floccus](https://en.wikipedia.org/wiki/Cirrocumulus_floccus), the cloud formation that looks like popcorn.
+
+| Emulator | Cloud | Port |
+|---|---|:---:|
+| [floci](https://github.com/floci-io/floci) | AWS | 4566 |
+| [floci-az](https://github.com/floci-io/floci-az) | Azure | 4577 |
+| **[floci-gcp](https://github.com/floci-io/floci-gcp)** | **GCP** | **4588** |
+| [floci-oci](https://github.com/floci-io/floci-oci) | OCI | 4599 |
 
 ## Quick Start
 
@@ -98,7 +106,7 @@ Run GCP-compatible services locally without a GCP account, service account key, 
 <details>
 <summary><strong>Single port for everything</strong></summary>
 
-All GCP services — gRPC and REST — share a single port (`4588`) via HTTP/2 ALPN negotiation. No per-service daemon setup, no port management.
+All GCP services (gRPC and REST) share a single port (`4588`) via HTTP/2 ALPN negotiation. No per-service daemon setup, no port management.
 
 </details>
 
@@ -125,7 +133,7 @@ Choose from in-memory, persistent, hybrid, and write-ahead log storage depending
 
 ## Why floci-gcp?
 
-GCP's official emulators are fragmented — each service ships its own binary, runs on a different port, and requires separate setup. floci-gcp unifies them under a single port.
+GCP's official emulators are fragmented: each service ships its own binary, runs on a different port, and requires separate setup. floci-gcp unifies them under a single port.
 
 | Capability | floci-gcp | GCP official emulators |
 |---|:---:|:---:|
@@ -235,12 +243,12 @@ floci-gcp emulates GCP services across storage, messaging, identity, and managed
 
 ## Real Docker Integration
 
-floci-gcp uses real Docker containers when in-process emulation would reduce fidelity — stateful databases, connection-heavy protocols, and image-based runtimes. These services spawn sidecar containers via the host Docker daemon. Each is gated by a per-service `mock` flag: set it to `true` to keep the service metadata-only without Docker.
+floci-gcp uses real Docker containers when in-process emulation would reduce fidelity: stateful databases, connection-heavy protocols, and image-based runtimes. These services spawn sidecar containers via the host Docker daemon. Each is gated by a per-service `mock` flag: set it to `true` to keep the service metadata-only without Docker.
 
 | Service | Default image | What is real | Mock flag |
 |---|---|---|---|
 | Managed Kafka | `redpandadata/redpanda:latest` | Kafka-compatible broker via Redpanda | `FLOCI_GCP_SERVICES_KAFKA_MOCK` |
-| Cloud SQL for PostgreSQL | `postgres:15.18-alpine` (15–18) | PostgreSQL engine, JDBC-compatible access | `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` |
+| Cloud SQL for PostgreSQL | `postgres:15.18-alpine` (15-18) | PostgreSQL engine, JDBC-compatible access | `FLOCI_GCP_SERVICES_CLOUDSQL_MOCK` |
 | Cloud Run | User-specified container image | Image-based service execution and request serving | `FLOCI_GCP_SERVICES_CLOUDRUN_MOCK` |
 | GKE (Kubernetes Engine) | `rancher/k3s:latest` | Real k3s Kubernetes clusters reachable via kubectl | `FLOCI_GCP_SERVICES_GKE_MOCK` |
 
@@ -279,7 +287,7 @@ Use `memory` for fast CI runs. Use `hybrid` when you want state preserved across
 
 ## Multi-Project Isolation
 
-GCP resource names follow `projects/{project}/...`. floci-gcp uses the project ID as the multi-tenancy boundary — resources in `project-a` are invisible to `project-b`.
+GCP resource names follow `projects/{project}/...`. floci-gcp uses the project ID as the multi-tenancy boundary: resources in `project-a` are invisible to `project-b`.
 
 The project ID is resolved in this order:
 1. URL path segment `projects/{project}/...`
@@ -604,7 +612,7 @@ cd compatibility-tests && just test-terraform
 
 ## Migrating from gcloud emulators
 
-Google ships a separate emulator per service (`gcloud beta emulators pubsub | firestore | datastore | bigtable | spanner`), each its own process on its own port. floci-gcp replaces all of them with one binary on a single port (`4588`), reusing the same `*_EMULATOR_HOST` environment variables the GCP SDKs already honor — just point them at floci-gcp.
+Google ships a separate emulator per service (`gcloud beta emulators pubsub | firestore | datastore | bigtable | spanner`), each its own process on its own port. floci-gcp replaces all of them with one binary on a single port (`4588`), reusing the same `*_EMULATOR_HOST` environment variables the GCP SDKs already honor. Just point them at floci-gcp.
 
 | gcloud emulator | floci-gcp |
 |---|---|
@@ -615,7 +623,7 @@ Google ships a separate emulator per service (`gcloud beta emulators pubsub | fi
 | _(no official emulator)_ | `SECRET_MANAGER_EMULATOR_HOST=localhost:4588` |
 | Firebase Auth emulator → `FIREBASE_AUTH_EMULATOR_HOST=localhost:9099` | `FIREBASE_AUTH_EMULATOR_HOST=localhost:4588` |
 
-The GCP SDKs skip credential checks automatically when these variables are set, so no code changes are needed — one container replaces the fragmented per-service emulator processes.
+The GCP SDKs skip credential checks automatically when these variables are set, so no code changes are needed. One container replaces the fragmented per-service emulator processes.
 
 ## Image Tags
 
@@ -640,6 +648,12 @@ image: floci/floci-gcp:0.5.0
 # Track main
 image: floci/floci-gcp:nightly
 ```
+
+### Release train
+
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Between trains, `floci/floci-gcp:nightly` tracks `main`. Every merged fix is available the next day, with immutable `nightly-mmddyyyy` tags for reproducible builds.
+
+Versions are derived from Conventional Commits by [semantic-release](https://github.com/semantic-release/semantic-release); `CHANGELOG.md` is generated, never hand-edited. Releases are cut from `main` only: there are no maintenance branches.
 
 ## Configuration
 
@@ -760,4 +774,4 @@ tiers, is listed in [THANKS.md](https://github.com/floci-io/.github/blob/main/TH
 
 ## License
 
-MIT — use it however you want.
+MIT: use it however you want.

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ image: floci/floci-gcp:nightly
 
 ### Release train
 
-Stable releases ship on the **1st and 3rd Tuesday of each month**. Between trains, `floci/floci-gcp:nightly` tracks `main`. Every merged fix is available the next day, with immutable `nightly-mmddyyyy` tags for reproducible builds.
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Between trains, `floci/floci-gcp:nightly` tracks `main`. Every merged fix is available the next day, and dated `nightly-mmddyyyy` tags let you pin a specific night's build.
 
 Versions are derived from Conventional Commits by [semantic-release](https://github.com/semantic-release/semantic-release); `CHANGELOG.md` is generated, never hand-edited. Releases are cut from `main` only: there are no maintenance branches.
 


### PR DESCRIPTION
## Summary

Implements hub decision 0017. Documentation only, no behavior change.

- **Release train.** States the stable cadence, the 1st and 3rd Tuesday of each month, at the end of `## Image Tags`, with the nightly channel as the between-trains answer. The cadence appeared in no README, docs page, `CONTRIBUTING.md` or workflow, so an evaluator reading the releases page saw a release count with no schedule behind it.
- **Four-cloud family.** Promotes "Any Cloud. Locally." to the header and adds the family table to the opening section, reusing the pattern `floci-oci` already carries.
- **Punctuation.** Replaces every em-dash with ordinary punctuation and records the rule in `AGENTS.md`, matching the convention already set for community content. The one en-dash, a `(15-18)` PostgreSQL version range, becomes a hyphen.

No new top-level heading: `### Release train` is an `h3` inside `## Image Tags`, so the `##` count is unchanged at 20 and every nav anchor still resolves.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

Not applicable. No source, wire protocol, or workflow is touched.

## Checklist

- [x] Tests pass locally (not run: no source changed, docs only)
- [ ] New or updated integration test added (not applicable, documentation only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
