### PR TITLE
docs: state the release cadence in CONTRIBUTING and the docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Thank you for your interest in contributing! Floci is a community-driven project
 
 ## Ways to Contribute
 
-- **Bug reports** — open an issue with a minimal reproduction
-- **Feature requests** — open an issue describing the GCP behavior you need
-- **Pull requests** — bug fixes, new service implementations, or improvements
-- **Compatibility tests** — add cases to `./compatibility-tests/`
+- **Bug reports**: open an issue with a minimal reproduction
+- **Feature requests**: open an issue describing the GCP behavior you need
+- **Pull requests**: bug fixes, new service implementations, or improvements
+- **Compatibility tests**: add cases to `./compatibility-tests/`
 
 ## Getting Started
 
@@ -47,16 +47,16 @@ If you prefer to use your own Maven installation (3.9+), you can use `mvn` inste
 
 ## Branching Model
 
-Floci uses a **tag-driven release model**. Docker images are never published on PR merge — only when a maintainer pushes a version tag.
+Floci uses a **tag-driven release model**. Docker images are never published on PR merge, only when a maintainer pushes a version tag.
 
 | Branch | Purpose | Docker published? |
 |---|---|---|
-| `main` | Integration branch — all PRs merge here. Treated as unstable/nightly. | No (CI tests only) |
+| `main` | Integration branch: all PRs merge here. Treated as unstable/nightly. | No (CI tests only) |
 | `X.Y.Z` tag | Signals a production release. Triggers the full Docker publish pipeline. | Yes (`x.y.z`, `latest`, `x.y.z-jvm`, `latest-jvm`) |
 
 ## Commit Message Format
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/) — semantic-release reads these to generate the changelog and version bumps automatically.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/): semantic-release reads these to generate the changelog and version bumps automatically.
 
 > **The PR title is validated automatically by CI** and must follow this format, since it becomes the squash-merge commit message that semantic-release reads.
 
@@ -66,9 +66,9 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) �
 <type>[optional scope]: <description>
 ```
 
-- **type** — one of the values in the table below (lowercase)
-- **scope** — optional, in parentheses, identifies the service or area (e.g. `gcs`, `pubsub`, `core`)
-- **description** — short summary in the imperative mood, no trailing period
+- **type**: one of the values in the table below (lowercase)
+- **scope**: optional, in parentheses, identifies the service or area (e.g. `gcs`, `pubsub`, `core`)
+- **description**: short summary in the imperative mood, no trailing period
 - Append `!` before the colon to signal a breaking change: `feat(api)!:`
 
 | Type | When to use | Version bump |
@@ -78,13 +78,13 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) �
 | `perf` | Performance improvement | patch |
 | `revert` | Reverts a previous commit | patch |
 | `docs` | Documentation only | none |
-| `style` | Formatting, whitespace — no logic change | none |
+| `style` | Formatting, whitespace, no logic change | none |
 | `chore` | Build, CI, dependencies, housekeeping | none |
 | `refactor` | Code restructure without behavior change | none |
 | `test` | Adding or updating tests | none |
 | `build` | Build system or tooling changes | none |
 | `ci` | CI workflow changes | none |
-| `BREAKING CHANGE` | Footer or `!` suffix — incompatible change | major |
+| `BREAKING CHANGE` | Footer or `!` suffix, incompatible change | major |
 
 ### Valid examples ✅
 
@@ -133,7 +133,7 @@ ln -s AGENTS.md COPILOT.md
 ## Adding a New GCP Service
 
 1. Create a package under `src/main/java/.../services/<service>/`
-2. Add a Controller (follow the correct protocol — gRPC, REST JSON, REST XML, or HTTP/protobuf)
+2. Add a Controller (follow the correct protocol: gRPC, REST JSON, REST XML, or HTTP/protobuf)
 3. Add a Service (`@ApplicationScoped`) and model POJOs
 4. Add config entries in `EmulatorConfig.java` and `application.yml`
 5. Register a `ServiceDescriptor` in `ServiceRegistry`
@@ -142,19 +142,23 @@ ln -s AGENTS.md COPILOT.md
 
 `ServiceRegistry`, `ServiceEnabledFilter`, and `StorageFactory` should resolve service metadata through existing service descriptors and storage patterns. Adding a service should not require new service-keyed switch statements in those consumers.
 
-Always implement the **real GCP wire protocol** — never invent custom endpoints. The GCP SDK must work against floci-gcp without modification.
+Always implement the **real GCP wire protocol**. Never invent custom endpoints. The GCP SDK must work against floci-gcp without modification.
 
 ## Pull Request Guidelines
 
 1. Branch off `main`: `git checkout -b feature/my-feature`
 2. Open a PR targeting `main`.
-3. CI runs tests automatically — all checks must pass before merge.
-4. Keep PRs focused — one feature or fix per PR.
+3. CI runs tests automatically. All checks must pass before merge.
+4. Keep PRs focused: one feature or fix per PR.
 5. Reference any related issues in the PR description.
 
 Docker images are never built on contributor PRs, so merging to `main` is always cheap.
 
 ## Release Process (maintainers)
+
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does
+not cut a release: the change rides the next train, and is in that night's `nightly` image
+either way.
 
 Releases are cut from `main` with the **Release Cut** workflow
 (Actions → Release Cut → Run workflow). semantic-release analyzes the
@@ -163,7 +167,7 @@ Conventional Commits since the last tag, bumps `pom.xml`, regenerates
 push triggers the Docker publish pipeline. Use the `dry-run` input to
 preview the next version and notes without releasing.
 
-`CHANGELOG.md` is generated — **do not edit it by hand**. Your Conventional
+`CHANGELOG.md` is generated. **Do not edit it by hand.** Your Conventional
 Commit message is the changelog entry. Genuine corrections to the file
 require the `changelog-edit` label on the PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,8 +157,8 @@ Docker images are never built on contributor PRs, so merging to `main` is always
 ## Release Process (maintainers)
 
 Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does
-not cut a release: the change rides the next train, and is in that night's `nightly` image
-either way.
+not cut a release: the change rides the next train, and reaches the `nightly` image on the
+next nightly build.
 
 Releases are cut from `main` with the **Release Cut** workflow
 (Actions → Release Cut → Run workflow). semantic-release analyzes the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,9 +4,9 @@ floci-gcp is MIT licensed and welcomes contributions of all kinds.
 
 ## Ways to Help
 
-- **Bug reports** — open a [GitHub issue](https://github.com/floci-io/floci-gcp/issues/new?template=bug_report.md) with a minimal reproduction
-- **Missing API operations** — open a [feature request](https://github.com/floci-io/floci-gcp/issues/new?template=feature_request.md)
-- **Pull requests** — new service operations, bug fixes, documentation improvements
+- **Bug reports**: open a [GitHub issue](https://github.com/floci-io/floci-gcp/issues/new?template=bug_report.md) with a minimal reproduction
+- **Missing API operations**: open a [feature request](https://github.com/floci-io/floci-gcp/issues/new?template=feature_request.md)
+- **Pull requests**: new service operations, bug fixes, documentation improvements
 
 ## Development Setup
 
@@ -102,6 +102,12 @@ just test-all-iac      # Terraform / OpenTofu
 ```
 
 If the compatibility test suite is unavailable in your environment, state that explicitly in the PR description.
+
+## Releases
+
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does not cut a release: the change rides the next train, and is in that night's `nightly` image either way.
+
+Maintainers cut releases from `main` with the Release Cut workflow, which runs semantic-release over the Conventional Commits since the last tag. That is why the commit type matters: `feat:` and `fix:` move the version, `docs:` and `chore:` do not. `CHANGELOG.md` is generated from those messages and is never edited by hand.
 
 ## Reporting Security Issues
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -105,9 +105,9 @@ If the compatibility test suite is unavailable in your environment, state that e
 
 ## Releases
 
-Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does not cut a release: the change rides the next train, and is in that night's `nightly` image either way.
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does not cut a release: the change rides the next train, and reaches the `nightly` image on the next nightly build.
 
-Maintainers cut releases from `main` with the Release Cut workflow, which runs semantic-release over the Conventional Commits since the last tag. That is why the commit type matters: `feat:` and `fix:` move the version, `docs:` and `chore:` do not. `CHANGELOG.md` is generated from those messages and is never edited by hand.
+Maintainers cut releases from `main` with the Release Cut workflow, which runs semantic-release over the Conventional Commits since the last tag. That is why the commit type matters: `feat:` and `fix:` move the version, `docs:` and `chore:` do not. `CHANGELOG.md` is generated from those messages and is not edited by hand; a genuine correction goes in a PR carrying the `changelog-edit` label.
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
## Summary

Follow-up to #156, which documented the release train in the README. The cadence was still missing everywhere a contributor or maintainer would actually look for it.

- **`CONTRIBUTING.md`** described how a release is cut but never when. The 1st and 3rd Tuesday train now leads the release section, and merging to `main` is stated not to cut a release.
- **`docs/contributing.md`**, the published contributing page, said nothing about releases at all. It gains a `## Releases` section, including why the commit type matters, since semantic-release derives the version from it.

Em-dashes in the touched files are replaced with ordinary punctuation, per the `## Documentation Style` rule added to `AGENTS.md` in #156.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

Not applicable. No source, wire protocol, or workflow is touched.

## Checklist

- [x] Tests pass locally (not run: no source changed, docs only)
- [ ] New or updated integration test added (not applicable, documentation only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<sub>`mkdocs build --strict` exits 0 with no warnings.</sub>
