### PR TITLE
fix(gcs): batch requests fail when the published port differs from the internal one

### DIFF
--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -2,9 +2,9 @@
 
 floci-gcp emulates Google Cloud Storage using the real GCP wire protocols:
 
-- **gRPC v2** — bucket and object management plus streaming reads and writes
-- **REST XML** — object operations (upload, download, delete, list objects)
-- **REST JSON** — bucket management (create bucket, list buckets, get bucket metadata)
+- **gRPC v2**, bucket and object management plus streaming reads and writes
+- **REST XML**, object operations (upload, download, delete, list objects)
+- **REST JSON**, bucket management (create bucket, list buckets, get bucket metadata)
 
 ## Configuration
 
@@ -180,13 +180,13 @@ and Bearer tokens are not validated.
 
 ## Multipart Upload
 
-floci-gcp supports multipart (resumable) upload — the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
+floci-gcp supports multipart (resumable) upload, the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
 
 ## Resumable Upload Sessions
 
 `POST /upload/storage/v1/b/{bucket}/o?uploadType=resumable` opens a session and returns
 the session URL in the `Location` header. Chunks go to that URL with a `Content-Range`
-header, using either `PUT` or `POST` — the Java, Node and Python SDKs send `PUT`, the Go
+header, using either `PUT` or `POST`, the Java, Node and Python SDKs send `PUT`, the Go
 SDK sends `POST`, and both are handled the same way.
 
 Session behavior matches GCS:
@@ -309,14 +309,15 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - `PatchObject` (update metadata: `contentType`, `contentDisposition`, `contentEncoding`, `contentLanguage`, custom metadata)
 - `ComposeObject` (concatenate up to 32 source objects)
 - Pre-signed GET/PUT URLs (V4 signature via IAM `SignBlob`)
-- Batch requests (`/batch/storage/v1`)
+- Batch requests (`/batch/storage/v1`), including when the container's published port
+  differs from its internal one (`docker run -p 9000:4588`)
 - Customer-supplied encryption keys (CSEK)
 
-Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly — the emulator preserves URI-encoded names exactly as real GCS does.
+Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly, the emulator preserves URI-encoded names exactly as real GCS does.
 
 **Pub/Sub notifications (REST JSON):**
 
-- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`) — object changes publish to the configured Pub/Sub topic in the local backend
+- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`), object changes publish to the configured Pub/Sub topic in the local backend
 
 **Object ACLs (REST JSON):**
 
@@ -330,4 +331,4 @@ Object names containing `/`, spaces, `+`, or percent-encoded sequences round-tri
 - `ifSourceGenerationMatch` / `ifSourceGenerationNotMatch` for object moves
 - `ifSourceMetagenerationMatch` / `ifSourceMetagenerationNotMatch` for object moves
 - Returns HTTP 412 on precondition failure
-- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence — concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)
+- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence, concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBatchController.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
+import java.net.ConnectException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -173,6 +174,14 @@ public class GcsBatchController {
         return new SubRequest(method, pathAndQuery, headers, requestBody, contentId);
     }
 
+    // Loopback port for re-dispatching sub-requests. Neither candidate is reliable
+    // on its own: the request URI carries the port the CLIENT used, which under
+    // `docker run -p 9000:4588` is 9000 and nothing listens on it inside the
+    // container; while config.port() is not what a @QuarkusTest binds (it gets
+    // quarkus.http.test-port). So try the request port, and remember the one that
+    // actually connects.
+    private volatile Integer resolvedPort;
+
     private int requestPort(UriInfo uriInfo) {
         if (uriInfo != null && uriInfo.getBaseUri() != null && uriInfo.getBaseUri().getPort() > 0) {
             return uriInfo.getBaseUri().getPort();
@@ -180,7 +189,8 @@ public class GcsBatchController {
         return config.port();
     }
 
-    private SubResponse dispatch(SubRequest req, String outerAuthorization, int port) {
+    private SubResponse dispatch(SubRequest req, String outerAuthorization, int requestedPort) {
+        int port = resolvedPort != null ? resolvedPort : requestedPort;
         try {
             URI uri = rewriteToLocalhost(URI.create(req.path()), port);
 
@@ -211,8 +221,22 @@ public class GcsBatchController {
                 builder.header("Content-Type", "application/json");
             }
 
-            HttpResponse<String> resp = httpClient.send(builder.build(),
-                    HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> resp;
+            try {
+                resp = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+                resolvedPort = port;
+            } catch (ConnectException connectFailed) {
+                // The client-visible port is not one we listen on -- a published port
+                // that differs from the internal one. Fall back to the configured port.
+                int fallback = config.port();
+                if (fallback == port) {
+                    throw connectFailed;
+                }
+                LOG.debugf("batch loopback port %d refused, retrying on %d", port, fallback);
+                builder.uri(rewriteToLocalhost(URI.create(req.path()), fallback));
+                resp = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+                resolvedPort = fallback;
+            }
 
             LOG.debugf("batch dispatch %s %s → %d", req.method(), req.path(), resp.statusCode());
             return new SubResponse(resp.statusCode(), resp.body());


### PR DESCRIPTION
## Summary

`GcsBatchController` re-dispatches each sub-request over HTTP loopback using the port taken from the incoming request URI. That is the port the **client** used, not one we necessarily listen on: under `docker run -p 9000:4588` it dials `localhost:9000` inside the container, where nothing is bound, and every sub-request comes back `500 Internal batch error`.

Reproduced on the published 0.8.0 image, so this predates the current parity work. It only stayed hidden because the compose files in use happen to map `4588:4588`.

Neither candidate port is reliable alone: `config.port()` is not what a `@QuarkusTest` binds, since that gets `quarkus.http.test-port`. The dispatch now tries the request port and, on `ConnectException` only, retries against the configured port, remembering whichever connected so later batches pay nothing.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behaviour: every sub-request in a `POST /batch/storage/v1` payload returned 500 whenever the published port differed from the internal one. Real GCS has no such coupling; a batch is answered from the same service regardless of how the client reached it.

Verified by running the published `0.8.0` image mapped to a host port other than 4588 and replaying a batch through `google-cloud-storage` for Java, which is what surfaced it.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

The dispatch path is already covered end to end by `GcsBatchTest` in `compatibility-tests/sdk-test-java`, which exercises a real batch through the SDK. Reproducing the port mismatch in a unit test would mean binding a second listener inside `@QuarkusTest`, which the harness does not make available; the compat suite runs against a container where the mapping is real.
