### PR TITLE
fix(gcs): resolve the request base URL from the authority, not the Host header

### DIFF
--- a/src/main/java/io/floci/gcp/core/common/RequestBaseUrl.java
+++ b/src/main/java/io/floci/gcp/core/common/RequestBaseUrl.java
@@ -1,0 +1,83 @@
+package io.floci.gcp.core.common;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+
+/**
+ * Resolves the base URL a client should use to reach the emulator back.
+ *
+ * <p>Services mint absolute URLs into their responses, the resumable upload session
+ * {@code Location}, {@code selfLink}, {@code mediaLink}, and the client dials whatever comes
+ * back. Those URLs have to name the address the caller actually reached, which is not
+ * necessarily the one the emulator listens on: under {@code docker run -p 9000:4588} the
+ * published port differs from the internal one.
+ *
+ * <p><strong>Read the authority from the request URI, not from the {@code Host} header.</strong>
+ * HTTP/2 carries the authority in the {@code :authority} pseudo-header and sends no {@code Host}
+ * header at all, so a Host-only lookup returns null on every HTTP/2 request and silently falls
+ * back to the configured base URL. floci-gcp negotiates HTTP/2 by ALPN on the same port it
+ * serves HTTP/1.1 on, so both shapes arrive on every deployment: a client that upgrades (Java's
+ * {@code HttpClient} does by default) would be handed session URLs pointing at whatever
+ * {@code floci-gcp.base-url} names. {@link io.floci.gcp.core.common.routing.ServiceRoutingFilter}
+ * and {@code CloudRunUrlRoutingFilter} already fall back this way; this centralises the same
+ * rule for the URL-minting paths.
+ */
+public final class RequestBaseUrl {
+
+    private RequestBaseUrl() {
+    }
+
+    /**
+     * @param uriInfo            the request's URI info, the authoritative source of the authority
+     * @param headers            request headers, consulted only if the request URI has no authority
+     * @param configuredBaseUrl  {@code floci-gcp.base-url}, the fallback and the scheme to use
+     * @param configuredPort     {@code floci-gcp.port}, used when the authority carries no port
+     */
+    public static String resolve(UriInfo uriInfo, HttpHeaders headers,
+            String configuredBaseUrl, int configuredPort) {
+        String authority = requestAuthority(uriInfo, headers);
+        if (authority == null || authority.isBlank()) {
+            return configuredBaseUrl;
+        }
+
+        URI configured = configuredBaseUrl != null ? URI.create(configuredBaseUrl) : null;
+        String scheme = configured != null && configured.getScheme() != null
+                ? configured.getScheme()
+                : requestScheme(uriInfo);
+
+        if (hasPort(authority)) {
+            return scheme + "://" + authority;
+        }
+        // A portless authority is legal, a proxy fronting the emulator on 80 or 443 sends one , 
+        // but dropping the port here would produce a session URL the client cannot dial back.
+        int port = configured != null && configured.getPort() >= 0 ? configured.getPort() : configuredPort;
+        return scheme + "://" + authority + ":" + port;
+    }
+
+    private static String requestAuthority(UriInfo uriInfo, HttpHeaders headers) {
+        if (uriInfo != null && uriInfo.getRequestUri() != null) {
+            String authority = uriInfo.getRequestUri().getRawAuthority();
+            if (authority != null && !authority.isBlank()) {
+                return authority;
+            }
+        }
+        return headers != null ? headers.getHeaderString(HttpHeaders.HOST) : null;
+    }
+
+    private static String requestScheme(UriInfo uriInfo) {
+        if (uriInfo != null && uriInfo.getBaseUri() != null && uriInfo.getBaseUri().getScheme() != null) {
+            return uriInfo.getBaseUri().getScheme();
+        }
+        return "http";
+    }
+
+    /** True when the authority already carries an explicit port, IPv6 literals included. */
+    private static boolean hasPort(String authority) {
+        if (authority.startsWith("[")) {
+            return authority.indexOf("]:") > 0;
+        }
+        return authority.indexOf(':') >= 0;
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.RequestBaseUrl;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.StoredAcl;
@@ -16,6 +17,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -27,6 +29,11 @@ import java.util.Map;
 @Path("/storage/v1/b")
 @Produces(MediaType.APPLICATION_JSON)
 public class GcsBucketController {
+
+    // Injected per request rather than threaded through every method signature: the
+    // request URI is where the authority lives on HTTP/2, which carries no Host header.
+    @Context
+    UriInfo uriInfo;
 
     private final GcsService service;
     private final EmulatorConfig config;
@@ -353,7 +360,6 @@ public class GcsBucketController {
     }
 
     private String requestBaseUrl(HttpHeaders headers) {
-        String host = headers.getHeaderString("Host");
-        return host != null ? "http://" + host : config.baseUrl();
+        return RequestBaseUrl.resolve(uriInfo, headers, config.baseUrl(), config.port());
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -3,6 +3,7 @@ package io.floci.gcp.services.gcs;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.PageToken;
+import io.floci.gcp.core.common.RequestBaseUrl;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
@@ -14,6 +15,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,6 +29,11 @@ import java.util.TreeSet;
 @Path("/storage/v1/b/{bucket}/o")
 @Produces(MediaType.APPLICATION_JSON)
 public class GcsObjectController {
+
+    // Injected per request rather than threaded through every method signature: the
+    // request URI is where the authority lives on HTTP/2, which carries no Host header.
+    @Context
+    UriInfo uriInfo;
 
     private final GcsService service;
     private final EmulatorConfig config;
@@ -357,7 +364,6 @@ public class GcsObjectController {
     }
 
     private String requestBaseUrl(HttpHeaders headers) {
-        String host = headers.getHeaderString("Host");
-        return host != null ? "http://" + host : config.baseUrl();
+        return RequestBaseUrl.resolve(uriInfo, headers, config.baseUrl(), config.port());
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -3,6 +3,7 @@ package io.floci.gcp.services.gcs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.common.RequestBaseUrl;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.CompletedResumableUpload;
 import io.floci.gcp.services.gcs.model.GcsContentRange;
@@ -276,24 +277,7 @@ public class GcsUploadController {
     }
 
     private String requestBaseUrl(HttpHeaders headers, UriInfo uriInfo) {
-        String host = headers.getHeaderString("Host");
-        if (host == null) {
-            return config.baseUrl();
-        }
-        if (hasPort(host)) {
-            return "http://" + host;
-        }
-        URI baseUrl = URI.create(config.baseUrl());
-        int port = baseUrl.getPort() >= 0 ? baseUrl.getPort() : config.port();
-        String scheme = baseUrl.getScheme() != null ? baseUrl.getScheme() : uriInfo.getBaseUri().getScheme();
-        return scheme + "://" + host + ":" + port;
-    }
-
-    private static boolean hasPort(String host) {
-        if (host.startsWith("[")) {
-            return host.indexOf("]:") > 0;
-        }
-        return host.indexOf(':') >= 0;
+        return RequestBaseUrl.resolve(uriInfo, headers, config.baseUrl(), config.port());
     }
 
     private static Map<String, String> extractUserMetadata(Map<?, ?> requestMetadata) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.gcs;
 
 import io.floci.gcp.config.EmulatorConfig;
+import io.floci.gcp.core.common.RequestBaseUrl;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -78,8 +79,7 @@ public class GcsXmlDownloadController {
         authorizationService.requireObjectWrite(
                 headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, objectPath);
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
-        String host = headers.getHeaderString("Host");
-        String baseUrl = host != null ? "http://" + host : config.baseUrl();
+        String baseUrl = RequestBaseUrl.resolve(uriInfo, headers, config.baseUrl(), config.port());
         GcsObjectMeta meta = service.putObject(bucket, objectPath, contentType, body != null ? body : new byte[0],
                 GcsCustomerEncryption.fromHeaders(headers), googMetaHeaders(headers), baseUrl);
         return Response.ok(meta).build();

--- a/src/test/java/io/floci/gcp/core/common/RequestBaseUrlTest.java
+++ b/src/test/java/io/floci/gcp/core/common/RequestBaseUrlTest.java
@@ -1,0 +1,88 @@
+package io.floci.gcp.core.common;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestBaseUrlTest {
+
+    private static final String CONFIGURED = "http://localhost:4588";
+
+    @Test
+    void prefersTheRequestAuthorityOverTheConfiguredBaseUrl() {
+        assertEquals("http://localhost:9000",
+                RequestBaseUrl.resolve(uriInfo("http://localhost:9000/storage/v1/b"),
+                        headers("localhost:9000"), CONFIGURED, 4588));
+    }
+
+    @Test
+    void usesTheRequestAuthorityWhenNoHostHeaderIsPresent() {
+        // The HTTP/2 shape: the authority arrives as :authority and no Host header is sent, so a
+        // Host-only lookup would fall back to the configured base URL and name the wrong port.
+        assertEquals("http://localhost:9000",
+                RequestBaseUrl.resolve(uriInfo("http://localhost:9000/storage/v1/b"),
+                        headers(null), CONFIGURED, 4588));
+    }
+
+    @Test
+    void fallsBackToTheHostHeaderWhenTheRequestUriHasNoAuthority() {
+        assertEquals("http://gcs.example:8080",
+                RequestBaseUrl.resolve(uriInfo("/storage/v1/b"),
+                        headers("gcs.example:8080"), CONFIGURED, 4588));
+    }
+
+    @Test
+    void fallsBackToTheConfiguredBaseUrlWhenNeitherIsAvailable() {
+        assertEquals(CONFIGURED,
+                RequestBaseUrl.resolve(uriInfo("/storage/v1/b"), headers(null), CONFIGURED, 4588));
+    }
+
+    @Test
+    void addsTheConfiguredPortToAPortlessAuthority() {
+        // A proxy fronting the emulator on 80 sends a portless authority; dropping the port would
+        // produce a session URL the client cannot dial back.
+        assertEquals("http://gcs.example:4588",
+                RequestBaseUrl.resolve(uriInfo("http://gcs.example/storage/v1/b"),
+                        headers("gcs.example"), CONFIGURED, 4588));
+    }
+
+    @Test
+    void keepsThePortOfAnIpv6Authority() {
+        assertEquals("http://[::1]:9000",
+                RequestBaseUrl.resolve(uriInfo("http://[::1]:9000/storage/v1/b"),
+                        headers("[::1]:9000"), CONFIGURED, 4588));
+    }
+
+    @Test
+    void addsTheConfiguredPortToAPortlessIpv6Authority() {
+        assertEquals("http://[::1]:4588",
+                RequestBaseUrl.resolve(uriInfo("http://[::1]/storage/v1/b"),
+                        headers("[::1]"), CONFIGURED, 4588));
+    }
+
+    @Test
+    void takesTheSchemeFromTheConfiguredBaseUrl() {
+        assertEquals("https://localhost:9000",
+                RequestBaseUrl.resolve(uriInfo("http://localhost:9000/storage/v1/b"),
+                        headers("localhost:9000"), "https://localhost:4588", 4588));
+    }
+
+    private static UriInfo uriInfo(String requestUri) {
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(URI.create(requestUri));
+        when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost:4588/"));
+        return uriInfo;
+    }
+
+    private static HttpHeaders headers(String host) {
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getHeaderString(HttpHeaders.HOST)).thenReturn(host);
+        return headers;
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsHttp2BaseUrlRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsHttp2BaseUrlRestIntegrationTest.java
@@ -1,0 +1,107 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * URLs the emulator mints must name the address the caller actually reached, over HTTP/2 as well
+ * as HTTP/1.1.
+ *
+ * <p>HTTP/2 carries the authority in the {@code :authority} pseudo-header and sends no
+ * {@code Host} header, so reading {@code Host} yields null on every HTTP/2 request. That used to
+ * fall back to {@code floci-gcp.base-url}, handing the client a resumable session
+ * {@code Location} on port 4588 regardless of where it had actually connected, and since
+ * floci-gcp negotiates HTTP/2 by ALPN on its single port, any client that upgrades hits it.
+ * Java's {@code HttpClient} upgrades by default, which is how this surfaced.
+ */
+@QuarkusTest
+class GcsHttp2BaseUrlRestIntegrationTest {
+
+    private static final String BUCKET = "http2-base-url-bucket";
+
+    @TestHTTPResource
+    URL testUrl;
+
+    private String origin() {
+        return "http://" + testUrl.getHost() + ":" + testUrl.getPort();
+    }
+
+    @BeforeEach
+    void ensureBucket() throws Exception {
+        send(HttpClient.Version.HTTP_1_1,
+                HttpRequest.newBuilder(URI.create(origin() + "/storage/v1/b?project=test-project"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"" + BUCKET + "\"}")));
+    }
+
+    @Test
+    void resumableSessionLocationNamesTheRequestAuthorityOverHttp2() throws Exception {
+        HttpResponse<String> response = startSession(HttpClient.Version.HTTP_2, "over-http2.bin");
+
+        assertEquals(200, response.statusCode());
+        assertEquals(HttpClient.Version.HTTP_2, response.version());
+
+        String location = response.headers().firstValue("Location").orElseThrow();
+        assertEquals(testUrl.getPort(), URI.create(location).getPort(),
+                "session Location must name the port the client connected to, not floci-gcp.base-url");
+
+        // And the session it names has to be the one that was just opened.
+        HttpResponse<String> status = send(HttpClient.Version.HTTP_2,
+                HttpRequest.newBuilder(URI.create(location))
+                        .header("Content-Range", "bytes */*")
+                        .PUT(HttpRequest.BodyPublishers.noBody()));
+        assertEquals(308, status.statusCode());
+    }
+
+    @Test
+    void resumableSessionLocationNamesTheRequestAuthorityOverHttp11() throws Exception {
+        HttpResponse<String> response = startSession(HttpClient.Version.HTTP_1_1, "over-http11.bin");
+
+        assertEquals(200, response.statusCode());
+        String location = response.headers().firstValue("Location").orElseThrow();
+        assertEquals(testUrl.getPort(), URI.create(location).getPort());
+    }
+
+    @Test
+    void objectSelfLinkNamesTheRequestAuthorityOverHttp2() throws Exception {
+        HttpResponse<String> uploaded = send(HttpClient.Version.HTTP_2,
+                HttpRequest.newBuilder(URI.create(origin() + "/upload/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=media&name=selflink.txt"))
+                        .header("Content-Type", "text/plain")
+                        .POST(HttpRequest.BodyPublishers.ofString("bytes")));
+
+        assertEquals(200, uploaded.statusCode());
+        String port = ":" + testUrl.getPort();
+        assertTrue(uploaded.body().contains("\"selfLink\":\"http://" + testUrl.getHost() + port),
+                "selfLink must name the request authority, body was: " + uploaded.body());
+        assertTrue(uploaded.body().contains("\"mediaLink\":\"http://" + testUrl.getHost() + port),
+                "mediaLink must name the request authority, body was: " + uploaded.body());
+    }
+
+    private HttpResponse<String> startSession(HttpClient.Version version, String name) throws Exception {
+        return send(version,
+                HttpRequest.newBuilder(URI.create(origin() + "/upload/storage/v1/b/" + BUCKET
+                                + "/o?uploadType=resumable&name=" + name))
+                        .header("X-Upload-Content-Type", "application/octet-stream")
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}")));
+    }
+
+    private static HttpResponse<String> send(HttpClient.Version version, HttpRequest.Builder request)
+            throws Exception {
+        try (HttpClient client = HttpClient.newBuilder().version(version).build()) {
+            return client.send(request.version(version).build(), HttpResponse.BodyHandlers.ofString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

HTTP/2 carries the authority in the `:authority` pseudo-header and sends **no `Host` header at all**. Four GCS controllers read `Host`, so on every HTTP/2 request the lookup returned null and they fell back to `floci-gcp.base-url`. Clients were handed a resumable session `Location`, `selfLink` and `mediaLink` naming whatever that config value said rather than the address they had actually reached.

floci-gcp negotiates HTTP/2 by ALPN on the same port it serves HTTP/1.1 on, so both shapes arrive on every deployment, and Java's `HttpClient` upgrades by default.

New `core/common/RequestBaseUrl` reads the authority from the request URI, falls back to `Host`, then to the configured base URL. `ServiceRoutingFilter` and `CloudRunUrlRoutingFilter` already fell back this way; this applies the same rule to the URL-minting paths and replaces three copies of a two-line helper.

Two behaviours come along with the consolidation: the portless-authority port fixup that only `GcsUploadController` had now covers `selfLink` and `mediaLink` too, and IPv6 authorities are handled.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Incorrect behaviour: minted URLs named the wrong host and port over HTTP/2. Against a running emulator on port 4590:

```
HTTP/1.1 -> Location: http://localhost:4590/upload/...   correct
HTTP/2   -> Location: http://localhost:4588/upload/...   the configured base-url
```

Confirmed the mechanism directly with a temporary probe endpoint: over HTTP/1.1 the request carries `[Accept, Host, User-Agent]`; over HTTP/2 it carries `[accept, user-agent]` and no `Host`, while `uriInfo.getRequestUri().getAuthority()` is correct in both.

Real GCS mints URLs that address the endpoint the client reached, which is what the SDKs then dial back. This is the same class of bug as the batch dispatch fix, and it stays invisible whenever `base-url` happens to match the published address.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`RequestBaseUrlTest` (8 unit cases, including the no-`Host` HTTP/2 shape, portless and IPv6 authorities) and `GcsHttp2BaseUrlRestIntegrationTest` (3 cases driving real h2). Verified the regression test pins the behaviour: reverting the helper to `Host`-only fails the two HTTP/2 cases with `expected: <8081> but was: <4588>` while the HTTP/1.1 control still passes.
