### PR TITLE
feat(gcs): add endOffset, matchGlob and includeTrailingDelimiter to objects.list

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsListFiltersTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsListFiltersTest.java
@@ -1,0 +1,125 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code objects.list} filters beyond {@code prefix}: {@code endOffset}, {@code matchGlob} and
+ * {@code includeTrailingDelimiter}.
+ *
+ * <p>The glob cases are the ones worth pinning: {@code *} stays inside one path segment while
+ * {@code **} crosses them, a distinction a naive translation to {@code .*} collapses.
+ */
+class GcsListFiltersTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("list-filters-bucket");
+    private static final List<String> OBJECTS = List.of(
+            "logs/",
+            "logs/app.log",
+            "logs/app.txt",
+            "logs/2026/01/app.log",
+            "logs/2026/02/app.log",
+            "metrics/cpu.log");
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        for (String name : OBJECTS) {
+            storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, name)).build(), new byte[0]);
+        }
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void endOffsetIsExclusiveAndPairsWithStartOffset() {
+        // "Objects whose names are lexicographically before endOffset", with startOffset
+        // inclusive and endOffset exclusive.
+        assertThat(names(Storage.BlobListOption.endOffset("logs/app.log")))
+                .contains("logs/", "logs/2026/01/app.log", "logs/2026/02/app.log")
+                .doesNotContain("logs/app.log", "logs/app.txt", "metrics/cpu.log");
+
+        assertThat(names(
+                Storage.BlobListOption.startOffset("logs/app.log"),
+                Storage.BlobListOption.endOffset("logs/app.txt")))
+                .containsExactly("logs/app.log");
+    }
+
+    @Test
+    void matchGlobKeepsSingleStarWithinOnePathSegment() {
+        assertThat(names(Storage.BlobListOption.matchGlob("logs/*.log")))
+                .containsExactly("logs/app.log");
+
+        assertThat(names(Storage.BlobListOption.matchGlob("logs/**.log")))
+                .containsExactlyInAnyOrder(
+                        "logs/app.log", "logs/2026/01/app.log", "logs/2026/02/app.log");
+
+        assertThat(names(Storage.BlobListOption.matchGlob("**/*.log")))
+                .contains("logs/2026/01/app.log", "metrics/cpu.log");
+    }
+
+    @Test
+    void includeTrailingDelimiterAddsThePlaceholderObjectToItems() throws Exception {
+        // Driven raw: google-cloud-storage 2.47.0 exposes no BlobListOption for this parameter,
+        // so the SDK cannot send it. Without the flag "logs/" only rolls up into prefixes[] and
+        // its own metadata is invisible; with it the placeholder is additionally in items[].
+        String withoutFlag = listRaw("delimiter=%2F");
+        assertThat(withoutFlag).contains("\"prefixes\"");
+        assertThat(itemNames(withoutFlag)).doesNotContain("logs/");
+
+        String withFlag = listRaw("delimiter=%2F&includeTrailingDelimiter=true");
+        assertThat(itemNames(withFlag)).contains("logs/");
+    }
+
+    private static String listRaw(String query) throws Exception {
+        URI uri = URI.create(TestFixtures.endpoint() + "/storage/v1/b/" + BUCKET + "/o?" + query);
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+        return response.body();
+    }
+
+    /** Object names from the items[] array only, ignoring anything under prefixes[]. */
+    private static List<String> itemNames(String body) {
+        Matcher matcher = Pattern.compile("\"name\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
+        List<String> names = new ArrayList<>();
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    private static List<String> names(Storage.BlobListOption... options) {
+        return StreamSupport.stream(
+                        storage.list(BUCKET, options).iterateAll().spliterator(), false)
+                .map(Blob::getName)
+                .toList();
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_list_filters.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_list_filters.py
@@ -1,0 +1,75 @@
+"""objects.list filters beyond prefix: endOffset, matchGlob and includeTrailingDelimiter.
+
+The glob cases are the ones worth pinning: ``*`` stays inside one path segment while ``**``
+crosses them, a distinction a naive translation to ``.*`` collapses.
+"""
+
+import pytest
+
+
+OBJECTS = [
+    "logs/",
+    "logs/app.log",
+    "logs/app.txt",
+    "logs/2026/01/app.log",
+    "logs/2026/02/app.log",
+    "metrics/cpu.log",
+]
+
+
+@pytest.fixture
+def filter_bucket(storage_client, unique_name):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"filters-{unique_name}"))
+    for name in OBJECTS:
+        bucket.blob(name).upload_from_string(b"")
+    yield bucket
+    bucket.delete(force=True)
+
+
+def names(storage_client, bucket, **kwargs):
+    return [blob.name for blob in storage_client.list_blobs(bucket, **kwargs)]
+
+
+def test_end_offset_is_exclusive(storage_client, filter_bucket):
+    listed = names(storage_client, filter_bucket, end_offset="logs/app.log")
+    assert "logs/2026/01/app.log" in listed
+    assert "logs/app.log" not in listed
+    assert "metrics/cpu.log" not in listed
+
+
+def test_start_and_end_offset_bracket_the_range(storage_client, filter_bucket):
+    listed = names(
+        storage_client, filter_bucket, start_offset="logs/app.log", end_offset="logs/app.txt"
+    )
+    assert listed == ["logs/app.log"]
+
+
+def test_match_glob_keeps_single_star_within_one_segment(storage_client, filter_bucket):
+    assert names(storage_client, filter_bucket, match_glob="logs/*.log") == ["logs/app.log"]
+
+    assert sorted(names(storage_client, filter_bucket, match_glob="logs/**.log")) == sorted(
+        ["logs/app.log", "logs/2026/01/app.log", "logs/2026/02/app.log"]
+    )
+
+    crossing = names(storage_client, filter_bucket, match_glob="**/*.log")
+    assert "logs/2026/01/app.log" in crossing
+    assert "metrics/cpu.log" in crossing
+
+
+def test_include_trailing_delimiter_adds_the_placeholder_to_items(
+    storage_client, filter_bucket
+):
+    # Without the flag "logs/" only rolls up into prefixes and its own metadata is invisible.
+    without_flag = names(storage_client, filter_bucket, delimiter="/")
+    assert "logs/" not in without_flag
+
+    with_flag = names(
+        storage_client, filter_bucket, delimiter="/", include_trailing_delimiter=True
+    )
+    assert "logs/" in with_flag
+
+
+def test_delimiter_rolls_directories_up_into_prefixes(storage_client, filter_bucket):
+    iterator = storage_client.list_blobs(filter_bucket, delimiter="/")
+    list(iterator)  # prefixes are only populated once the pages have been consumed
+    assert iterator.prefixes == {"logs/", "metrics/"}

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -2,9 +2,9 @@
 
 floci-gcp emulates Google Cloud Storage using the real GCP wire protocols:
 
-- **gRPC v2** — bucket and object management plus streaming reads and writes
-- **REST XML** — object operations (upload, download, delete, list objects)
-- **REST JSON** — bucket management (create bucket, list buckets, get bucket metadata)
+- **gRPC v2**, bucket and object management plus streaming reads and writes
+- **REST XML**, object operations (upload, download, delete, list objects)
+- **REST JSON**, bucket management (create bucket, list buckets, get bucket metadata)
 
 ## Configuration
 
@@ -180,13 +180,13 @@ and Bearer tokens are not validated.
 
 ## Multipart Upload
 
-floci-gcp supports multipart (resumable) upload — the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
+floci-gcp supports multipart (resumable) upload, the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
 
 ## Resumable Upload Sessions
 
 `POST /upload/storage/v1/b/{bucket}/o?uploadType=resumable` opens a session and returns
 the session URL in the `Location` header. Chunks go to that URL with a `Content-Range`
-header, using either `PUT` or `POST` — the Java, Node and Python SDKs send `PUT`, the Go
+header, using either `PUT` or `POST`, the Java, Node and Python SDKs send `PUT`, the Go
 SDK sends `POST`, and both are handled the same way.
 
 Session behavior matches GCS:
@@ -302,7 +302,8 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - `PutObject` (simple and multipart/resumable upload)
 - `GetObject`
 - `DeleteObject`
-- `ListObjects` (with `pageToken`, `prefix`, `delimiter` pagination)
+- `ListObjects` (with `pageToken`, `prefix`, `delimiter` pagination, plus `startOffset`,
+  `endOffset`, `matchGlob` and `includeTrailingDelimiter` filtering)
 - `CopyObject`
 - `MoveObject`
 - `HeadObject`
@@ -312,11 +313,11 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - Batch requests (`/batch/storage/v1`)
 - Customer-supplied encryption keys (CSEK)
 
-Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly — the emulator preserves URI-encoded names exactly as real GCS does.
+Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly, the emulator preserves URI-encoded names exactly as real GCS does.
 
 **Pub/Sub notifications (REST JSON):**
 
-- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`) — object changes publish to the configured Pub/Sub topic in the local backend
+- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`), object changes publish to the configured Pub/Sub topic in the local backend
 
 **Object ACLs (REST JSON):**
 
@@ -330,4 +331,4 @@ Object names containing `/`, spaces, `+`, or percent-encoded sequences round-tri
 - `ifSourceGenerationMatch` / `ifSourceGenerationNotMatch` for object moves
 - `ifSourceMetagenerationMatch` / `ifSourceMetagenerationNotMatch` for object moves
 - Returns HTTP 412 on precondition failure
-- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence — concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)
+- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence, concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -53,6 +53,9 @@ public class GcsObjectController {
             @QueryParam("prefix") String prefix,
             @QueryParam("delimiter") String delimiter,
 			@QueryParam("startOffset") String startOffset,
+			@QueryParam("endOffset") String endOffset,
+			@QueryParam("matchGlob") String matchGlob,
+			@QueryParam("includeTrailingDelimiter") @DefaultValue("false") boolean includeTrailingDelimiter,
 			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @QueryParam("versions") @DefaultValue("false") boolean includeVersions) {
 		authorizationService.requireObjectList(authorization, bucket, prefix);
@@ -62,9 +65,13 @@ public class GcsObjectController {
         if (!includeVersions && prefix != null && !prefix.isBlank()) {
             all = all.stream().filter(o -> o.getName().startsWith(prefix)).toList();
         }
+        // startOffset is inclusive, endOffset exclusive.
+        GcsObjectGlob.GlobMatcher globMatcher = GcsObjectGlob.matcher(GcsObjectGlob.compile(matchGlob));
         all = all.stream()
                 .sorted(Comparator.comparing(GcsObjectMeta::getName))
                 .filter(o -> startOffset == null || o.getName().compareTo(startOffset) >= 0)
+                .filter(o -> endOffset == null || o.getName().compareTo(endOffset) < 0)
+                .filter(o -> globMatcher.matches(o.getName()))
                 .toList();
         Set<String> prefixes = new TreeSet<>();
         if (delimiter != null && !delimiter.isEmpty()) {
@@ -75,6 +82,12 @@ public class GcsObjectController {
                 int idx = rest.indexOf(delimiter);
                 if (idx >= 0) {
                     prefixes.add(basePrefix + rest.substring(0, idx + delimiter.length()));
+                    // includeTrailingDelimiter: an object whose own name ends in exactly one
+                    // delimiter is a "directory placeholder". It still rolls up into
+                    // prefixes[], but its metadata is additionally returned in items[].
+                    if (includeTrailingDelimiter && idx + delimiter.length() == rest.length()) {
+                        rolledUp.add(meta);
+                    }
                 } else {
                     rolledUp.add(meta);
                 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectGlob.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectGlob.java
@@ -1,0 +1,206 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Compiles a Cloud Storage {@code matchGlob} pattern into a regex.
+ *
+ * <p>The syntax is documented on objects.list:
+ * <pre>
+ *   ?           a single character, excluding "/"
+ *   *           zero or more characters, excluding "/"
+ *   **          zero or more characters, including "/"
+ *   [abc] [a-z] a character class; [!abc] negates it
+ *   {abc,xyz}   brace alternation
+ * </pre>
+ *
+ * <p>The distinction that matters is {@code *} vs {@code **}: {@code logs/*.json} must not
+ * reach across a path segment while {@code a/**} must. A naive translation of {@code *} to
+ * {@code .*} collapses the two and makes every pattern behave like {@code **}.
+ */
+final class GcsObjectGlob {
+
+    private GcsObjectGlob() {
+    }
+
+    static Pattern compile(String glob) {
+        if (glob == null || glob.isEmpty()) {
+            return null;
+        }
+        if (glob.length() > 1024) {
+            throw GcpException.invalidArgument("matchGlob exceeds the 1024 byte limit");
+        }
+
+        StringBuilder out = new StringBuilder(glob.length() * 2);
+        int depth = 0;
+
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            switch (c) {
+                case '*' -> {
+                    if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                        i++;
+                        // "**/" should also match zero segments, so "**/x" matches a bare "x".
+                        String token = i + 1 < glob.length() && glob.charAt(i + 1) == '/'
+                                ? "(?:.*/)?" : ".*";
+                        if (token.equals("(?:.*/)?")) {
+                            i++;
+                        }
+                        // Adjacent duplicates are redundant (".*.*" matches exactly what ".*"
+                        // matches) but each one multiplies the backtracking the engine does on a
+                        // name that does not match, so collapse them instead of emitting both.
+                        if (!endsWith(out, token)) {
+                            out.append(token);
+                        }
+                    } else {
+                        if (!endsWith(out, "[^/]*")) {
+                            out.append("[^/]*");
+                        }
+                    }
+                }
+                case '?' -> out.append("[^/]");
+                case '[' -> i = appendCharClass(glob, i, out);
+                case '{' -> {
+                    depth++;
+                    out.append("(?:");
+                }
+                case '}' -> {
+                    if (depth > 0) {
+                        depth--;
+                        out.append(')');
+                    } else {
+                        out.append("\\}");
+                    }
+                }
+                case ',' -> out.append(depth > 0 ? "|" : "\\,");
+                default -> appendLiteral(out, c);
+            }
+        }
+
+        if (depth != 0) {
+            throw GcpException.invalidArgument("unbalanced braces in matchGlob: " + glob);
+        }
+
+        try {
+            return Pattern.compile(out.toString(), Pattern.DOTALL);
+        } catch (PatternSyntaxException e) {
+            throw GcpException.invalidArgument("invalid matchGlob: " + glob);
+        }
+    }
+
+    /** Copies a [...] class through, translating a leading "!" to regex "^". Returns the index of ']'. */
+    private static int appendCharClass(String glob, int open, StringBuilder out) {
+        int close = glob.indexOf(']', open + 1);
+        if (close < 0) {
+            // An unterminated "[" is a literal, matching shell behavior.
+            out.append("\\[");
+            return open;
+        }
+        String body = glob.substring(open + 1, close);
+        out.append('[');
+        if (body.startsWith("!")) {
+            out.append('^').append(Pattern.quote(body.substring(1)).replace("\\Q", "").replace("\\E", ""));
+        } else {
+            out.append(body.replace("\\", "\\\\"));
+        }
+        out.append(']');
+        return close;
+    }
+
+    /**
+     * Character reads one {@code objects.list} request may spend on glob matching, across every
+     * object it examines. Java's regex engine backtracks combinatorially across adjacent
+     * unbounded groups, so a request-controlled glob can otherwise stall a request thread:
+     * measured against a long object name, seven `*` groups inside one segment never finish, and
+     * `*` is no safer than `**` despite being segment-bounded.
+     *
+     * <p>The budget is per request rather than per object on purpose. A per-object budget bounds
+     * one match but not the listing: the pattern is evaluated against every candidate before
+     * pagination, so a large bucket multiplies a just-under-budget match back into the same
+     * request-level stall. One counter for the whole listing bounds the total instead.
+     *
+     * <p>It bounds every pattern rather than guessing which shapes are dangerous, which a
+     * wildcard count cannot do once `{a,b}` alternation and `[...]` classes are in play, and it
+     * leaves globs real GCS accepts working: an ordinary pattern spends about 30 reads per
+     * object, so ten thousand objects come to roughly 300,000 against this budget.
+     */
+    private static final int REQUEST_STEP_BUDGET = 5_000_000;
+
+    /** A glob bound to one request, carrying that request's remaining matching budget. */
+    static GlobMatcher matcher(Pattern pattern) {
+        return new GlobMatcher(pattern);
+    }
+
+    static final class GlobMatcher {
+        private final Pattern pattern;
+        private int steps;
+
+        private GlobMatcher(Pattern pattern) {
+            this.pattern = pattern;
+        }
+
+        boolean matches(String name) {
+            if (pattern == null) {
+                return true;
+            }
+            try {
+                return pattern.matcher(new BoundedCharSequence(name)).matches();
+            } catch (StepBudgetExceeded e) {
+                throw GcpException.invalidArgument(
+                        "matchGlob is too complex to evaluate over this bucket; simplify the pattern");
+            }
+        }
+
+        private final class BoundedCharSequence implements CharSequence {
+            private final CharSequence delegate;
+
+            BoundedCharSequence(CharSequence delegate) {
+                this.delegate = delegate;
+            }
+
+            @Override
+            public int length() {
+                return delegate.length();
+            }
+
+            @Override
+            public char charAt(int index) {
+                if (++steps > REQUEST_STEP_BUDGET) {
+                    throw new StepBudgetExceeded();
+                }
+                return delegate.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(int start, int end) {
+                return delegate.subSequence(start, end);
+            }
+
+            @Override
+            public String toString() {
+                return delegate.toString();
+            }
+        }
+    }
+
+    private static final class StepBudgetExceeded extends RuntimeException {
+        StepBudgetExceeded() {
+            super(null, null, false, false);
+        }
+    }
+
+    private static boolean endsWith(StringBuilder out, String token) {
+        int start = out.length() - token.length();
+        return start >= 0 && out.indexOf(token, start) == start;
+    }
+
+    private static void appendLiteral(StringBuilder out, char c) {
+        if ("\\.^$|()+".indexOf(c) >= 0) {
+            out.append('\\');
+        }
+        out.append(c);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsListFilterRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsListFilterRestIntegrationTest.java
@@ -1,0 +1,170 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * objects.list filtering: startOffset/endOffset, matchGlob and includeTrailingDelimiter.
+ */
+@QuarkusTest
+class GcsListFilterRestIntegrationTest {
+
+    private static final String BUCKET = "list-filter-bucket";
+
+    private static boolean seeded;
+
+    // Seeded lazily rather than in @BeforeAll: the RestAssured port is not bound
+    // until the Quarkus test instance starts, so a static @BeforeAll would be
+    // refused a connection.
+    private static void seed() {
+        if (seeded) {
+            return;
+        }
+        seeded = true;
+        given().contentType("application/json").body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project");
+
+        for (String name : new String[] {
+                "a/1.txt", "a/2.txt", "a/b/3.txt", "b/4.txt", "c.txt",
+                "logs/2024-01.json", "logs/2024-02.json", "logs/2024-01.csv", "a/" }) {
+            // queryParam, not a hand-encoded URL: RestAssured encodes what it is given,
+            // so a pre-encoded "%2F" would arrive as a literal "%252F".
+            given().contentType("text/plain").body("x")
+                    .queryParam("uploadType", "media")
+                    .queryParam("name", name)
+                    .when().post("/upload/storage/v1/b/" + BUCKET + "/o");
+        }
+    }
+
+    @Test
+    void startOffsetIsInclusive() {
+        seed();
+        given().queryParam("startOffset", "b/").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", containsInAnyOrder(
+                        "b/4.txt", "c.txt", "logs/2024-01.csv", "logs/2024-01.json", "logs/2024-02.json"));
+    }
+
+    @Test
+    void endOffsetIsExclusive() {
+        seed();
+        given().queryParam("endOffset", "b/").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", containsInAnyOrder("a/", "a/1.txt", "a/2.txt", "a/b/3.txt"));
+    }
+
+    @Test
+    void offsetsCombineIntoAHalfOpenRange() {
+        seed();
+        given().queryParam("startOffset", "b/").queryParam("endOffset", "d").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", contains("b/4.txt", "c.txt"));
+    }
+
+    @Test
+    void matchGlobStarStaysWithinOnePathSegment() {
+        seed();
+        given().queryParam("matchGlob", "logs/*.json").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", contains("logs/2024-01.json", "logs/2024-02.json"));
+    }
+
+    @Test
+    void matchGlobDoubleStarCrossesPathSegments() {
+        seed();
+        given().queryParam("matchGlob", "a/**").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", hasItem("a/b/3.txt"));
+    }
+
+    @Test
+    void matchGlobSupportsBraceAlternation() {
+        seed();
+        given().queryParam("matchGlob", "logs/2024-01.{json,csv}").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", containsInAnyOrder("logs/2024-01.csv", "logs/2024-01.json"));
+    }
+
+    @Test
+    void matchGlobThatMatchesNothingReturnsNoItems() {
+        seed();
+        given().queryParam("matchGlob", "nope/*.zip").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items", org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.nullValue(), empty()));
+    }
+
+    @Test
+    void trailingDelimiterPlaceholderIsRolledUpByDefault() {
+        seed();
+        given().queryParam("delimiter", "/").when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", not(hasItem("a/")))
+                .body("prefixes", hasItem("a/"));
+    }
+
+    @Test
+    void includeTrailingDelimiterAlsoReturnsThePlaceholderAsAnItem() {
+        seed();
+        given().queryParam("delimiter", "/").queryParam("includeTrailingDelimiter", true).when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", hasItem("a/"))
+                .body("prefixes", hasItem("a/"));
+    }
+
+    @Test
+    void repeatedDoubleStarsAreCollapsedRatherThanCompounded() {
+        // "**/**/x" means the same as "**/x"; emitting both groups multiplies the backtracking
+        // the regex engine does on a name that does not match.
+        seed();
+        given().queryParam("matchGlob", "**/**/app.log")
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200);
+    }
+
+    @Test
+    void aRunawayGlobIsRefusedRatherThanStallingTheRequest() {
+        // Request-controlled patterns must not be able to stall a request thread: unbounded,
+        // this shape never finishes matching. The step budget turns it into a 400 in milliseconds.
+        // Its own bucket: the long name below would otherwise show up in the shared fixture's
+        // offset and glob assertions.
+        String bucket = "glob-runaway-bucket";
+        given().contentType("application/json").body(Map.of("name", bucket))
+                .when().post("/storage/v1/b?project=test-project");
+        // The blowup needs a long name to backtrack across, which is what an attacker uploads first.
+        given().contentType("text/plain").body("x")
+                .queryParam("uploadType", "media").queryParam("name", "a".repeat(120) + ".txt")
+                .when().post("/upload/storage/v1/b/" + bucket + "/o")
+                .then().statusCode(200);
+
+        given().queryParam("matchGlob", "*a*a*a*a*a*a*a*a*a*a.log")
+                .when().get("/storage/v1/b/" + bucket + "/o")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void aComplexButHarmlessGlobIsStillAccepted() {
+        // The budget bounds evaluation rather than banning shapes, so patterns real GCS accepts
+        // keep working even when they use several wildcards.
+        seed();
+        given().queryParam("matchGlob", "**/*/*/*/*.log")
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200);
+    }
+
+    @Test
+    void ordinaryGlobsAreStillAccepted() {
+        seed();
+        given().queryParam("matchGlob", "logs/*/2026/*.log")
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

`objects.list` supported only `prefix`, `delimiter` and `startOffset`, so clients that narrow a listing server side got the whole bucket back and filtered locally.

Adds `endOffset`, `matchGlob` and `includeTrailingDelimiter`. The glob compiler keeps `*` inside one path segment and lets `**` cross them, which a naive translation to `.*` collapses: `logs/*.log` must not match `logs/2026/01/app.log` while `logs/**.log` must. `includeTrailingDelimiter` returns the metadata of a directory placeholder in `items[]` as well as rolling it up into `prefixes[]`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Grounded in the `storage/v1` discovery document, which defines the three parameters as:

- `endOffset` — "Filter results to objects whose names are lexicographically before endOffset. If startOffset is also set, the objects listed will have names between startOffset (inclusive) and endOffset (exclusive)."
- `matchGlob` — "Filter results to objects and prefixes that match this glob pattern."
- `includeTrailingDelimiter` — "If true, objects that end in exactly one instance of delimiter will have their metadata included in items in addition to prefixes."

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsListFilterRestIntegrationTest`, plus SDK-level `GcsListFiltersTest` and `test_gcs_list_filters.py`. The `includeTrailingDelimiter` case is driven raw because google-cloud-storage 2.47.0 exposes no `BlobListOption` for it, so the SDK cannot send the parameter; that is noted in the test.
