### PR TITLE
feat(gcs): accept system metadata at upload time and allow zero-byte objects

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsObjectSystemMetadataTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsObjectSystemMetadataTest.java
@@ -1,0 +1,121 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * System metadata set at upload time, and the storage class an object inherits from its bucket.
+ *
+ * <p>The metageneration assertions are the point of the first test: these fields have to land
+ * with the object rather than being patched on afterwards, otherwise every upload reports a
+ * spurious metageneration bump and clients that branch on it see a phantom change.
+ */
+class GcsObjectSystemMetadataTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("system-metadata-bucket");
+    private static final String NEARLINE_BUCKET = TestFixtures.uniqueName("nearline-bucket");
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        storage.create(BucketInfo.newBuilder(NEARLINE_BUCKET)
+                .setStorageClass(StorageClass.NEARLINE)
+                .build());
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void systemMetadataSurvivesTheUploadWithoutAMetagenerationBump() {
+        OffsetDateTime customTime = OffsetDateTime.of(2026, 3, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+        Blob created = storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, "system-metadata.txt"))
+                .setContentType("text/plain")
+                .setContentDisposition("attachment; filename=\"report.txt\"")
+                .setContentLanguage("en")
+                .setCacheControl("public, max-age=3600")
+                .setCustomTimeOffsetDateTime(customTime)
+                .build(), "body".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(created.getContentDisposition()).isEqualTo("attachment; filename=\"report.txt\"");
+        assertThat(created.getContentLanguage()).isEqualTo("en");
+        assertThat(created.getCacheControl()).isEqualTo("public, max-age=3600");
+        assertThat(created.getCustomTimeOffsetDateTime()).isEqualTo(customTime);
+        assertThat(created.getMetageneration()).isEqualTo(1L);
+
+        // Re-read to confirm the fields are persisted rather than echoed from the request.
+        Blob reread = storage.get(BlobId.of(BUCKET, "system-metadata.txt"));
+        assertThat(reread.getContentDisposition()).isEqualTo("attachment; filename=\"report.txt\"");
+        assertThat(reread.getContentLanguage()).isEqualTo("en");
+        assertThat(reread.getCacheControl()).isEqualTo("public, max-age=3600");
+        assertThat(reread.getCustomTimeOffsetDateTime()).isEqualTo(customTime);
+        assertThat(reread.getMetageneration()).isEqualTo(1L);
+    }
+
+    @Test
+    void customTimeCanBeSetByPatchAfterUpload() {
+        BlobId id = BlobId.of(BUCKET, "patched-custom-time.txt");
+        storage.create(BlobInfo.newBuilder(id).build(), new byte[0]);
+
+        OffsetDateTime customTime = OffsetDateTime.of(2026, 4, 2, 8, 30, 0, 0, ZoneOffset.UTC);
+        Blob updated = storage.update(BlobInfo.newBuilder(id)
+                .setCustomTimeOffsetDateTime(customTime)
+                .build());
+
+        assertThat(updated.getCustomTimeOffsetDateTime()).isEqualTo(customTime);
+        assertThat(storage.get(id).getCustomTimeOffsetDateTime()).isEqualTo(customTime);
+    }
+
+    @Test
+    void objectInheritsTheBucketDefaultStorageClass() {
+        Blob inherited = storage.create(
+                BlobInfo.newBuilder(BlobId.of(NEARLINE_BUCKET, "inherited.txt")).build(),
+                new byte[0]);
+        assertThat(inherited.getStorageClass()).isEqualTo(StorageClass.NEARLINE);
+
+        // An explicit storage class on the upload still wins over the bucket default.
+        Blob explicitClass = storage.create(
+                BlobInfo.newBuilder(BlobId.of(NEARLINE_BUCKET, "explicit.txt"))
+                        .setStorageClass(StorageClass.COLDLINE)
+                        .build(),
+                new byte[0]);
+        assertThat(explicitClass.getStorageClass()).isEqualTo(StorageClass.COLDLINE);
+
+        // A bucket left on the default still reports STANDARD.
+        Blob standard = storage.create(
+                BlobInfo.newBuilder(BlobId.of(BUCKET, "standard.txt")).build(), new byte[0]);
+        assertThat(standard.getStorageClass()).isEqualTo(StorageClass.STANDARD);
+    }
+
+    @Test
+    void zeroByteObjectRoundTrips() {
+        // Directory placeholders, Spark _SUCCESS markers and .keep files are all empty objects,
+        // and the Node SDK creates them through a resumable session with no bytes at all.
+        BlobId id = BlobId.of(BUCKET, "empty/_SUCCESS");
+        Blob created = storage.create(BlobInfo.newBuilder(id).build(), new byte[0]);
+
+        assertThat(created.getSize()).isZero();
+        assertThat(storage.readAllBytes(id)).isEmpty();
+        assertThat(storage.get(id).getSize()).isZero();
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_system_metadata.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_system_metadata.py
@@ -1,0 +1,85 @@
+"""System metadata set at upload time, and the storage class inherited from the bucket.
+
+The metageneration assertion is the point of the first test: these fields have to land with the
+object rather than being patched on afterwards, otherwise every upload reports a spurious
+metageneration bump and clients that branch on it see a phantom change.
+"""
+
+import datetime
+
+import pytest
+
+
+def test_system_metadata_survives_upload_without_metageneration_bump(
+    storage_client, unique_name
+):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"sysmeta-{unique_name}"))
+    try:
+        custom_time = datetime.datetime(2026, 3, 1, 12, 0, tzinfo=datetime.timezone.utc)
+        blob = bucket.blob("system-metadata.txt")
+        blob.content_disposition = 'attachment; filename="report.txt"'
+        blob.content_language = "en"
+        blob.cache_control = "public, max-age=3600"
+        blob.custom_time = custom_time
+        blob.upload_from_string(b"body", content_type="text/plain")
+
+        assert blob.content_disposition == 'attachment; filename="report.txt"'
+        assert blob.content_language == "en"
+        assert blob.cache_control == "public, max-age=3600"
+        assert blob.metageneration == 1
+
+        # Re-read to confirm the fields are persisted rather than echoed from the request.
+        reread = bucket.get_blob("system-metadata.txt")
+        assert reread.content_disposition == 'attachment; filename="report.txt"'
+        assert reread.content_language == "en"
+        assert reread.cache_control == "public, max-age=3600"
+        assert reread.custom_time == custom_time
+        assert reread.metageneration == 1
+    finally:
+        bucket.delete(force=True)
+
+
+def test_custom_time_can_be_set_by_patch_after_upload(storage_client, unique_name):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"customtime-{unique_name}"))
+    try:
+        blob = bucket.blob("patched.txt")
+        blob.upload_from_string(b"")
+
+        custom_time = datetime.datetime(2026, 4, 2, 8, 30, tzinfo=datetime.timezone.utc)
+        blob.custom_time = custom_time
+        blob.patch()
+
+        assert bucket.get_blob("patched.txt").custom_time == custom_time
+    finally:
+        bucket.delete(force=True)
+
+
+def test_object_inherits_bucket_default_storage_class(storage_client, unique_name):
+    bucket = storage_client.bucket(f"nearline-{unique_name}")
+    bucket.storage_class = "NEARLINE"
+    bucket = storage_client.create_bucket(bucket)
+    try:
+        inherited = bucket.blob("inherited.txt")
+        inherited.upload_from_string(b"")
+        assert bucket.get_blob("inherited.txt").storage_class == "NEARLINE"
+
+        # An explicit storage class on the upload still wins over the bucket default.
+        explicit = bucket.blob("explicit.txt")
+        explicit.storage_class = "COLDLINE"
+        explicit.upload_from_string(b"")
+        assert bucket.get_blob("explicit.txt").storage_class == "COLDLINE"
+    finally:
+        bucket.delete(force=True)
+
+
+def test_zero_byte_object_round_trips(storage_client, unique_name):
+    # Directory placeholders, Spark _SUCCESS markers and .keep files are all empty objects.
+    bucket = storage_client.create_bucket(storage_client.bucket(f"empty-{unique_name}"))
+    try:
+        blob = bucket.blob("empty/_SUCCESS")
+        blob.upload_from_string(b"")
+
+        assert bucket.get_blob("empty/_SUCCESS").size == 0
+        assert blob.download_as_bytes() == b""
+    finally:
+        bucket.delete(force=True)

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -306,7 +306,10 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - `CopyObject`
 - `MoveObject`
 - `HeadObject`
-- `PatchObject` (update metadata: `contentType`, `contentDisposition`, `contentEncoding`, `contentLanguage`, custom metadata)
+- `PatchObject` (update metadata: `contentType`, `contentDisposition`, `contentEncoding`, `contentLanguage`, `customTime`, custom metadata)
+- System metadata at upload time (`contentEncoding`, `contentDisposition`, `contentLanguage`,
+  `customTime`, `storageClass`) as query parameters or in the JSON metadata part of a
+  multipart/resumable upload
 - `ComposeObject` (concatenate up to 32 source objects)
 - Pre-signed GET/PUT URLs (V4 signature via IAM `SignBlob`)
 - Batch requests (`/batch/storage/v1`)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsGrpcMapper.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsGrpcMapper.java
@@ -148,7 +148,11 @@ final class GcsGrpcMapper {
         meta.setName(value.getName());
         meta.setBucket(bucketId(value.getBucket()));
         meta.setContentType(value.getContentType().isBlank() ? "application/octet-stream" : value.getContentType());
-        meta.setStorageClass(value.getStorageClass().isBlank() ? "STANDARD" : value.getStorageClass());
+        // Left unset when the client omits it, so the object inherits the bucket default the
+        // same way a REST write does; putObject falls back to STANDARD when the bucket has none.
+        if (!value.getStorageClass().isBlank()) {
+            meta.setStorageClass(value.getStorageClass());
+        }
         meta.setContentDisposition(blankToNull(value.getContentDisposition()));
         meta.setContentEncoding(blankToNull(value.getContentEncoding()));
         meta.setContentLanguage(blankToNull(value.getContentLanguage()));

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -340,7 +340,12 @@ public class GcsService {
         if (userMetadata != null && !userMetadata.isEmpty()) {
             meta.setMetadata(new LinkedHashMap<>(userMetadata));
         }
-        meta.setStorageClass("STANDARD");
+        // Objects inherit the bucket's default storage class; an explicit class on the
+        // upload overrides it via the metadata template applied below.
+        meta.setStorageClass(bucketStore.get(bucket)
+                .map(GcsBucket::getStorageClass)
+                .filter(sc -> sc != null && !sc.isBlank())
+                .orElse("STANDARD"));
         applyInitialObjectMetadata(meta, metadataTemplate);
         meta.setTimeCreated(now);
         meta.setUpdated(now);
@@ -386,9 +391,13 @@ public class GcsService {
         target.setContentDisposition(template.getContentDisposition());
         target.setContentEncoding(template.getContentEncoding());
         target.setContentLanguage(template.getContentLanguage());
+        target.setCacheControl(template.getCacheControl());
         target.setTemporaryHold(template.getTemporaryHold());
         if (template.getEventBasedHold() != null) {
             target.setEventBasedHold(template.getEventBasedHold());
+        }
+        if (template.getCustomTime() != null) {
+            target.setCustomTime(template.getCustomTime());
         }
     }
 
@@ -614,6 +623,12 @@ public class GcsService {
         }
         if (patch.containsKey("eventBasedHold")) {
             meta.setEventBasedHold((Boolean) patch.get("eventBasedHold"));
+        }
+        if (patch.containsKey("cacheControl")) {
+            meta.setCacheControl((String) patch.get("cacheControl"));
+        }
+        if (patch.containsKey("customTime")) {
+            meta.setCustomTime((String) patch.get("customTime"));
         }
         meta.setUpdated(nowTimestamp());
         long mg = Long.parseLong(meta.getMetageneration() != null ? meta.getMetageneration() : "1");
@@ -961,15 +976,22 @@ public class GcsService {
     public String startResumableUpload(String bucket, String objectName, String contentType,
             GcsCustomerEncryption customerEncryption, Map<String, String> metadata,
             GcsObjectPreconditions preconditions) {
+        return startResumableUpload(bucket, objectName, contentType, customerEncryption, metadata, null,
+                preconditions);
+    }
+
+    public String startResumableUpload(String bucket, String objectName, String contentType,
+            GcsCustomerEncryption customerEncryption, Map<String, String> metadata,
+            GcsObjectMeta systemMetadata, GcsObjectPreconditions preconditions) {
         synchronized (objectLock(bucket, objectName)) {
             return startResumableUploadLocked(bucket, objectName, contentType, customerEncryption, metadata,
-                    preconditions);
+                    systemMetadata, preconditions);
         }
     }
 
     private String startResumableUploadLocked(String bucket, String objectName, String contentType,
             GcsCustomerEncryption customerEncryption, Map<String, String> metadata,
-            GcsObjectPreconditions preconditions) {
+            GcsObjectMeta systemMetadata, GcsObjectPreconditions preconditions) {
         LOG.debugf("startResumableUpload bucket=%s name=%s contentType=%s", bucket, objectName, contentType);
         if (bucketStore.get(bucket).isEmpty()) {
             LOG.warnf("startResumableUpload failed: bucket not found bucket=%s", bucket);
@@ -977,7 +999,7 @@ public class GcsService {
         }
         String uploadId = UUID.randomUUID().toString();
         resumableUploads.put(uploadId, new ResumableUpload(bucket, objectName, contentType,
-                customerEncryption.metadata(), metadata, preconditions, new byte[0], null));
+                customerEncryption.metadata(), metadata, systemMetadata, preconditions, new byte[0], null));
         LOG.debugf("startResumableUpload uploadId=%s", uploadId);
         return uploadId;
     }
@@ -1019,7 +1041,7 @@ public class GcsService {
             if (range.totalSize() == null || range.end() + 1 < range.totalSize()) {
                 resumableUploads.put(uploadId, new ResumableUpload(
                         upload.bucket(), upload.objectName(), upload.contentType(), upload.customerEncryption(),
-                        upload.metadata(), upload.preconditions(), combined,
+                        upload.metadata(), upload.systemMetadata(), upload.preconditions(), combined,
                         upload.totalSize() != null ? upload.totalSize() : range.totalSize()));
                 return ResumableChunkOutcome.incomplete(combined.length);
             }
@@ -1040,7 +1062,7 @@ public class GcsService {
     private GcsObjectMeta finishResumableUpload(String uploadId, ResumableUpload upload, byte[] data, String baseUrl) {
         GcsObjectMeta meta = putObject(upload.bucket(), upload.objectName(), upload.contentType(), data,
                 GcsCustomerEncryption.fromMetadata(upload.customerEncryption()), upload.metadata(),
-                upload.preconditions(), baseUrl);
+                upload.systemMetadata(), upload.preconditions(), baseUrl);
         completedResumableUploads.put(uploadId,
                 new CompletedResumableUpload(upload.bucket(), upload.objectName(), meta));
         resumableUploads.remove(uploadId);

--- a/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsUploadController.java
@@ -64,12 +64,13 @@ public class GcsUploadController {
         }
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
+        GcsObjectMeta systemMetadata = systemMetadataFromQuery(uriInfo);
         if ("multipart".equals(uploadType)) {
-            return handleMultipart(bucket, nameParam, headers, uriInfo, body, preconditions);
+            return handleMultipart(bucket, nameParam, headers, uriInfo, body, preconditions, systemMetadata);
         } else if ("resumable".equals(uploadType)) {
-            return handleStartResumable(bucket, nameParam, headers, uriInfo, body, preconditions);
+            return handleStartResumable(bucket, nameParam, headers, uriInfo, body, preconditions, systemMetadata);
         } else if ("media".equals(uploadType)) {
-            return handleMedia(bucket, nameParam, headers, uriInfo, body, preconditions);
+            return handleMedia(bucket, nameParam, headers, uriInfo, body, preconditions, systemMetadata);
         }
         throw GcpException.invalidArgument("unsupported uploadType: " + uploadType);
     }
@@ -133,6 +134,59 @@ public class GcsUploadController {
         return Response.status(308);
     }
 
+    // System metadata a client can set at upload time. GCS accepts these both as
+    // query parameters on the upload URL and, for multipart/resumable, as fields
+    // of the JSON metadata part. They are carried as a template rather than
+    // patched afterwards so the object lands with them already set, without the
+    // spurious metageneration bump a follow-up patch would cause.
+    private static final String[] SYSTEM_METADATA_FIELDS = {
+            "contentEncoding", "contentDisposition", "contentLanguage", "cacheControl",
+            "customTime", "storageClass"
+    };
+
+    private static GcsObjectMeta systemMetadataFromQuery(UriInfo uriInfo) {
+        var params = uriInfo.getQueryParameters();
+        GcsObjectMeta meta = null;
+        for (String field : SYSTEM_METADATA_FIELDS) {
+            String value = params.getFirst(field);
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            if (meta == null) {
+                meta = new GcsObjectMeta();
+            }
+            assignSystemMetadata(meta, field, value);
+        }
+        return meta;
+    }
+
+    // Fields in the JSON metadata part take precedence over the query string.
+    private static GcsObjectMeta mergeSystemMetadata(GcsObjectMeta base, Map<?, ?> metadata) {
+        GcsObjectMeta merged = base;
+        for (String field : SYSTEM_METADATA_FIELDS) {
+            if (!(metadata.get(field) instanceof String value) || value.isBlank()) {
+                continue;
+            }
+            if (merged == null) {
+                merged = new GcsObjectMeta();
+            }
+            assignSystemMetadata(merged, field, value);
+        }
+        return merged;
+    }
+
+    private static void assignSystemMetadata(GcsObjectMeta meta, String field, String value) {
+        switch (field) {
+            case "contentEncoding" -> meta.setContentEncoding(value);
+            case "contentDisposition" -> meta.setContentDisposition(value);
+            case "contentLanguage" -> meta.setContentLanguage(value);
+            case "cacheControl" -> meta.setCacheControl(value);
+            case "customTime" -> meta.setCustomTime(value);
+            case "storageClass" -> meta.setStorageClass(value);
+            default -> { /* unreachable: every SYSTEM_METADATA_FIELDS entry is handled above */ }
+        }
+    }
+
     private static GcsContentRange parseContentRange(String header, int bodyLength) {
         if (!header.startsWith("bytes ")) {
             throw GcpException.invalidArgument("invalid Content-Range header: " + header);
@@ -158,7 +212,12 @@ public class GcsUploadController {
         Long totalSize = "*".equals(totalValue) ? null : parseLong(totalValue, header);
         long end;
         if ("*".equals(endValue)) {
-            if (totalSize != null || bodyLength == 0) {
+            // "bytes <start>-*/*" is what a client streaming an unknown length sends: the
+            // chunk it carries is the final one, so the total is what we hold once it is
+            // appended. A zero-length body is the legitimate empty-object case -- the Node
+            // SDK emits exactly this header with content-length 0 for file.save("") -- and
+            // it leaves end one before start.
+            if (totalSize != null) {
                 throw GcpException.invalidArgument("invalid Content-Range header: " + header);
             }
             end = start + bodyLength - 1L;
@@ -166,7 +225,8 @@ public class GcsUploadController {
         } else {
             end = parseLong(endValue, header);
         }
-        if (start < 0 || end < start || bodyLength != end - start + 1) {
+        boolean emptyFinalChunk = bodyLength == 0 && end == start - 1L;
+        if (start < 0 || (end < start && !emptyFinalChunk) || bodyLength != end - start + 1) {
             throw GcpException.invalidArgument("invalid Content-Range header: " + header);
         }
         if (totalSize != null && end >= totalSize) {
@@ -184,7 +244,7 @@ public class GcsUploadController {
     }
 
     private Response handleMultipart(String bucket, String nameParam, HttpHeaders headers, UriInfo uriInfo, byte[] body,
-            GcsObjectPreconditions preconditions) {
+            GcsObjectPreconditions preconditions, GcsObjectMeta systemMetadata) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String[] rawParts = parseMultipartRaw(contentType, new String(body, ISO));
 
@@ -206,14 +266,17 @@ public class GcsUploadController {
         authorizationService.requireObjectWrite(
                 headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, objectName);
         var userMetadata = extractUserMetadata(metadata);
+        // The metadata part wins over the query string when both carry a field.
+        GcsObjectMeta system = mergeSystemMetadata(systemMetadata, metadata);
         byte[] dataBytes = extractPartBody(rawParts[1]).getBytes(ISO);
         GcsObjectMeta meta = service.putObject(bucket, objectName, objectContentType, dataBytes,
-                GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions, requestBaseUrl(headers, uriInfo));
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata, system, preconditions,
+                requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
     }
 
     private Response handleStartResumable(String bucket, String nameParam, HttpHeaders headers, UriInfo uriInfo, byte[] body,
-            GcsObjectPreconditions preconditions) {
+            GcsObjectPreconditions preconditions, GcsObjectMeta systemMetadata) {
         String requestContentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         if (body != null && body.length > 0 && !isJsonContentType(requestContentType)) {
             throw GcpException.invalidArgument("Unsupported content with type: " + mediaType(requestContentType));
@@ -236,6 +299,7 @@ public class GcsUploadController {
                     contentType = bodyContentType;
                 }
                 userMetadata = extractUserMetadata(meta);
+                systemMetadata = mergeSystemMetadata(systemMetadata, meta);
             }
         }
 
@@ -249,7 +313,7 @@ public class GcsUploadController {
         authorizationService.requireObjectWrite(
                 headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, name);
         String uploadId = service.startResumableUpload(bucket, name, contentType,
-                GcsCustomerEncryption.fromHeaders(headers), userMetadata, preconditions);
+                GcsCustomerEncryption.fromHeaders(headers), userMetadata, systemMetadata, preconditions);
         String location = requestBaseUrl(headers, uriInfo) + "/upload/storage/v1/b/" + bucket
                 + "/o?uploadType=resumable&upload_id=" + uploadId;
 
@@ -257,12 +321,13 @@ public class GcsUploadController {
     }
 
     private Response handleMedia(String bucket, String name, HttpHeaders headers, UriInfo uriInfo, byte[] body,
-            GcsObjectPreconditions preconditions) {
+            GcsObjectPreconditions preconditions, GcsObjectMeta systemMetadata) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         authorizationService.requireObjectWrite(
                 headers.getHeaderString(HttpHeaders.AUTHORIZATION), bucket, name);
         GcsObjectMeta meta = service.putObject(bucket, name, contentType, body,
-                GcsCustomerEncryption.fromHeaders(headers), preconditions, requestBaseUrl(headers, uriInfo));
+                GcsCustomerEncryption.fromHeaders(headers), null, systemMetadata, preconditions,
+                requestBaseUrl(headers, uriInfo));
         return Response.ok(meta).build();
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
@@ -29,6 +29,7 @@ public class GcsObjectMeta {
     private String contentDisposition;
     private String contentEncoding;
     private String contentLanguage;
+    private String cacheControl;
     private Map<String, String> metadata;
     private Map<String, String> customerEncryption;
 
@@ -89,6 +90,9 @@ public class GcsObjectMeta {
     public String getContentEncoding() { return contentEncoding; }
     public void setContentEncoding(String contentEncoding) { this.contentEncoding = contentEncoding; }
 
+    public String getCacheControl() { return cacheControl; }
+    public void setCacheControl(String cacheControl) { this.cacheControl = cacheControl; }
+
     public String getContentLanguage() { return contentLanguage; }
     public void setContentLanguage(String contentLanguage) { this.contentLanguage = contentLanguage; }
 
@@ -103,6 +107,10 @@ public class GcsObjectMeta {
     private Boolean temporaryHold;
     private Boolean eventBasedHold;
     private String retentionExpirationTime;
+    // User-settable timestamp. Lifecycle rules key off it so an application can
+    // express "delete 30 days after the record was superseded" rather than
+    // relying on the object's create time.
+    private String customTime;
 
     public String getTimeDeleted() { return timeDeleted; }
     public void setTimeDeleted(String timeDeleted) { this.timeDeleted = timeDeleted; }
@@ -118,4 +126,7 @@ public class GcsObjectMeta {
 
     public String getRetentionExpirationTime() { return retentionExpirationTime; }
     public void setRetentionExpirationTime(String retentionExpirationTime) { this.retentionExpirationTime = retentionExpirationTime; }
+
+    public String getCustomTime() { return customTime; }
+    public void setCustomTime(String customTime) { this.customTime = customTime; }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/ResumableUpload.java
@@ -2,6 +2,10 @@ package io.floci.gcp.services.gcs.model;
 
 import java.util.Map;
 
+// systemMetadata carries the fields a client may set when opening the session
+// (contentEncoding, customTime, ...) so they survive to the finalizing put
+// rather than being dropped once the first chunk arrives.
 public record ResumableUpload(String bucket, String objectName, String contentType,
         Map<String, String> customerEncryption, Map<String, String> metadata,
-        GcsObjectPreconditions preconditions, byte[] data, Long totalSize) {}
+        GcsObjectMeta systemMetadata, GcsObjectPreconditions preconditions,
+        byte[] data, Long totalSize) {}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsSystemMetadataRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsSystemMetadataRestIntegrationTest.java
@@ -1,0 +1,160 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * System metadata a client sets at upload time (contentEncoding, customTime, ...) and
+ * zero-length objects, which the Node SDK writes through a resumable session.
+ */
+@QuarkusTest
+class GcsSystemMetadataRestIntegrationTest {
+
+    private static final String BUCKET = "system-metadata-bucket";
+
+    private static void ensureBucket() {
+        given().contentType("application/json").body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project");
+    }
+
+    @Test
+    void mediaUploadHonorsContentEncodingQueryParameter() {
+        ensureBucket();
+        given().contentType("text/plain").body("compressed-bytes")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=ce-media&contentEncoding=gzip")
+                .then().statusCode(200)
+                .body("contentEncoding", equalTo("gzip"));
+    }
+
+    @Test
+    void mediaUploadHonorsCacheControlQueryParameter() {
+        // cacheControl is in the accepted system-metadata set, so it has to persist rather
+        // than being silently dropped on the way through.
+        ensureBucket();
+        given().contentType("text/plain").body("x")
+                .when().post("/upload/storage/v1/b/" + BUCKET
+                        + "/o?uploadType=media&name=cc-media&cacheControl=max-age=3600")
+                .then().statusCode(200)
+                .body("cacheControl", equalTo("max-age=3600"));
+
+        given().when().get("/storage/v1/b/" + BUCKET + "/o/cc-media")
+                .then().statusCode(200)
+                .body("cacheControl", equalTo("max-age=3600"));
+    }
+
+    @Test
+    void patchSetsCacheControl() {
+        ensureBucket();
+        given().contentType("text/plain").body("x")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=cc-patch")
+                .then().statusCode(200);
+        given().contentType("application/json").body("{\"cacheControl\":\"no-store\"}")
+                .when().patch("/storage/v1/b/" + BUCKET + "/o/cc-patch")
+                .then().statusCode(200)
+                .body("cacheControl", equalTo("no-store"));
+    }
+
+    @Test
+    void mediaUploadHonorsCustomTimeQueryParameter() {
+        ensureBucket();
+        given().contentType("text/plain").body("x")
+                .when().post("/upload/storage/v1/b/" + BUCKET
+                        + "/o?uploadType=media&name=ct-media&customTime=2026-01-15T10:30:00.000Z")
+                .then().statusCode(200)
+                .body("customTime", equalTo("2026-01-15T10:30:00.000Z"));
+    }
+
+    @Test
+    void multipartUploadHonorsContentEncodingInTheMetadataPart() {
+        ensureBucket();
+        var boundary = "sysmeta";
+        var body = "--" + boundary + "\r\n"
+                + "Content-Type: application/json\r\n\r\n"
+                + "{\"name\":\"ce-multipart\",\"contentEncoding\":\"gzip\",\"customTime\":\"2026-01-15T10:30:00.000Z\"}\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Type: text/plain\r\n\r\n"
+                + "compressed-bytes\r\n"
+                + "--" + boundary + "--\r\n";
+
+        given().header("Content-Type", "multipart/related; boundary=" + boundary)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=multipart")
+                .then().statusCode(200)
+                .body("contentEncoding", equalTo("gzip"))
+                .body("customTime", equalTo("2026-01-15T10:30:00.000Z"));
+    }
+
+    @Test
+    void patchSetsCustomTime() {
+        ensureBucket();
+        given().contentType("text/plain").body("x")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=media&name=ct-patch");
+
+        given().contentType("application/json").body(Map.of("customTime", "2026-06-20T08:00:00.000Z"))
+                .when().patch("/storage/v1/b/" + BUCKET + "/o/ct-patch")
+                .then().statusCode(200)
+                .body("customTime", equalTo("2026-06-20T08:00:00.000Z"));
+    }
+
+    @Test
+    void resumableSessionCarriesSystemMetadataToTheFinalizedObject() {
+        ensureBucket();
+        String location = given()
+                .contentType("application/json")
+                .body("{\"name\":\"ce-resumable\",\"contentEncoding\":\"gzip\"}")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        given().header("Content-Range", "bytes 0-4/5").body("hello")
+                .when().put(location)
+                .then().statusCode(200)
+                .body("contentEncoding", equalTo("gzip"));
+    }
+
+    /**
+     * The Node SDK streams every write through a resumable session. With no bytes to size the
+     * range from it sends the open-ended "bytes 0-*&#47;*" with an empty body, which used to be
+     * rejected outright, so file.save("") could never create an object. Empty objects are
+     * common in practice: Spark _SUCCESS markers, .keep files, directory placeholders.
+     */
+    @Test
+    void resumableSessionAcceptsAnOpenEndedRangeWithAnEmptyBody() {
+        ensureBucket();
+        String location = given()
+                .contentType("application/json").body("{\"name\":\"empty-resumable\"}")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        given().header("Content-Range", "bytes 0-*/*").body(new byte[0])
+                .when().put(location)
+                .then().statusCode(200)
+                .body("size", equalTo("0"));
+
+        given().when().get("/storage/v1/b/" + BUCKET + "/o/empty-resumable")
+                .then().statusCode(200)
+                .body("size", equalTo("0"));
+    }
+
+    @Test
+    void openEndedRangeWithAPayloadStillFinalizesAtTheRightSize() {
+        ensureBucket();
+        String location = given()
+                .contentType("application/json").body("{\"name\":\"open-ended\"}")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o?uploadType=resumable")
+                .then().statusCode(200)
+                .extract().header("Location");
+
+        given().header("Content-Range", "bytes 0-*/*").body("hello")
+                .when().put(location)
+                .then().statusCode(200)
+                .body("size", equalTo("5"));
+    }
+}


### PR DESCRIPTION
## Summary

Three gaps in the upload path.

**System metadata** (`contentEncoding`, `contentDisposition`, `contentLanguage`, `customTime`, `storageClass`) was ignored at upload and had to be patched on afterwards. It is now accepted as query parameters or in the JSON metadata part, and survives a resumable session to the finalizing put. It is carried as a **template rather than patched after the fact**, so the object lands with the fields already set and without a spurious metageneration bump that clients branching on metageneration would see as a phantom change.

**Zero-byte objects.** A resumable session now accepts `Content-Range: bytes <start>-*/*` with an empty body. The Node SDK streams every write through a resumable session and, with no bytes to size the range from, sends exactly that header with `content-length: 0`, so `file.save('')` could not create an object at all. The same header with a payload was already accepted. Empty objects are common in practice: Spark `_SUCCESS` markers, `.keep` files, directory placeholders.

**Storage class inheritance.** An object inherits its bucket's default storage class instead of always reporting `STANDARD`; an explicit `storageClass` on the upload still wins, and it does so through the same metadata template, which is why the two belong in one change.

`customTime` is settable at upload and via patch.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Field names and their placement (query parameter vs metadata part) taken from the `storage/v1` discovery document's `objects.insert` and the `Object` schema. The resumable `Content-Range` shape follows the "Performing resumable uploads" documentation, which specifies `bytes <start>-*/*` for a chunk of unknown total size.

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python. The zero-byte case originally surfaced through the Node SDK.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsSystemMetadataRestIntegrationTest`, plus SDK-level `GcsObjectSystemMetadataTest` and `test_gcs_system_metadata.py`. Those assert `metageneration == 1` after upload rather than only that the fields round trip, which is the part that catches a patch-after-the-fact implementation.
