### PR TITLE
feat(gcs): add projects.serviceAccount and the GCS testIamPermissions spelling

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsProjectServiceAccountTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsProjectServiceAccountTest.java
@@ -1,0 +1,48 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.ServiceAccount;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Clients call {@code projects.serviceAccount} before wiring Pub/Sub notifications, to learn
+ * which principal needs publish rights on the topic. It used to 404 even though
+ * notificationConfigs itself worked, which broke that setup path.
+ */
+class GcsProjectServiceAccountTest {
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void projectExposesItsStorageServiceAccount() {
+        ServiceAccount account = storage.getServiceAccount(TestFixtures.projectId());
+
+        assertThat(account).isNotNull();
+        assertThat(account.getEmail())
+                .contains(TestFixtures.projectId())
+                .endsWith("gs-project-accounts.iam.gserviceaccount.com");
+    }
+
+    @Test
+    void serviceAccountIsStableAcrossCalls() {
+        // Callers store this address in IAM bindings, so it must not move between calls.
+        assertThat(storage.getServiceAccount(TestFixtures.projectId()).getEmail())
+                .isEqualTo(storage.getServiceAccount(TestFixtures.projectId()).getEmail());
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_service_account.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_service_account.py
@@ -1,0 +1,21 @@
+"""projects.serviceAccount.
+
+Clients call this before wiring Pub/Sub notifications, to learn which principal needs publish
+rights on the topic. It used to 404 even though notificationConfigs itself worked, which broke
+that setup path.
+"""
+
+
+def test_project_exposes_its_storage_service_account(storage_client, project_id):
+    email = storage_client.get_service_account_email()
+
+    assert project_id in email
+    assert email.endswith("gs-project-accounts.iam.gserviceaccount.com")
+
+
+def test_service_account_is_stable_across_calls(storage_client):
+    # Callers store this address in IAM bindings, so it must not move between calls.
+    assert (
+        storage_client.get_service_account_email()
+        == storage_client.get_service_account_email()
+    )

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -2,9 +2,9 @@
 
 floci-gcp emulates Google Cloud Storage using the real GCP wire protocols:
 
-- **gRPC v2** — bucket and object management plus streaming reads and writes
-- **REST XML** — object operations (upload, download, delete, list objects)
-- **REST JSON** — bucket management (create bucket, list buckets, get bucket metadata)
+- **gRPC v2**, bucket and object management plus streaming reads and writes
+- **REST XML**, object operations (upload, download, delete, list objects)
+- **REST JSON**, bucket management (create bucket, list buckets, get bucket metadata)
 
 ## Configuration
 
@@ -180,13 +180,13 @@ and Bearer tokens are not validated.
 
 ## Multipart Upload
 
-floci-gcp supports multipart (resumable) upload — the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
+floci-gcp supports multipart (resumable) upload, the standard GCS mechanism for large objects. The GCP SDK uses this automatically for objects above a threshold.
 
 ## Resumable Upload Sessions
 
 `POST /upload/storage/v1/b/{bucket}/o?uploadType=resumable` opens a session and returns
 the session URL in the `Location` header. Chunks go to that URL with a `Content-Range`
-header, using either `PUT` or `POST` — the Java, Node and Python SDKs send `PUT`, the Go
+header, using either `PUT` or `POST`, the Java, Node and Python SDKs send `PUT`, the Go
 SDK sends `POST`, and both are handled the same way.
 
 Session behavior matches GCS:
@@ -288,7 +288,9 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - `ListBuckets` (with `pageToken` pagination)
 - `UpdateBucket` / `PatchBucket`
 - `DeleteBucket`
-- `GetBucketIamPolicy` / `SetBucketIamPolicy` / `TestBucketIamPermissions`
+- `GetBucketIamPolicy` / `SetBucketIamPolicy`
+- `TestBucketIamPermissions`, `GET /b/{bucket}/iam/testPermissions?permissions=...` (the GCS
+  spelling); the Cloud IAM style `POST /b/{bucket}/iam:testPermissions` is also accepted
 
 **Bucket ACLs (REST JSON):**
 
@@ -296,6 +298,11 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - `GetBucketAcl` / `UpdateBucketAcl` / `DeleteBucketAcl`
 - `ListDefaultObjectAcl` / `CreateDefaultObjectAcl`
 - `GetDefaultObjectAcl` / `UpdateDefaultObjectAcl` / `DeleteDefaultObjectAcl`
+
+**Project resources (REST JSON):**
+
+- `GetServiceAccount` (`/storage/v1/projects/{project}/serviceAccount`), the principal
+  Cloud Storage publishes as; grant it publish rights before wiring notifications
 
 **Object operations (REST XML + REST JSON):**
 
@@ -312,11 +319,11 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - Batch requests (`/batch/storage/v1`)
 - Customer-supplied encryption keys (CSEK)
 
-Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly — the emulator preserves URI-encoded names exactly as real GCS does.
+Object names containing `/`, spaces, `+`, or percent-encoded sequences round-trip correctly, the emulator preserves URI-encoded names exactly as real GCS does.
 
 **Pub/Sub notifications (REST JSON):**
 
-- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`) — object changes publish to the configured Pub/Sub topic in the local backend
+- `CreateNotification` / `ListNotifications` / `GetNotification` / `DeleteNotification` (`/storage/v1/b/{bucket}/notificationConfigs`), object changes publish to the configured Pub/Sub topic in the local backend
 
 **Object ACLs (REST JSON):**
 
@@ -330,4 +337,4 @@ Object names containing `/`, spaces, `+`, or percent-encoded sequences round-tri
 - `ifSourceGenerationMatch` / `ifSourceGenerationNotMatch` for object moves
 - `ifSourceMetagenerationMatch` / `ifSourceMetagenerationNotMatch` for object moves
 - Returns HTTP 412 on precondition failure
-- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence — concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)
+- Enforced atomically on object mutation paths under object locks, with a monotonic generation sequence, concurrent writers with `ifGenerationMatch=0` race safely (exactly one wins)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketController.java
@@ -196,18 +196,35 @@ public class GcsBucketController {
         return Response.ok(bucketIamResponse(bucket, policy)).build();
     }
 
+    // GCS spells this GET /b/{bucket}/iam/testPermissions?permissions=..., note
+    // the slash and the repeated query parameter. The colon form below is the
+    // Cloud IAM convention and is kept only so existing callers do not break.
+    @GET
+    @Path("/{bucket}/iam/testPermissions")
+    public Response testBucketIamPermissions(@PathParam("bucket") String bucket,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
+            @QueryParam("permissions") List<String> permissions) {
+        return testPermissionsResponse(bucket, authorization, permissions);
+    }
+
     @POST
     @Path("/{bucket}/iam:testPermissions")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response testBucketIamPermissions(@PathParam("bucket") String bucket,
+    public Response testBucketIamPermissionsPost(@PathParam("bucket") String bucket,
 			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             Map<String, Object> body) {
-		authorizationService.rejectDownscopedToken(authorization);
-        service.getBucket(bucket);
         @SuppressWarnings("unchecked")
         List<String> requested = body != null ? (List<String>) body.get("permissions") : List.of();
+        return testPermissionsResponse(bucket, authorization, requested);
+    }
+
+    private Response testPermissionsResponse(String bucket, String authorization, List<String> requested) {
+		authorizationService.rejectDownscopedToken(authorization);
+        service.getBucket(bucket);
         List<String> granted = iamService.testPermissions("buckets/" + bucket, requested != null ? requested : List.of());
-        return Response.ok(Map.of("permissions", granted)).build();
+        return Response.ok(Map.of(
+                "kind", "storage#testIamPermissionsResponse",
+                "permissions", granted)).build();
     }
 
     // ── Bucket ACLs ───────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/gcp/services/gcs/GcsProjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsProjectController.java
@@ -1,0 +1,38 @@
+package io.floci.gcp.services.gcs;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+
+/**
+ * Project-scoped Cloud Storage resources.
+ *
+ * <p>{@code projects.serviceAccount} returns the service account Cloud Storage uses to publish
+ * on a project's behalf. Clients call it before wiring Pub/Sub notifications, to learn which
+ * principal needs publish rights on the topic, {@code storage.getServiceAccount()} in the Node
+ * and Python SDKs, {@code Storage#getServiceAccount} in Java. Without it that setup path fails
+ * with a 404 even though notificationConfigs itself works.
+ */
+@ApplicationScoped
+@Path("/storage/v1/projects/{project}")
+@Produces(MediaType.APPLICATION_JSON)
+public class GcsProjectController {
+
+    @GET
+    @Path("/serviceAccount")
+    public Response getServiceAccount(@PathParam("project") String project) {
+        // Real GCS derives this from an internal project number. The emulator has no such
+        // number, so it mints a stable address from the project id: same project, same
+        // address across restarts, which is what a test asserting on it needs.
+        String email = "service-" + project + "@gs-project-accounts.iam.gserviceaccount.com";
+        return Response.ok(Map.of(
+                "kind", "storage#serviceAccount",
+                "email_address", email)).build();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -152,7 +152,8 @@ public class GcsService {
                 .resourceClasses(GcsBucketController.class, GcsObjectController.class,
                         GcsUploadController.class, GcsDownloadController.class,
                         GcsXmlDownloadController.class, GcsNotificationController.class,
-                        GcsBatchController.class, GcsGrpcController.class)
+                        GcsBatchController.class, GcsGrpcController.class,
+                        GcsProjectController.class)
                 .build());
         if (config.services().gcs().enabled()) {
             GcsGrpcController controller = new GcsGrpcController(this, config, authorizationService);

--- a/src/test/java/io/floci/gcp/services/gcs/GcsProjectControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsProjectControllerTest.java
@@ -1,0 +1,38 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class GcsProjectControllerTest {
+
+    @Test
+    void serviceAccountReturnsAnEmailForTheProject() {
+        given().when().get("/storage/v1/projects/test-project/serviceAccount")
+                .then().statusCode(200)
+                .body("kind", equalTo("storage#serviceAccount"))
+                .body("email_address", containsString("@"));
+    }
+
+    @Test
+    void serviceAccountIsStableForTheSameProject() {
+        String first = given().when().get("/storage/v1/projects/test-project/serviceAccount")
+                .then().statusCode(200).extract().path("email_address");
+        String second = given().when().get("/storage/v1/projects/test-project/serviceAccount")
+                .then().statusCode(200).extract().path("email_address");
+        org.junit.jupiter.api.Assertions.assertEquals(first, second);
+    }
+
+    @Test
+    void differentProjectsGetDifferentServiceAccounts() {
+        String a = given().when().get("/storage/v1/projects/project-a/serviceAccount")
+                .then().extract().path("email_address");
+        String b = given().when().get("/storage/v1/projects/project-b/serviceAccount")
+                .then().extract().path("email_address");
+        org.junit.jupiter.api.Assertions.assertNotEquals(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

Two gaps in the management surface.

`GET /storage/v1/projects/{project}/serviceAccount` used to 404 even though `notificationConfigs` itself worked. Clients call it **before** wiring Pub/Sub notifications, to learn which principal needs publish rights on the topic (`storage.getServiceAccount()` in the Node and Python SDKs, `Storage#getServiceAccount` in Java), so that setup path failed at the first step. Real GCS derives the address from an internal project number; with no such number the emulator mints a stable one from the project id, so it is the same across restarts.

`testIamPermissions` is now also served at `GET /b/{bucket}/iam/testPermissions`, which is how GCS spells it, returning the `storage#testIamPermissionsResponse` kind. The Cloud IAM style `POST .../iam:testPermissions` is kept for existing callers.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Both shapes come from the `storage/v1` discovery document:

- `projects.serviceAccount.get` — path `projects/{projectId}/serviceAccount`, `GET`; the `ServiceAccount` schema has exactly two properties, `email_address` and `kind` (note the snake_case property name, which is what the JSON API actually returns).
- `buckets.testIamPermissions` — `GET b/{bucket}/iam/testPermissions` with a repeated `permissions` query parameter.

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsProjectControllerTest`, plus SDK-level `GcsProjectServiceAccountTest` and `test_gcs_service_account.py`, which go through `Storage#getServiceAccount` and `client.get_service_account_email()` respectively.
