### PR TITLE
feat(gcs): honour conditional read preconditions on objects.get

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsConditionalReadRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsConditionalReadRawTest.java
@@ -1,0 +1,105 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Conditional reads on {@code objects.get}. The two precondition families fail differently:
+ * a {@code *Match} that does not hold is 412, while a {@code *NotMatch} that does not hold is
+ * 304 Not Modified, which is the whole point of sending it, the caller already has the body
+ * and wants to skip the transfer.
+ *
+ * <p>Raw HTTP because the assertion is on the status code itself, and the SDK collapses a 304
+ * into a null or a cached value rather than surfacing it.
+ */
+class GcsConditionalReadRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("conditional-read-bucket");
+    private static final String OBJECT = "conditional.txt";
+    private static final byte[] PAYLOAD = "conditional body".getBytes(StandardCharsets.UTF_8);
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+    private static long generation;
+    private static long metageneration;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        Blob blob = storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, OBJECT)).build(), PAYLOAD);
+        generation = blob.getGeneration();
+        metageneration = blob.getMetageneration();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void notMatchThatHoldsFalseReturns304() throws Exception {
+        assertThat(get("ifGenerationNotMatch=" + generation)).isEqualTo(304);
+        assertThat(get("ifMetagenerationNotMatch=" + metageneration)).isEqualTo(304);
+
+        // Same on the media read, which is where skipping the body actually pays.
+        assertThat(get("alt=media&ifGenerationNotMatch=" + generation)).isEqualTo(304);
+    }
+
+    @Test
+    void matchThatDoesNotHoldReturns412() throws Exception {
+        assertThat(get("ifGenerationMatch=" + (generation + 1))).isEqualTo(412);
+        assertThat(get("ifMetagenerationMatch=" + (metageneration + 1))).isEqualTo(412);
+        assertThat(get("alt=media&ifGenerationMatch=" + (generation + 1))).isEqualTo(412);
+    }
+
+    @Test
+    void preconditionsThatHoldReturnTheObject() throws Exception {
+        assertThat(get("ifGenerationMatch=" + generation)).isEqualTo(200);
+        assertThat(get("ifMetagenerationMatch=" + metageneration)).isEqualTo(200);
+        assertThat(get("ifGenerationNotMatch=" + (generation + 1))).isEqualTo(200);
+        assertThat(get("alt=media&ifGenerationMatch=" + generation)).isEqualTo(200);
+    }
+
+    @Test
+    void the304CarriesTheObjectValidators() throws Exception {
+        // RFC 7232: a 304 generates the header fields a 200 for the same request would have
+        // sent, ETag among them, so a cache-aware client keeps the validators it needs.
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + BUCKET + "/o/" + OBJECT
+                + "?alt=media&ifGenerationNotMatch=" + generation);
+        HttpResponse<Void> response = CLIENT.send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.discarding());
+
+        assertThat(response.statusCode()).isEqualTo(304);
+        assertThat(response.headers().firstValue("ETag")).isPresent();
+        assertThat(response.headers().firstValue("x-goog-generation"))
+                .hasValue(String.valueOf(generation));
+    }
+
+    private static int get(String query) throws Exception {
+        URI uri = URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?" + query);
+        HttpResponse<Void> response = CLIENT.send(
+                HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.discarding());
+        return response.statusCode();
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_conditional_reads.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_conditional_reads.py
@@ -1,0 +1,90 @@
+"""Conditional reads on objects.get.
+
+The two precondition families fail differently: a ``*Match`` that does not hold is 412, while a
+``*NotMatch`` that does not hold is 304 Not Modified, which is the whole point of sending it , 
+the caller already has the body and wants to skip the transfer.
+
+Driven over raw HTTP because the assertion is on the status code itself, and the SDK collapses
+a 304 into a cached value rather than surfacing it.
+"""
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture
+def conditional_object(storage_client, unique_name):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"conditional-{unique_name}"))
+    blob = bucket.blob("conditional.txt")
+    blob.upload_from_string(b"conditional body")
+    yield bucket, blob
+    bucket.delete(force=True)
+
+
+def status(storage_emulator_host, bucket, blob, query):
+    url = (
+        f"{storage_emulator_host}/storage/v1/b/{bucket.name}/o/{blob.name}?{query}"
+    )
+    try:
+        with urllib.request.urlopen(url) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        return error.code
+
+
+def test_not_match_that_holds_false_returns_304(
+    storage_emulator_host, conditional_object
+):
+    bucket, blob = conditional_object
+    assert status(
+        storage_emulator_host, bucket, blob, f"ifGenerationNotMatch={blob.generation}"
+    ) == 304
+    assert status(
+        storage_emulator_host,
+        bucket,
+        blob,
+        f"ifMetagenerationNotMatch={blob.metageneration}",
+    ) == 304
+    # Same on the media read, which is where skipping the body actually pays.
+    assert status(
+        storage_emulator_host,
+        bucket,
+        blob,
+        f"alt=media&ifGenerationNotMatch={blob.generation}",
+    ) == 304
+
+
+def test_match_that_does_not_hold_returns_412(storage_emulator_host, conditional_object):
+    bucket, blob = conditional_object
+    assert status(
+        storage_emulator_host, bucket, blob, f"ifGenerationMatch={blob.generation + 1}"
+    ) == 412
+    assert status(
+        storage_emulator_host,
+        bucket,
+        blob,
+        f"ifMetagenerationMatch={blob.metageneration + 1}",
+    ) == 412
+    assert status(
+        storage_emulator_host,
+        bucket,
+        blob,
+        f"alt=media&ifGenerationMatch={blob.generation + 1}",
+    ) == 412
+
+
+def test_preconditions_that_hold_return_the_object(
+    storage_emulator_host, conditional_object
+):
+    bucket, blob = conditional_object
+    assert status(
+        storage_emulator_host, bucket, blob, f"ifGenerationMatch={blob.generation}"
+    ) == 200
+    assert status(
+        storage_emulator_host, bucket, blob, f"ifGenerationNotMatch={blob.generation + 1}"
+    ) == 200
+    assert status(
+        storage_emulator_host, bucket, blob, f"alt=media&ifGenerationMatch={blob.generation}"
+    ) == 200

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -159,6 +159,10 @@ public class GcsObjectController {
             @PathParam("object") String objectPath,
             @QueryParam("alt") String alt,
             @QueryParam("generation") String generation,
+            @QueryParam("ifGenerationMatch") Long ifGenerationMatch,
+            @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
+            @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
+            @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
 			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @HeaderParam("Range") String rangeHeader) {
@@ -166,12 +170,76 @@ public class GcsObjectController {
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if ("media".equals(alt)) {
             var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
+            if (readPreconditionsFail(download.meta(), ifGenerationMatch, ifGenerationNotMatch,
+                    ifMetagenerationMatch, ifMetagenerationNotMatch)) {
+                return notModified(download.meta());
+            }
             return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
         }
-        if (generation != null) {
-            return Response.ok(service.getObjectMeta(bucket, objectPath, generation)).build();
+        GcsObjectMeta meta = generation != null
+                ? service.getObjectMeta(bucket, objectPath, generation)
+                : service.getObjectMeta(bucket, objectPath);
+        if (readPreconditionsFail(meta, ifGenerationMatch, ifGenerationNotMatch,
+                ifMetagenerationMatch, ifMetagenerationNotMatch)) {
+            return notModified(meta);
         }
-        return Response.ok(service.getObjectMeta(bucket, objectPath)).build();
+        return Response.ok(meta).build();
+    }
+
+    /**
+     * A 304 carries the selected object's validators. RFC 7232 requires a 304 to generate the
+     * header fields that a 200 for the same request would have sent, ETag among them, and the
+     * media path does send ETag and the x-goog generation headers. A bare 304 would leave a
+     * cache-aware client without the validators it needs to revalidate what it already holds.
+     */
+    private static Response notModified(GcsObjectMeta meta) {
+        Response.ResponseBuilder builder = Response.notModified();
+        if (meta.getEtag() != null) {
+            builder.header("ETag", meta.getEtag());
+        }
+        if (meta.getGeneration() != null) {
+            builder.header("x-goog-generation", meta.getGeneration());
+        }
+        if (meta.getMetageneration() != null) {
+            builder.header("x-goog-metageneration", meta.getMetageneration());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Evaluates conditional-read preconditions.
+     *
+     * <p>The two families fail differently, per the documented precondition table: a
+     * {@code *Match} that does not hold is {@code 412 Precondition Failed}, while a
+     * {@code *NotMatch} that does not hold is {@code 304 Not Modified}, the request would have
+     * succeeded, so the point is to skip transferring a body the caller already has. Returns true
+     * when the caller should answer 304; throws for the 412 cases.
+     */
+    private static boolean readPreconditionsFail(GcsObjectMeta meta, Long ifGenerationMatch,
+            Long ifGenerationNotMatch, Long ifMetagenerationMatch, Long ifMetagenerationNotMatch) {
+        long generation = parseOrZero(meta.getGeneration());
+        long metageneration = parseOrZero(meta.getMetageneration());
+
+        if (ifGenerationMatch != null && generation != ifGenerationMatch) {
+            throw GcpException.conditionNotMet(
+                    "ifGenerationMatch: " + generation + " != " + ifGenerationMatch);
+        }
+        if (ifMetagenerationMatch != null && metageneration != ifMetagenerationMatch) {
+            throw GcpException.conditionNotMet(
+                    "ifMetagenerationMatch: " + metageneration + " != " + ifMetagenerationMatch);
+        }
+        if (ifGenerationNotMatch != null && generation == ifGenerationNotMatch) {
+            return true;
+        }
+        return ifMetagenerationNotMatch != null && metageneration == ifMetagenerationNotMatch;
+    }
+
+    private static long parseOrZero(String value) {
+        try {
+            return value == null ? 0L : Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 
     @PATCH


### PR DESCRIPTION
## Summary

`objects.get` accepted no precondition parameters at all, so `ifGenerationNotMatch` and friends were silently ignored and every read returned 200. A client using them to avoid re-downloading an unchanged object re-downloaded it every time, and one using them as a guard got no guard.

The two families fail **differently**: a `*Match` that does not hold is `412 Precondition Failed`, while a `*NotMatch` that does not hold is `304 Not Modified`. The 304 is the whole point of sending it, since the caller already has the body and wants to skip the transfer. Both apply to the metadata read and to `alt=media`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Parameter names verified against the `storage/v1` discovery document, which lists `ifGenerationMatch`, `ifGenerationNotMatch`, `ifMetagenerationMatch` and `ifMetagenerationNotMatch` on `objects.get`. The 412-vs-304 split follows the documented precondition table.

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsConditionalReadRawTest` and `test_gcs_conditional_reads.py`, both driven over raw HTTP: the assertion is on the status code itself, and the SDKs collapse a 304 into a cached value rather than surfacing it. Each covers all three outcomes (304, 412, 200) on both the metadata and media paths.
