### PR TITLE
feat(gcs): serve decompressive transcoding and add XML list and delete

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsTranscodingRawTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsTranscodingRawTest.java
@@ -1,0 +1,112 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Decompressive transcoding: an object stored with {@code contentEncoding: gzip} is served
+ * decompressed to a client that did not ask for gzip, and as stored to one that did.
+ *
+ * <p>Driven over raw HTTP rather than through the SDK because the assertion is about the exact
+ * {@code Accept-Encoding} sent and the exact bytes returned, and an HTTP client that negotiates
+ * compression on the caller's behalf would hide both. {@code java.net.http.HttpClient} adds no
+ * {@code Accept-Encoding} of its own.
+ */
+class GcsTranscodingRawTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("transcoding-bucket");
+    private static final String OBJECT = "compressed.txt";
+    private static final String TEXT = "transcoding payload ".repeat(64);
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+
+    private static Storage storage;
+    private static byte[] gzipped;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+
+        gzipped = gzip(TEXT.getBytes(StandardCharsets.UTF_8));
+        storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, OBJECT))
+                .setContentType("text/plain")
+                .setContentEncoding("gzip")
+                .build(), gzipped);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void clientThatDoesNotAskForGzipGetsTheDecompressedBytes() throws Exception {
+        HttpResponse<byte[]> response = CLIENT.send(
+                HttpRequest.newBuilder(mediaUri()).GET().build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(new String(response.body(), StandardCharsets.UTF_8)).isEqualTo(TEXT);
+        // A transcoded response is no longer gzip on the wire, so it must not claim to be.
+        assertThat(response.headers().firstValue("Content-Encoding")).isEmpty();
+    }
+
+    @Test
+    void clientThatAsksForGzipGetsTheStoredBytes() throws Exception {
+        HttpResponse<byte[]> response = CLIENT.send(
+                HttpRequest.newBuilder(mediaUri())
+                        .header("Accept-Encoding", "gzip")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo(gzipped);
+        assertThat(response.headers().firstValue("Content-Encoding")).hasValue("gzip");
+    }
+
+    @Test
+    void rangeIsIgnoredOnATranscodedRead() throws Exception {
+        // Stored offsets do not correspond to the bytes the caller receives once the object is
+        // decompressed, so real GCS ignores Range rather than serving a slice of the wrong thing.
+        HttpResponse<byte[]> response = CLIENT.send(
+                HttpRequest.newBuilder(mediaUri())
+                        .header("Range", "bytes=0-9")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofByteArray());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(new String(response.body(), StandardCharsets.UTF_8)).isEqualTo(TEXT);
+    }
+
+    private static URI mediaUri() {
+        return URI.create(TestFixtures.endpoint()
+                + "/storage/v1/b/" + BUCKET + "/o/" + OBJECT + "?alt=media");
+    }
+
+    private static byte[] gzip(byte[] raw) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(out)) {
+            gzip.write(raw);
+        }
+        return out.toByteArray();
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_transcoding.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_transcoding.py
@@ -1,0 +1,77 @@
+"""Decompressive transcoding.
+
+An object stored with ``contentEncoding: gzip`` is served decompressed to a client that did not
+ask for gzip, and as stored to one that did. Range is ignored on a transcoded read, because
+stored offsets do not correspond to the bytes the caller receives.
+
+The raw cases use urllib so the exact ``Accept-Encoding`` sent and the exact bytes returned are
+under the test's control; an HTTP client that negotiates compression on the caller's behalf
+would hide both.
+"""
+
+import gzip
+import urllib.request
+
+import pytest
+
+
+TEXT = b"transcoding payload " * 64
+
+
+@pytest.fixture
+def gzipped_object(storage_client, unique_name):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"transcode-{unique_name}"))
+    compressed = gzip.compress(TEXT)
+    blob = bucket.blob("compressed.txt")
+    blob.content_encoding = "gzip"
+    blob.upload_from_string(compressed, content_type="text/plain")
+    yield bucket, blob, compressed
+    bucket.delete(force=True)
+
+
+def media_url(storage_emulator_host, bucket, blob):
+    return f"{storage_emulator_host}/storage/v1/b/{bucket.name}/o/{blob.name}?alt=media"
+
+
+def test_client_that_does_not_ask_for_gzip_gets_decompressed_bytes(
+    storage_emulator_host, gzipped_object
+):
+    bucket, blob, _ = gzipped_object
+    request = urllib.request.Request(media_url(storage_emulator_host, bucket, blob))
+    with urllib.request.urlopen(request) as response:
+        body = response.read()
+        # A transcoded response is no longer gzip on the wire, so it must not claim to be.
+        assert response.headers.get("Content-Encoding") is None
+
+    assert body == TEXT
+
+
+def test_client_that_asks_for_gzip_gets_the_stored_bytes(
+    storage_emulator_host, gzipped_object
+):
+    bucket, blob, compressed = gzipped_object
+    request = urllib.request.Request(
+        media_url(storage_emulator_host, bucket, blob),
+        headers={"Accept-Encoding": "gzip"},
+    )
+    with urllib.request.urlopen(request) as response:
+        body = response.read()
+        assert response.headers.get("Content-Encoding") == "gzip"
+
+    assert body == compressed
+
+
+def test_range_is_ignored_on_a_transcoded_read(storage_emulator_host, gzipped_object):
+    bucket, blob, _ = gzipped_object
+    request = urllib.request.Request(
+        media_url(storage_emulator_host, bucket, blob), headers={"Range": "bytes=0-9"}
+    )
+    with urllib.request.urlopen(request) as response:
+        assert response.status == 200
+        assert response.read() == TEXT
+
+
+def test_sdk_raw_download_returns_the_stored_bytes(gzipped_object):
+    # raw_download=True is how the SDK asks for the object exactly as stored.
+    _, blob, compressed = gzipped_object
+    assert blob.download_as_bytes(raw_download=True) == compressed

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -311,6 +311,9 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - `DeleteObject`
 - `ListObjects` (with `pageToken`, `prefix`, `delimiter` pagination, plus `startOffset`,
   `endOffset`, `matchGlob` and `includeTrailingDelimiter` filtering)
+- Decompressive transcoding (an object stored with `contentEncoding: gzip` is served
+  decompressed to a client that did not send `Accept-Encoding: gzip`, and as stored to one
+  that did; `Range` is ignored on a transcoded read)
 - `CopyObject`
 - `MoveObject`
 - `HeadObject`

--- a/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsDownloadController.java
@@ -32,10 +32,11 @@ public class GcsDownloadController {
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
             @HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
-            @HeaderParam("Range") String rangeHeader) {
+            @HeaderParam("Range") String rangeHeader,
+            @HeaderParam("Accept-Encoding") String acceptEncoding) {
         authorizationService.requireObjectRead(authorization, bucket, objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
-        return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
+        return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader, acceptEncoding);
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsMediaResponses.java
@@ -14,6 +14,30 @@ final class GcsMediaResponses {
     private GcsMediaResponses() {}
 
     static Response mediaResponse(byte[] data, GcsObjectMeta meta, String rangeHeader) {
+        return mediaResponse(data, meta, rangeHeader, null);
+    }
+
+    /**
+     * Builds a media response, applying decompressive transcoding when it applies.
+     *
+     * <p>An object stored with {@code contentEncoding: gzip} is served decompressed to a client
+     * that did not ask for gzip, and as stored to one that did. GCS also ignores {@code Range} on a
+     * transcoded read: the stored byte offsets do not correspond to the bytes the caller receives
+     * and answers with the whole object, which is what we do here.
+     */
+    static Response mediaResponse(byte[] data, GcsObjectMeta meta, String rangeHeader,
+            String acceptEncoding) {
+        if (shouldTranscode(meta, acceptEncoding)) {
+            byte[] decompressed = gunzip(data);
+            if (decompressed != null) {
+                return withMetadataHeaders(Response.ok(decompressed).type(meta.getContentType()), meta)
+                        .header("Content-Length", decompressed.length)
+                        .build();
+            }
+            // Not actually gzip despite the declared encoding: serve the stored bytes rather
+            // than failing a read.
+        }
+
         Response.ResponseBuilder builder;
         if (rangeHeader == null || rangeHeader.isBlank()) {
             builder = Response.ok(data);
@@ -23,7 +47,76 @@ final class GcsMediaResponses {
                     .entity(Arrays.copyOfRange(data, range.start(), range.end() + 1))
                     .header("Content-Range", "bytes " + range.start() + "-" + range.end() + "/" + data.length);
         }
+        if (isGzipStored(meta)) {
+            // Served as stored, so the client must be told to inflate it.
+            builder.header("Content-Encoding", "gzip");
+        }
         return withMetadataHeaders(builder.type(meta.getContentType()), meta).build();
+    }
+
+    private static boolean isGzipStored(GcsObjectMeta meta) {
+        return "gzip".equalsIgnoreCase(meta.getContentEncoding());
+    }
+
+    private static boolean shouldTranscode(GcsObjectMeta meta, String acceptEncoding) {
+        return isGzipStored(meta) && !acceptsGzip(acceptEncoding);
+    }
+
+    // Absent Accept-Encoding means the client made no claim, so it gets the decompressed
+    // bytes; "identity" is an explicit refusal of gzip and behaves the same way.
+    private static boolean acceptsGzip(String acceptEncoding) {
+        if (acceptEncoding == null || acceptEncoding.isBlank()) {
+            return false;
+        }
+        Double gzipQ = null;
+        Double wildcardQ = null;
+        for (String part : acceptEncoding.split(",")) {
+            String token = part.trim().toLowerCase(java.util.Locale.ROOT);
+            int semi = token.indexOf(';');
+            String coding = semi >= 0 ? token.substring(0, semi).trim() : token;
+            String params = semi >= 0 ? token.substring(semi + 1).replace(" ", "") : "";
+            if (coding.equals("gzip")) {
+                gzipQ = qValue(params);
+            } else if (coding.equals("*")) {
+                wildcardQ = qValue(params);
+            }
+        }
+        // A codings entry names gzip specifically, so it decides regardless of the wildcard:
+        // "gzip;q=0, *" is a refusal, not an acceptance (RFC 7231 section 5.3.4).
+        if (gzipQ != null) {
+            return gzipQ > 0;
+        }
+        return wildcardQ != null && wildcardQ > 0;
+    }
+
+    /**
+     * The qvalue of an Accept-Encoding entry, defaulting to 1 when absent. Parsed as a number
+     * rather than matched as text: RFC 7231 writes a qvalue as {@code "0" [ "." 0*3DIGIT ]}, so
+     * {@code q=0.0} and {@code q=0.000} are the same explicit refusal as {@code q=0}, and a
+     * string comparison against "q=0" alone would hand gzip to a client that refused it.
+     */
+    private static double qValue(String params) {
+        for (String param : params.split(";")) {
+            if (param.startsWith("q=")) {
+                try {
+                    return Double.parseDouble(param.substring(2));
+                } catch (NumberFormatException e) {
+                    return 1;
+                }
+            }
+        }
+        return 1;
+    }
+
+    private static byte[] gunzip(byte[] data) {
+        if (data == null || data.length < 2 || (data[0] & 0xff) != 0x1f || (data[1] & 0xff) != 0x8b) {
+            return null;
+        }
+        try (var in = new java.util.zip.GZIPInputStream(new java.io.ByteArrayInputStream(data))) {
+            return in.readAllBytes();
+        } catch (java.io.IOException e) {
+            return null;
+        }
     }
 
     private static Response.ResponseBuilder withMetadataHeaders(Response.ResponseBuilder builder, GcsObjectMeta meta) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -185,7 +185,8 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
 			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
-            @HeaderParam("Range") String rangeHeader) {
+            @HeaderParam("Range") String rangeHeader,
+            @HeaderParam("Accept-Encoding") String acceptEncoding) {
         authorizationService.requireObjectRead(authorization, bucket, objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         if ("media".equals(alt)) {
@@ -194,7 +195,7 @@ public class GcsObjectController {
                     ifMetagenerationMatch, ifMetagenerationNotMatch)) {
                 return notModified(download.meta());
             }
-            return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
+            return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader, acceptEncoding);
         }
         GcsObjectMeta meta = generation != null
                 ? service.getObjectMeta(bucket, objectPath, generation)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsXmlDownloadController.java
@@ -2,6 +2,7 @@ package io.floci.gcp.services.gcs;
 
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.RequestBaseUrl;
+import io.floci.gcp.core.common.XmlBuilder;
 import io.floci.gcp.services.credentials.GcsAuthorizationService;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -13,13 +14,20 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
- * Handles GCS XML API requests: GET/PUT /{bucket}/{object}.
- * Used by Go SDK (STORAGE_EMULATOR_HOST) and for signed URL access.
+ * Handles GCS XML API requests: GET on a bucket (list objects) and GET/PUT/DELETE on an object.
+ * Used by the Go SDK (STORAGE_EMULATOR_HOST), for signed-URL access, and by S3-shaped tooling
+ * that predates the JSON API.
  */
 @ApplicationScoped
 @Path("/{bucket: [a-z0-9._-]+}")
@@ -57,12 +65,13 @@ public class GcsXmlDownloadController {
             @QueryParam("generation") String generation,
             @HeaderParam("x-goog-encryption-key-sha256") String customerEncryptionKeySha256,
 			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
-            @HeaderParam("Range") String rangeHeader) {
+            @HeaderParam("Range") String rangeHeader,
+            @HeaderParam("Accept-Encoding") String acceptEncoding) {
         GcsSignedUrl.checkNotExpired(uriInfo);
         authorizationService.requireObjectRead(authorization, bucket, objectPath);
         GcsCustomerEncryption customerEncryption = GcsCustomerEncryption.fromKeySha256(customerEncryptionKeySha256);
         var download = service.getObjectForDownload(bucket, objectPath, generation, customerEncryption);
-        return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader);
+        return GcsMediaResponses.mediaResponse(download.data(), download.meta(), rangeHeader, acceptEncoding);
     }
 
     @PUT
@@ -83,6 +92,143 @@ public class GcsXmlDownloadController {
         GcsObjectMeta meta = service.putObject(bucket, objectPath, contentType, body != null ? body : new byte[0],
                 GcsCustomerEncryption.fromHeaders(headers), googMetaHeaders(headers), baseUrl);
         return Response.ok(meta).build();
+    }
+
+    /**
+     * XML API DELETE. The JSON API equivalent is {@code DELETE /storage/v1/b/{b}/o/{o}}; a client
+     * speaking the XML API expects a bare 204 here rather than a 405.
+     */
+    @DELETE
+    @Path("/{object: .+}")
+    public Response delete(
+            @PathParam("bucket") String bucket,
+            @PathParam("object") String objectPath,
+            @Context UriInfo uriInfo,
+            @QueryParam("generation") String generation,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+        GcsSignedUrl.checkNotExpired(uriInfo);
+        authorizationService.requireObjectDelete(authorization, bucket, objectPath);
+        if (generation != null && !generation.isBlank()) {
+            service.deleteObjectVersion(bucket, objectPath, generation);
+        } else if (!service.deleteObject(bucket, objectPath)) {
+            throw io.floci.gcp.core.common.GcpException.notFound("Object not found: " + objectPath);
+        }
+        return Response.noContent().build();
+    }
+
+    /**
+     * XML API ListObjects: {@code GET /{bucket}}, answering with {@code ListBucketResult}.
+     *
+     * <p>Emits the v1 shape (Contents/CommonPrefixes/Marker), which is what GCS serves by default
+     * and what S3-compatible clients expect.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_XML)
+    public Response listObjects(
+            @PathParam("bucket") String bucket,
+            @Context UriInfo uriInfo,
+            @QueryParam("prefix") String prefix,
+            @QueryParam("delimiter") String delimiter,
+            @QueryParam("max-keys") Integer maxKeys,
+            @QueryParam("marker") String marker,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+        GcsSignedUrl.checkNotExpired(uriInfo);
+        authorizationService.requireObjectList(authorization, bucket, prefix);
+        service.getBucket(bucket);
+
+        // "The object name after which you want to start listing objects. Objects whose names
+        // are lexicographically greater than the marker are returned in the list of objects."
+        // Without this a client that sees IsTruncated and re-requests gets the same first page
+        // forever, so pagination never terminates.
+        List<GcsObjectMeta> all = service.listObjects(bucket).stream()
+                .filter(o -> prefix == null || prefix.isEmpty() || o.getName().startsWith(prefix))
+                .sorted(Comparator.comparing(GcsObjectMeta::getName))
+                .toList();
+
+        // A page is a single lexicographic run over both objects and rolled-up prefixes, so
+        // max-keys bounds the combined result and NextMarker names whichever entry ended the
+        // page. Limiting only the objects would emit oversized pages and, worse, repeat every
+        // prefix on the next page because the marker would skip past them.
+        String basePrefix = prefix != null ? prefix : "";
+        List<String> entryKeys = new ArrayList<>();
+        Map<String, GcsObjectMeta> objectsByKey = new LinkedHashMap<>();
+        Set<String> seenPrefixes = new LinkedHashSet<>();
+        for (GcsObjectMeta meta : all) {
+            if (delimiter != null && !delimiter.isEmpty()) {
+                String rest = meta.getName().substring(basePrefix.length());
+                int idx = rest.indexOf(delimiter);
+                if (idx >= 0) {
+                    String common = basePrefix + rest.substring(0, idx + delimiter.length());
+                    if (seenPrefixes.add(common)) {
+                        entryKeys.add(common);
+                    }
+                    continue;
+                }
+            }
+            objectsByKey.put(meta.getName(), meta);
+            entryKeys.add(meta.getName());
+        }
+        // The marker is compared against the rolled-up entry key, not the raw object name. A
+        // NextMarker naming a common prefix would otherwise never advance: every object under
+        // "d1/" sorts after "d1/", so they would survive the filter and roll up to "d1/" again,
+        // handing the client the same page forever.
+        if (marker != null && !marker.isEmpty()) {
+            String from = marker;
+            entryKeys.removeIf(key -> key.compareTo(from) <= 0);
+        }
+        entryKeys.sort(Comparator.naturalOrder());
+
+        int limit = maxKeys != null && maxKeys > 0 ? maxKeys : entryKeys.size();
+        boolean truncated = entryKeys.size() > limit;
+        List<String> page = truncated ? entryKeys.subList(0, limit) : entryKeys;
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("ListBucketResult", "http://doc.s3.amazonaws.com/2006-03-01")
+                .elem("Name", bucket)
+                .elem("Prefix", basePrefix)
+                .elem("Marker", marker != null ? marker : "")
+                .elem("MaxKeys", limit);
+        if (delimiter != null && !delimiter.isEmpty()) {
+            xml.elem("Delimiter", delimiter);
+        }
+        xml.elem("IsTruncated", truncated);
+        if (truncated && !page.isEmpty()) {
+            // The key a follow-up request passes back as `marker`.
+            xml.elem("NextMarker", page.get(page.size() - 1));
+        }
+        for (String key : page) {
+            GcsObjectMeta meta = objectsByKey.get(key);
+            if (meta == null) {
+                xml.start("CommonPrefixes").elem("Prefix", key).end("CommonPrefixes");
+                continue;
+            }
+            xml.start("Contents")
+                    .elem("Key", meta.getName())
+                    .elem("Generation", meta.getGeneration())
+                    .elem("MetaGeneration", meta.getMetageneration())
+                    .elem("LastModified", meta.getUpdated())
+                    .elem("ETag", meta.getEtag())
+                    .elem("Size", meta.getSize())
+                    .elem("StorageClass", meta.getStorageClass())
+                    .end("Contents");
+        }
+        xml.end("ListBucketResult");
+        return Response.ok(xml.build(), MediaType.APPLICATION_XML).build();
+    }
+
+    private static void appendTag(StringBuilder xml, String tag, String value) {
+        if (value == null) {
+            return;
+        }
+        xml.append('<').append(tag).append('>').append(escapeXml(value)).append("</").append(tag).append('>');
+    }
+
+    private static String escapeXml(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
     private static Map<String, String> googMetaHeaders(HttpHeaders headers) {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsXmlListRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsXmlListRestIntegrationTest.java
@@ -1,0 +1,137 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * XML API listing: pagination and the gzip refusal that decides transcoding.
+ */
+@QuarkusTest
+class GcsXmlListRestIntegrationTest {
+
+    private static final String BUCKET = "xml-list-bucket";
+
+    private static void seed() {
+        given().contentType("application/json").body("{\"name\":\"" + BUCKET + "\"}")
+                .when().post("/storage/v1/b?project=test-project");
+        for (String name : new String[] {"a.txt", "b.txt", "c.txt"}) {
+            given().contentType("text/plain").body("x")
+                    .queryParam("uploadType", "media").queryParam("name", name)
+                    .when().post("/upload/storage/v1/b/" + BUCKET + "/o");
+        }
+    }
+
+    @Test
+    void markerStartsListingAfterTheGivenKey() {
+        // "Objects whose names are lexicographically greater than the marker are returned"
+        // (https://cloud.google.com/storage/docs/xml-api/get-bucket-list). Without marker
+        // support a client that pages on IsTruncated re-reads the first page forever.
+        seed();
+        given().queryParam("marker", "a.txt")
+                .when().get("/" + BUCKET)
+                .then().statusCode(200)
+                .body(not(containsString("<Key>a.txt</Key>")))
+                .body(containsString("<Key>b.txt</Key>"))
+                .body(containsString("<Key>c.txt</Key>"))
+                .body(containsString("<Marker>a.txt</Marker>"));
+    }
+
+    @Test
+    void truncatedListingCarriesTheNextMarker() {
+        seed();
+        given().queryParam("max-keys", 1)
+                .when().get("/" + BUCKET)
+                .then().statusCode(200)
+                .body(containsString("<IsTruncated>true</IsTruncated>"))
+                .body(containsString("<NextMarker>a.txt</NextMarker>"));
+    }
+
+    @Test
+    void pagingWithTheNextMarkerTerminates() {
+        seed();
+        String second = given().queryParam("max-keys", 1).queryParam("marker", "a.txt")
+                .when().get("/" + BUCKET)
+                .then().statusCode(200)
+                .extract().asString();
+        // The second page must move on rather than repeating the first.
+        org.junit.jupiter.api.Assertions.assertTrue(second.contains("<Key>b.txt</Key>"), second);
+        org.junit.jupiter.api.Assertions.assertFalse(second.contains("<Key>a.txt</Key>"), second);
+    }
+
+    @Test
+    void gzipRefusedWithAZeroQualityIsNotServedAsGzip() {
+        // RFC 7231 writes a qvalue as "0" [ "." 0*3DIGIT ], so q=0.0 is the same refusal as q=0.
+        given().contentType("application/json").body("{\"name\":\"" + BUCKET + "\"}")
+                .when().post("/storage/v1/b?project=test-project");
+        given().contentType("text/plain").body("plain-bytes")
+                .queryParam("uploadType", "media").queryParam("name", "q0.txt")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200);
+
+        given().header("Accept-Encoding", "gzip;q=0.0")
+                .when().get("/storage/v1/b/" + BUCKET + "/o/q0.txt?alt=media")
+                .then().statusCode(200)
+                .header("Content-Encoding", (String) null);
+    }
+
+    @Test
+    void maxKeysBoundsObjectsAndPrefixesTogether() {
+        // A page is one run over both, so a delimiter listing cannot emit unlimited prefixes
+        // alongside a capped set of objects, and the NextMarker has to name whichever entry
+        // ended the page or the next request repeats them.
+        given().contentType("application/json").body("{\"name\":\"" + BUCKET + "\"}")
+                .when().post("/storage/v1/b?project=test-project");
+        for (String name : new String[] {"d1/x.txt", "d2/x.txt", "d3/x.txt"}) {
+            given().contentType("text/plain").body("x")
+                    .queryParam("uploadType", "media").queryParam("name", name)
+                    .when().post("/upload/storage/v1/b/" + BUCKET + "/o");
+        }
+        String first = given().queryParam("delimiter", "/").queryParam("max-keys", 1)
+                .when().get("/" + BUCKET)
+                .then().statusCode(200)
+                .body(containsString("<IsTruncated>true</IsTruncated>"))
+                .extract().asString();
+        org.junit.jupiter.api.Assertions.assertTrue(first.contains("<NextMarker>"), first);
+        // Exactly one entry on the page, not one object plus every prefix.
+        org.junit.jupiter.api.Assertions.assertEquals(1,
+                first.split("<CommonPrefixes>", -1).length - 1 + (first.split("<Contents>", -1).length - 1),
+                first);
+    }
+
+    @Test
+    void explicitGzipRefusalBeatsAWildcard() {
+        // "gzip;q=0, *" refuses gzip: the specific entry decides (RFC 7231 section 5.3.4).
+        given().contentType("application/json").body("{\"name\":\"" + BUCKET + "\"}")
+                .when().post("/storage/v1/b?project=test-project");
+        given().contentType("text/plain").body("plain")
+                .queryParam("uploadType", "media").queryParam("name", "wc.txt")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200);
+        given().header("Accept-Encoding", "gzip;q=0, *")
+                .when().get("/storage/v1/b/" + BUCKET + "/o/wc.txt?alt=media")
+                .then().statusCode(200)
+                .header("Content-Encoding", (String) null);
+    }
+
+    @Test
+    void pagingFromAPrefixMarkerAdvancesPastThatPrefix() {
+        // A NextMarker naming a common prefix has to move the listing past every object under
+        // it; comparing against raw object names would re-roll the same prefix forever.
+        given().contentType("application/json").body("{\"name\":\"" + BUCKET + "\"}")
+                .when().post("/storage/v1/b?project=test-project");
+        for (String name : new String[] {"p1/a.txt", "p1/b.txt", "p2/a.txt"}) {
+            given().contentType("text/plain").body("x")
+                    .queryParam("uploadType", "media").queryParam("name", name)
+                    .when().post("/upload/storage/v1/b/" + BUCKET + "/o");
+        }
+        given().queryParam("delimiter", "/").queryParam("marker", "p1/")
+                .when().get("/" + BUCKET)
+                .then().statusCode(200)
+                .body(not(containsString("<Prefix>p1/</Prefix>")))
+                .body(containsString("<Prefix>p2/</Prefix>"));
+    }
+}


### PR DESCRIPTION
## Summary

> **Stacked on #170.** This PR is based on `feat/gcs-upload-system-metadata`, not `main`. Transcoding cannot trigger unless `contentEncoding` can be set when the object is written, which is that PR. Review only the top commit; the base will collapse once it merges.

Two gaps in the object read path.

**Decompressive transcoding.** An object stored with `contentEncoding: gzip` is now served decompressed to a client that did not ask for gzip, and as stored to one that did. `Range` is ignored on a transcoded read, as in real GCS, because stored offsets do not correspond to the bytes the caller receives, so serving a slice would hand back the wrong window rather than a shorter one. A body that is not actually gzip despite the declared encoding is served as stored rather than failing the read.

**XML API list and delete.** The XML API was object GET/PUT only. It now serves `ListObjects` (GET on the bucket, returning `ListBucketResult` with `Contents` and `CommonPrefixes`) and `DELETE` on an object, which used to answer 405.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Transcoding behaviour follows the Cloud Storage transcoding documentation: an object stored gzip-encoded is decompressed for a client that did not send `Accept-Encoding: gzip`, the response then does not carry `Content-Encoding: gzip`, and `Range` is not honoured on a transcoded read. The XML `ListBucketResult` element and its `Contents`/`CommonPrefixes` children follow the XML API listing format.

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsTranscodingRawTest` and `test_gcs_transcoding.py`, driven over raw HTTP so the exact `Accept-Encoding` sent and the exact bytes returned are under the test's control; an HTTP client that negotiates compression on the caller's behalf would hide both. Cut from `main` alone these fail, which is how the dependency above was found.
