### PR TITLE
feat(gcs): validate bucket names and tighten bucket and compose error shapes

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsBucketNamingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsBucketNamingTest.java
@@ -1,0 +1,92 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Bucket names are usually baked into configuration, so a name the emulator accepts and real
+ * GCS refuses fails at deploy rather than during development. Every name below is rejected by
+ * the documented Cloud Storage naming rules
+ * (https://cloud.google.com/storage/docs/buckets#naming).
+ */
+class GcsBucketNamingTest {
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void invalidBucketNamesAreRejectedWith400() {
+        List<String> invalid = List.of(
+                "ab",                       // shorter than 3 characters
+                "UpperCase",                // must be lowercase
+                "has space",                // no spaces
+                "-leading-hyphen",          // must start with a letter or number
+                "trailing-hyphen-",         // must end with a letter or number
+                "double..dot",              // no consecutive dots
+                "192.168.5.4",              // must not be formatted as an IP address
+                "goog-reserved",            // the 'goog' prefix is reserved
+                "contains-google-name",     // 'google' is reserved
+                "a".repeat(64));            // over 63 characters without dot separation
+
+        for (String name : invalid) {
+            assertThatThrownBy(() -> storage.create(BucketInfo.of(name)))
+                    .describedAs("bucket name %s should be rejected", name)
+                    .isInstanceOf(StorageException.class)
+                    .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(400));
+        }
+    }
+
+    @Test
+    void dotSeparatedNamesMayExceedSixtyThreeCharacters() {
+        // Legal in GCS above 63 characters only when every dot-separated label is at most 63,
+        // with the whole name at most 222.
+        String label = "a".repeat(60);
+        String name = String.join(".", label, label, label);
+        assertThat(name.length()).isGreaterThan(63).isLessThanOrEqualTo(222);
+
+        try {
+            assertThat(storage.create(BucketInfo.of(name)).getName()).isEqualTo(name);
+        } finally {
+            storage.delete(name);
+        }
+    }
+
+    @Test
+    void duplicateBucketReportsConflictReason() {
+        String name = TestFixtures.uniqueName("duplicate-bucket");
+        storage.create(BucketInfo.of(name));
+        try {
+            // GCS documents 'conflict' as the only reason it returns for a 409 here, and
+            // clients branch on it rather than on the status code alone.
+            assertThatThrownBy(() -> storage.create(BucketInfo.of(name)))
+                    .isInstanceOf(StorageException.class)
+                    .satisfies(e -> {
+                        StorageException se = (StorageException) e;
+                        assertThat(se.getCode()).isEqualTo(409);
+                        assertThat(se.getReason()).isEqualTo("conflict");
+                    });
+        } finally {
+            storage.delete(name);
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_bucket_naming.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_bucket_naming.py
@@ -1,0 +1,70 @@
+"""Bucket-name validation and the 409 reason a duplicate reports.
+
+Bucket names are usually baked into configuration, so a name the emulator accepts and real
+GCS refuses fails at deploy rather than during development. Every name below breaks one of the
+documented rules at https://cloud.google.com/storage/docs/buckets#naming.
+"""
+
+import uuid
+
+import pytest
+from google.api_core import exceptions
+
+
+# Names the SDK forwards, so the emulator is the thing that has to reject them.
+SERVER_REJECTED = [
+    "ab",                    # shorter than 3 characters
+    "UpperCase",             # must be lowercase
+    "has space",             # no spaces
+    "double..dot",           # no consecutive dots
+    "192.168.5.4",           # must not be formatted as an IP address
+    "goog-reserved",         # the 'goog' prefix is reserved
+    "contains-google-name",  # 'google' is reserved
+    "a" * 64,                # over 63 characters without dot separation
+]
+
+# google-cloud-storage pre-flights only one rule client side (_helpers._validate_name checks
+# that the first and last characters are alphanumeric), so these never reach the wire. Asserted
+# separately rather than folded in, so the test says which layer does the rejecting.
+CLIENT_REJECTED = [
+    "-leading-hyphen",
+    "trailing-hyphen-",
+]
+
+
+@pytest.mark.parametrize("name", SERVER_REJECTED)
+def test_invalid_bucket_name_is_rejected_by_the_server(storage_client, name):
+    with pytest.raises(exceptions.BadRequest):
+        storage_client.create_bucket(storage_client.bucket(name))
+
+
+@pytest.mark.parametrize("name", CLIENT_REJECTED)
+def test_leading_or_trailing_non_alphanumeric_is_rejected_by_the_sdk(storage_client, name):
+    with pytest.raises(ValueError):
+        storage_client.bucket(name)
+
+
+def test_dot_separated_name_may_exceed_63_characters(storage_client):
+    # Above 63 characters a name is legal only when every dot-separated label is at most 63,
+    # with the whole name at most 222.
+    label = "a" * 60
+    name = ".".join([label, label, label])
+    assert 63 < len(name) <= 222
+
+    bucket = storage_client.create_bucket(storage_client.bucket(name))
+    try:
+        assert bucket.name == name
+    finally:
+        bucket.delete(force=True)
+
+
+def test_duplicate_bucket_reports_conflict(storage_client):
+    name = f"duplicate-{uuid.uuid4().hex[:8]}"
+    bucket = storage_client.create_bucket(storage_client.bucket(name))
+    try:
+        # GCS documents 'conflict' as the only reason it returns for this 409, and clients
+        # branch on the reason rather than on the status code alone.
+        with pytest.raises(exceptions.Conflict):
+            storage_client.create_bucket(storage_client.bucket(name))
+    finally:
+        bucket.delete(force=True)

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -283,7 +283,8 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 
 **Bucket management (REST JSON):**
 
-- `CreateBucket` (with `location`, `storageClass`, `versioning`, `lifecycle`, `cors`, `retentionPolicy`)
+- `CreateBucket` (names validated against the GCS naming rules; a duplicate reports
+  `reason: conflict`) (with `location`, `storageClass`, `versioning`, `lifecycle`, `cors`, `retentionPolicy`)
 - `GetBucket`
 - `ListBuckets` (with `pageToken` pagination)
 - `UpdateBucket` / `PatchBucket`
@@ -318,7 +319,7 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 - System metadata at upload time (`contentEncoding`, `contentDisposition`, `contentLanguage`,
   `customTime`, `storageClass`) as query parameters or in the JSON metadata part of a
   multipart/resumable upload
-- `ComposeObject` (concatenate up to 32 source objects)
+- `ComposeObject` (concatenate 1 to 32 source objects; 0 or more than 32 is a 400)
 - Pre-signed GET/PUT URLs (V4 signature via IAM `SignBlob`)
 - Batch requests (`/batch/storage/v1`), including when the container's published port
   differs from its internal one (`docker run -p 9000:4588`)

--- a/src/main/java/io/floci/gcp/services/gcs/GcsBucketNames.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsBucketNames.java
@@ -1,0 +1,97 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+
+import java.util.Locale;
+
+/**
+ * Bucket-name validation, per the Cloud Storage naming rules.
+ *
+ * <p>Worth enforcing in an emulator rather than waving through: bucket names are usually baked
+ * into configuration, so a name that is accepted locally and rejected by GCS fails at deploy
+ * rather than during development, the most expensive place to find it.
+ *
+ * <p>Only the rules that hold for every bucket are checked. Names between 64 and 222 characters
+ * are legal in GCS only when dot-separated into labels of at most 63, which is handled below.
+ */
+final class GcsBucketNames {
+
+    private static final int MIN_LENGTH = 3;
+    private static final int MAX_LENGTH = 63;
+    private static final int MAX_DOTTED_LENGTH = 222;
+
+    private GcsBucketNames() {
+    }
+
+    static void validate(String name) {
+        if (name == null || name.isEmpty()) {
+            throw invalid("Bucket names must not be empty.");
+        }
+        if (!name.equals(name.toLowerCase(Locale.ROOT))) {
+            throw invalid("Bucket names must be lowercase: " + name);
+        }
+        if (name.length() < MIN_LENGTH) {
+            throw invalid("Bucket names must be at least " + MIN_LENGTH + " characters: " + name);
+        }
+
+        boolean dotted = name.indexOf('.') >= 0;
+        int limit = dotted ? MAX_DOTTED_LENGTH : MAX_LENGTH;
+        if (name.length() > limit) {
+            throw invalid("Bucket names must be at most " + limit + " characters: " + name);
+        }
+
+        if (!isAlphanumeric(name.charAt(0)) || !isAlphanumeric(name.charAt(name.length() - 1))) {
+            throw invalid("Bucket names must start and end with a letter or number: " + name);
+        }
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (!isAlphanumeric(c) && c != '-' && c != '_' && c != '.') {
+                throw invalid("Bucket names may only contain letters, numbers, '-', '_' and '.': " + name);
+            }
+        }
+        if (name.contains("..")) {
+            throw invalid("Bucket names must not contain consecutive dots: " + name);
+        }
+        if (dotted) {
+            for (String label : name.split("\\.", -1)) {
+                if (label.isEmpty() || label.length() > MAX_LENGTH) {
+                    throw invalid("Each dot-separated part must be 1-" + MAX_LENGTH + " characters: " + name);
+                }
+            }
+        }
+        if (looksLikeIpv4(name)) {
+            throw invalid("Bucket names must not be formatted as an IP address: " + name);
+        }
+        // "goog" and anything close to "google" are reserved.
+        String flattened = name.replace("-", "").replace("_", "").replace(".", "");
+        if (flattened.startsWith("goog") || flattened.contains("google")) {
+            throw invalid("Bucket names must not begin with 'goog' or contain 'google': " + name);
+        }
+    }
+
+    private static boolean isAlphanumeric(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+    }
+
+    private static boolean looksLikeIpv4(String name) {
+        String[] parts = name.split("\\.", -1);
+        if (parts.length != 4) {
+            return false;
+        }
+        for (String part : parts) {
+            if (part.isEmpty() || part.length() > 3) {
+                return false;
+            }
+            for (int i = 0; i < part.length(); i++) {
+                if (part.charAt(i) < '0' || part.charAt(i) > '9') {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static GcpException invalid(String message) {
+        return GcpException.invalidArgument(message).withReason("invalid");
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -167,9 +167,15 @@ public class GcsService {
     public GcsBucket createBucket(String name, String projectId, String baseUrl,
             Map<String, Object> body) {
         LOG.debugf("createBucket name=%s project=%s", name, projectId);
+        // Validate before the existence check: a malformed name is a 400 regardless of
+        // whether something with that name happens to exist.
+        GcsBucketNames.validate(name);
         if (bucketStore.get(name).isPresent()) {
             LOG.warnf("createBucket failed: bucket already exists name=%s", name);
-            throw GcpException.alreadyExists("Bucket already exists: " + name);
+            // GCS documents `conflict` as the only 409 reason, and client code branches
+            // on it; the generic ALREADY_EXISTS mapping would emit `alreadyExists`.
+            throw GcpException.alreadyExists(
+                    "You already own this bucket. Please select another name.").withReason("conflict");
         }
         String now = nowTimestamp();
         GcsBucket bucket = new GcsBucket();
@@ -201,7 +207,8 @@ public class GcsService {
                 bucket.setCors((List<Map<String, Object>>) body.get("cors"));
             }
             if (body.containsKey("retentionPolicy")) {
-                bucket.setRetentionPolicy((Map<String, Object>) body.get("retentionPolicy"));
+                bucket.setRetentionPolicy(
+                        withEffectiveTime((Map<String, Object>) body.get("retentionPolicy")));
             }
             if (body.containsKey("defaultEventBasedHold")) {
                 bucket.setDefaultEventBasedHold((Boolean) body.get("defaultEventBasedHold"));
@@ -234,7 +241,8 @@ public class GcsService {
             bucket.setCors((List<Map<String, Object>>) patch.get("cors"));
         }
         if (patch.containsKey("retentionPolicy")) {
-            bucket.setRetentionPolicy((Map<String, Object>) patch.get("retentionPolicy"));
+            bucket.setRetentionPolicy(
+                    withEffectiveTime((Map<String, Object>) patch.get("retentionPolicy")));
         }
         if (patch.containsKey("storageClass")) {
             bucket.setStorageClass((String) patch.get("storageClass"));
@@ -552,6 +560,8 @@ public class GcsService {
         return true;
     }
 
+    private static final int MAX_COMPOSE_SOURCES = 32;
+
     public void deleteObjectVersion(String bucket, String objectName, String generation) {
         deleteObjectVersion(bucket, objectName, generation, GcsObjectPreconditions.NONE);
     }
@@ -660,6 +670,15 @@ public class GcsService {
             List<GcsComposeSource> sources, String contentType, GcsObjectMeta metadataTemplate,
             GcsObjectPreconditions preconditions, String baseUrl) {
         LOG.debugf("composeObject bucket=%s dest=%s sources=%d", bucket, destObject, sources.size());
+        // GCS caps a single compose at 32 sources and requires at least one. Accepting
+        // more here would let a client build a composite locally that production rejects.
+        if (sources.isEmpty()) {
+            throw GcpException.invalidArgument("compose requires at least one source object");
+        }
+        if (sources.size() > MAX_COMPOSE_SOURCES) {
+            throw GcpException.invalidArgument(
+                    "compose accepts at most " + MAX_COMPOSE_SOURCES + " source objects, got " + sources.size());
+        }
         if (bucketStore.get(bucket).isEmpty()) {
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
@@ -1071,6 +1090,19 @@ public class GcsService {
         return meta;
     }
 
+    // GCS stamps effectiveTime when a retention policy is applied, not only when it is
+    // locked. Clients display it, and a lock compares against it.
+    private Map<String, Object> withEffectiveTime(Map<String, Object> retentionPolicy) {
+        if (retentionPolicy == null) {
+            return null;
+        }
+        Map<String, Object> copy = new java.util.LinkedHashMap<>(retentionPolicy);
+        // Server-determined per the storage/v1 discovery document, so a client-supplied
+        // value is replaced rather than preserved.
+        copy.put("effectiveTime", nowTimestamp());
+        return copy;
+    }
+
     private static void validateResumableTotalSize(ResumableUpload upload, Long totalSize) {
         if (upload.totalSize() != null && totalSize != null && !upload.totalSize().equals(totalSize)) {
             throw GcpException.invalidArgument(
@@ -1199,7 +1231,7 @@ public class GcsService {
     }
 
     public GcsBucket lockRetentionPolicy(String bucket, Long ifMetagenerationMatch) {
-        LOG.infof("lockRetentionPolicy bucket=%s", bucket);
+        LOG.debugf("lockRetentionPolicy bucket=%s", bucket);
         GcsBucket b = getBucket(bucket);
         long current = b.getMetageneration() != null ? Long.parseLong(b.getMetageneration()) : 1;
         if (ifMetagenerationMatch != null && current != ifMetagenerationMatch) {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsBucketNamesTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsBucketNamesTest.java
@@ -1,0 +1,72 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Bucket-name rules. Enforced locally because bucket names are usually baked into config, so a
+ * name accepted here and rejected by GCS fails at deploy rather than during development.
+ */
+class GcsBucketNamesTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ab",
+            "Invalid-Bucket",
+            "has space",
+            "_leading-underscore",
+            "-leading-hyphen",
+            "trailing-hyphen-",
+            "trailing-underscore_",
+            "double..dot",
+            "192.168.5.4",
+            "goog-reserved",
+            "my-google-bucket",
+            "contains/slash",
+    })
+    void rejectsInvalidNames(String name) {
+        assertThrows(GcpException.class, () -> GcsBucketNames.validate(name));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "abc",
+            "my-bucket-123",
+            "my.bucket.name",
+            "with_underscore",
+            "1234567890",
+    })
+    void acceptsValidNames(String name) {
+        assertDoesNotThrow(() -> GcsBucketNames.validate(name));
+    }
+
+    @Test
+    void rejectsANameLongerThan63WithoutDots() {
+        assertThrows(GcpException.class, () -> GcsBucketNames.validate("a".repeat(64)));
+    }
+
+    @Test
+    void acceptsADottedNameLongerThan63() {
+        // Dot-separated names may reach 222 characters provided each label is <= 63.
+        String name = String.join(".", "a".repeat(60), "b".repeat(60), "c".repeat(60));
+        assertDoesNotThrow(() -> GcsBucketNames.validate(name));
+    }
+
+    @Test
+    void rejectsADottedNameWithAnOverlongLabel() {
+        assertThrows(GcpException.class,
+                () -> GcsBucketNames.validate("a".repeat(64) + ".suffix"));
+    }
+
+    @Test
+    void reportsInvalidAsTheErrorReason() {
+        GcpException ex = assertThrows(GcpException.class, () -> GcsBucketNames.validate("AB"));
+        assertEquals("invalid", ex.getReason());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsComposeLimitsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsComposeLimitsRestIntegrationTest.java
@@ -1,0 +1,77 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Compose source-count limits. GCS caps a single compose at 32 sources and requires at least one;
+ * accepting more would let a client build a composite locally that production rejects.
+ */
+@QuarkusTest
+class GcsComposeLimitsRestIntegrationTest {
+
+    private static final String BUCKET = "compose-limits-bucket";
+    private static boolean seeded;
+
+    private static void seed() {
+        if (seeded) {
+            return;
+        }
+        seeded = true;
+        given().contentType("application/json").body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project");
+        for (int i = 0; i < 33; i++) {
+            given().contentType("text/plain").body(i + ";")
+                    .queryParam("uploadType", "media").queryParam("name", "part-" + i)
+                    .when().post("/upload/storage/v1/b/" + BUCKET + "/o");
+        }
+    }
+
+    private static Map<String, Object> sources(int count) {
+        List<Map<String, String>> items = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            items.add(Map.of("name", "part-" + i));
+        }
+        return Map.of("sourceObjects", items);
+    }
+
+    @Test
+    void thirtyTwoSourcesIsAccepted() {
+        seed();
+        given().contentType("application/json").body(sources(32))
+                .when().post("/storage/v1/b/" + BUCKET + "/o/composed-32/compose")
+                .then().statusCode(200)
+                .body("componentCount", equalTo(32));
+    }
+
+    @Test
+    void thirtyThreeSourcesIsRejected() {
+        seed();
+        given().contentType("application/json").body(sources(33))
+                .when().post("/storage/v1/b/" + BUCKET + "/o/composed-33/compose")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void zeroSourcesIsRejected() {
+        seed();
+        given().contentType("application/json").body(sources(0))
+                .when().post("/storage/v1/b/" + BUCKET + "/o/composed-0/compose")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void aSingleSourceIsAccepted() {
+        seed();
+        given().contentType("application/json").body(sources(1))
+                .when().post("/storage/v1/b/" + BUCKET + "/o/composed-1/compose")
+                .then().statusCode(200);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -80,8 +80,9 @@ class GcsServiceTest {
 
     @Test
     void listBucketsFiltersByProject() {
-        service.createBucket("b1", "p1", BASE_URL, Map.of());
-        service.createBucket("b2", "p1", BASE_URL, Map.of());
+        // "b1"/"b2" are shorter than the 3-character minimum GCS enforces.
+        service.createBucket("bucket-one", "p1", BASE_URL, Map.of());
+        service.createBucket("bucket-two", "p1", BASE_URL, Map.of());
 
         List<GcsBucket> buckets = service.listBuckets("p1");
         assertEquals(2, buckets.size());


### PR DESCRIPTION
## Summary

Three validation and error-shape gaps that let code pass locally and fail against real GCS.

**Bucket names are validated at create time.** Every invalid name a compatibility suite tried was previously accepted: `ab`, uppercase, spaces, leading and trailing hyphens, `..`, IP-shaped names, the reserved `goog` prefix, and names over 63 characters. Bucket names are usually baked into configuration, so one accepted locally and refused by GCS fails at deploy rather than during development. Dot-separated names may run to 222 characters provided each label is at most 63, which is handled. The new validator immediately caught an existing fixture using the name `b1`, renamed rather than exempted.

**A duplicate bucket reports `reason: conflict`.** GCS documents that as the only 409 reason and clients branch on it; the generic `ALREADY_EXISTS` mapping emitted `alreadyExists`.

**Compose source-count limits.** `ComposeObject` accepted any number of sources, including 33 and zero, while the docs already claimed "up to 32". GCS answers both with 400, so a client could build a composite locally that production refuses.

**`retentionPolicy.effectiveTime`** is stamped when the policy is set, not only when it is locked, since clients display it and a lock compares against it.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Naming rules from the bucket naming requirements documentation (length, character set, lowercase, no consecutive dots, no IP-address form, reserved `goog` prefix and `google` substring, and the 222-character dot-separated form with 63-character labels). The `conflict` reason and the compose source bounds are the documented GCS behaviour; `effectiveTime` is defined on the `Bucket.retentionPolicy` schema in the `storage/v1` discovery document.

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsBucketNamesTest` (21 cases) and `GcsComposeLimitsRestIntegrationTest`, plus SDK-level `GcsBucketNamingTest` and `test_gcs_bucket_naming.py`. The Python suite splits its cases by **rejecting layer**, because google-cloud-storage pre-flights the first/last-character rule client side (`_helpers._validate_name`) and those names never reach the wire; asserting them as server rejections would have been wrong.
