### PR TITLE
feat(gcs): add chunked rewrite, HMAC keys, and soft delete with restore

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsChunkedRewriteTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsChunkedRewriteTest.java
@@ -1,0 +1,90 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.CopyWriter;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code objects.rewrite} is multi-call in real GCS: when {@code maxBytesRewrittenPerCall} is
+ * below the object size the response comes back {@code done:false} with a {@code rewriteToken},
+ * and the client loops until it completes. That is the path GCS takes for large or
+ * class-changing copies, and a single-shot response never exercises it, so the SDK's chunking
+ * loop goes untested against the emulator.
+ */
+class GcsChunkedRewriteTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("chunked-rewrite-bucket");
+    private static final String SOURCE = "large-source.bin";
+    private static final String TARGET = "large-target.bin";
+    // Three chunks' worth at one megabyte per call.
+    private static final byte[] PAYLOAD = new byte[3 * 1024 * 1024];
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.of(BUCKET));
+        for (int i = 0; i < PAYLOAD.length; i++) {
+            PAYLOAD[i] = (byte) (i % 251);
+        }
+        storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, SOURCE)).build(), PAYLOAD);
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void rewriteCompletesOverSeveralCallsAndPublishesOnlyWhenDone() {
+        CopyWriter writer = storage.copy(Storage.CopyRequest.newBuilder()
+                .setSource(BlobId.of(BUCKET, SOURCE))
+                .setTarget(BlobId.of(BUCKET, TARGET))
+                .setMegabytesCopiedPerChunk(1L)
+                .build());
+
+        // The first call is issued by copy() itself and cannot have finished a 3 MiB object.
+        assertThat(writer.isDone()).isFalse();
+        assertThat(writer.getBlobSize()).isEqualTo(PAYLOAD.length);
+        assertThat(writer.getTotalBytesCopied()).isPositive().isLessThan(PAYLOAD.length);
+
+        // A partially rewritten object must not be visible: GCS publishes the destination only
+        // on the completing call.
+        assertThat(storage.get(BlobId.of(BUCKET, TARGET))).isNull();
+
+        int calls = 1;
+        while (!writer.isDone()) {
+            writer.copyChunk();
+            calls++;
+        }
+        assertThat(calls).isGreaterThan(1);
+        assertThat(writer.getTotalBytesCopied()).isEqualTo(PAYLOAD.length);
+
+        Blob target = writer.getResult();
+        assertThat(target.getName()).isEqualTo(TARGET);
+        assertThat(target.getSize()).isEqualTo(PAYLOAD.length);
+        assertThat(storage.readAllBytes(BlobId.of(BUCKET, TARGET))).isEqualTo(PAYLOAD);
+    }
+
+    @Test
+    void rewriteWithoutChunkingStillCompletesInOneCall() {
+        CopyWriter writer = storage.copy(Storage.CopyRequest.newBuilder()
+                .setSource(BlobId.of(BUCKET, SOURCE))
+                .setTarget(BlobId.of(BUCKET, "single-shot-target.bin"))
+                .build());
+
+        assertThat(writer.isDone()).isTrue();
+        assertThat(writer.getResult().getSize()).isEqualTo(PAYLOAD.length);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsChunkedRewriteTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsChunkedRewriteTest.java
@@ -6,6 +6,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -15,9 +16,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * {@code objects.rewrite} is multi-call in real GCS: when {@code maxBytesRewrittenPerCall} is
  * below the object size the response comes back {@code done:false} with a {@code rewriteToken},
- * and the client loops until it completes. That is the path GCS takes for large or
- * class-changing copies, and a single-shot response never exercises it, so the SDK's chunking
- * loop goes untested against the emulator.
+ * and the client loops until it completes. Per the storage/v1 discovery document the limit "only
+ * applies to requests where the source and destination span locations and/or storage classes",
+ * so the chunked case here changes the storage class, and a same-class copy is asserted to
+ * finish in one call whatever chunk size the client asked for.
  */
 class GcsChunkedRewriteTest {
 
@@ -50,7 +52,9 @@ class GcsChunkedRewriteTest {
     void rewriteCompletesOverSeveralCallsAndPublishesOnlyWhenDone() {
         CopyWriter writer = storage.copy(Storage.CopyRequest.newBuilder()
                 .setSource(BlobId.of(BUCKET, SOURCE))
-                .setTarget(BlobId.of(BUCKET, TARGET))
+                .setTarget(BlobInfo.newBuilder(BlobId.of(BUCKET, TARGET))
+                        .setStorageClass(StorageClass.NEARLINE)
+                        .build())
                 .setMegabytesCopiedPerChunk(1L)
                 .build());
 
@@ -74,7 +78,23 @@ class GcsChunkedRewriteTest {
         Blob target = writer.getResult();
         assertThat(target.getName()).isEqualTo(TARGET);
         assertThat(target.getSize()).isEqualTo(PAYLOAD.length);
+        assertThat(target.getStorageClass()).isEqualTo(StorageClass.NEARLINE);
         assertThat(storage.readAllBytes(BlobId.of(BUCKET, TARGET))).isEqualTo(PAYLOAD);
+    }
+
+    @Test
+    void chunkSizeIsIgnoredForASameClassCopyInOneLocation() {
+        // "this only applies to requests where the source and destination span locations and/or
+        // storage classes": real GCS finishes this copy in the first call, and so does the emulator.
+        CopyWriter writer = storage.copy(Storage.CopyRequest.newBuilder()
+                .setSource(BlobId.of(BUCKET, SOURCE))
+                .setTarget(BlobId.of(BUCKET, "same-class-target.bin"))
+                .setMegabytesCopiedPerChunk(1L)
+                .build());
+
+        assertThat(writer.isDone()).isTrue();
+        assertThat(writer.getTotalBytesCopied()).isEqualTo(PAYLOAD.length);
+        assertThat(writer.getResult().getSize()).isEqualTo(PAYLOAD.length);
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsHmacKeyTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsHmacKeyTest.java
@@ -1,0 +1,99 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.HmacKey;
+import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
+import com.google.cloud.storage.HmacKey.HmacKeyState;
+import com.google.cloud.storage.ServiceAccount;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * HMAC keys are the credentials S3-compatible clients present to GCS (boto3, the AWS SDKs,
+ * gsutil in interop mode). The lifecycle matters as much as the payload: a key must be moved to
+ * INACTIVE before it can be deleted, and code that does not handle that 400 gets stuck.
+ */
+class GcsHmacKeyTest {
+
+    private static final String SERVICE_ACCOUNT =
+            "hmac-test@" + TestFixtures.projectId() + ".iam.gserviceaccount.com";
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void keyLifecycleRequiresDeactivationBeforeDeletion() {
+        HmacKey created = storage.createHmacKey(ServiceAccount.of(SERVICE_ACCOUNT));
+
+        // The secret is returned once, on create, and never again.
+        assertThat(created.getSecretKey()).isNotBlank();
+
+        HmacKeyMetadata metadata = created.getMetadata();
+        assertThat(metadata.getState()).isEqualTo(HmacKeyState.ACTIVE);
+        assertThat(metadata.getAccessId()).isNotBlank();
+        assertThat(metadata.getServiceAccount().getEmail()).isEqualTo(SERVICE_ACCOUNT);
+
+        // A get returns the metadata but carries no secret to return.
+        HmacKeyMetadata fetched = storage.getHmacKey(metadata.getAccessId());
+        assertThat(fetched.getAccessId()).isEqualTo(metadata.getAccessId());
+        assertThat(fetched.getState()).isEqualTo(HmacKeyState.ACTIVE);
+
+        assertThat(accessIds()).contains(metadata.getAccessId());
+
+        // Deleting an ACTIVE key is refused, which is the step callers most often miss.
+        assertThatThrownBy(() -> storage.deleteHmacKey(fetched))
+                .isInstanceOf(StorageException.class)
+                .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(400));
+
+        HmacKeyMetadata deactivated = storage.updateHmacKeyState(fetched, HmacKeyState.INACTIVE);
+        assertThat(deactivated.getState()).isEqualTo(HmacKeyState.INACTIVE);
+
+        storage.deleteHmacKey(deactivated);
+
+        assertThat(accessIds()).doesNotContain(metadata.getAccessId());
+        assertThatThrownBy(() -> storage.getHmacKey(metadata.getAccessId()))
+                .isInstanceOf(StorageException.class)
+                .satisfies(e -> assertThat(((StorageException) e).getCode()).isEqualTo(404));
+    }
+
+    @Test
+    void deactivatedKeyCanBeReactivated() {
+        HmacKey created = storage.createHmacKey(ServiceAccount.of(SERVICE_ACCOUNT));
+        HmacKeyMetadata metadata = created.getMetadata();
+        try {
+            HmacKeyMetadata inactive = storage.updateHmacKeyState(metadata, HmacKeyState.INACTIVE);
+            assertThat(inactive.getState()).isEqualTo(HmacKeyState.INACTIVE);
+
+            HmacKeyMetadata active = storage.updateHmacKeyState(inactive, HmacKeyState.ACTIVE);
+            assertThat(active.getState()).isEqualTo(HmacKeyState.ACTIVE);
+        } finally {
+            storage.deleteHmacKey(
+                    storage.updateHmacKeyState(storage.getHmacKey(metadata.getAccessId()),
+                            HmacKeyState.INACTIVE));
+        }
+    }
+
+    private static java.util.List<String> accessIds() {
+        return StreamSupport.stream(storage.listHmacKeys().iterateAll().spliterator(), false)
+                .map(HmacKeyMetadata::getAccessId)
+                .toList();
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSoftDeleteTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsSoftDeleteTest.java
@@ -1,0 +1,91 @@
+package io.floci.gcp.test;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Soft delete has been on by default in real GCS since 2024, so code written against production
+ * may rely on being able to undo a delete. A deleted object leaves the live listing, appears
+ * under {@code softDeleted=true} with soft/hard delete timestamps, and can be restored by
+ * generation through {@code objects.restore}.
+ */
+class GcsSoftDeleteTest {
+
+    private static final String BUCKET = TestFixtures.uniqueName("soft-delete-bucket");
+    private static final byte[] PAYLOAD = "recoverable".getBytes(StandardCharsets.UTF_8);
+
+    private static Storage storage;
+
+    @BeforeAll
+    static void setUp() {
+        storage = TestFixtures.storageClient();
+        storage.create(BucketInfo.newBuilder(BUCKET)
+                .setSoftDeletePolicy(BucketInfo.SoftDeletePolicy.newBuilder()
+                        .setRetentionDuration(Duration.ofDays(7))
+                        .build())
+                .build());
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (storage instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Test
+    void bucketReportsItsSoftDeletePolicy() {
+        BucketInfo.SoftDeletePolicy policy = storage.get(BUCKET).getSoftDeletePolicy();
+        assertThat(policy).isNotNull();
+        assertThat(policy.getRetentionDuration()).isEqualTo(Duration.ofDays(7));
+    }
+
+    @Test
+    void deletedObjectLeavesTheLiveListingAndCanBeRestored() {
+        String name = "restore-me.txt";
+        Blob created = storage.create(BlobInfo.newBuilder(BlobId.of(BUCKET, name)).build(), PAYLOAD);
+        long generation = created.getGeneration();
+
+        assertThat(storage.delete(BlobId.of(BUCKET, name))).isTrue();
+
+        // Gone from the live view.
+        assertThat(storage.get(BlobId.of(BUCKET, name))).isNull();
+        assertThat(liveNames()).doesNotContain(name);
+
+        // Still visible as soft deleted, with the retention window stamped on it.
+        List<Blob> softDeleted = StreamSupport.stream(
+                        storage.list(BUCKET, Storage.BlobListOption.softDeleted(true))
+                                .iterateAll().spliterator(), false)
+                .filter(blob -> blob.getName().equals(name))
+                .toList();
+        assertThat(softDeleted).hasSize(1);
+        assertThat(softDeleted.get(0).getSoftDeleteTime()).isNotNull();
+        assertThat(softDeleted.get(0).getHardDeleteTime()).isNotNull();
+
+        Blob restored = storage.restore(BlobId.of(BUCKET, name, generation));
+        assertThat(restored.getName()).isEqualTo(name);
+
+        // Back in the live view, with its bytes intact.
+        assertThat(liveNames()).contains(name);
+        assertThat(storage.readAllBytes(BlobId.of(BUCKET, name))).isEqualTo(PAYLOAD);
+    }
+
+    private static List<String> liveNames() {
+        return StreamSupport.stream(storage.list(BUCKET).iterateAll().spliterator(), false)
+                .map(Blob::getName)
+                .toList();
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_hmac_keys.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_hmac_keys.py
@@ -1,0 +1,67 @@
+"""HMAC keys: the credentials S3-compatible clients present to GCS.
+
+boto3, the AWS SDKs and gsutil in interop mode all authenticate this way. The lifecycle
+matters as much as the payload: a key must be moved to INACTIVE before it can be deleted, and
+code that does not handle that 400 gets stuck.
+"""
+
+import pytest
+from google.api_core import exceptions
+
+
+@pytest.fixture
+def service_account_email(project_id):
+    return f"hmac-python@{project_id}.iam.gserviceaccount.com"
+
+
+def test_key_lifecycle_requires_deactivation_before_deletion(
+    storage_client, service_account_email
+):
+    metadata, secret = storage_client.create_hmac_key(
+        service_account_email=service_account_email
+    )
+
+    # The secret is returned once, on create, and never again.
+    assert secret
+    assert metadata.state == "ACTIVE"
+    assert metadata.access_id
+    assert metadata.service_account_email == service_account_email
+
+    fetched = storage_client.get_hmac_key_metadata(metadata.access_id)
+    assert fetched.state == "ACTIVE"
+
+    access_ids = [key.access_id for key in storage_client.list_hmac_keys()]
+    assert metadata.access_id in access_ids
+
+    # Deleting an ACTIVE key is refused, which is the step callers most often miss.
+    with pytest.raises(exceptions.BadRequest):
+        fetched.delete()
+
+    fetched.state = "INACTIVE"
+    fetched.update()
+    assert storage_client.get_hmac_key_metadata(metadata.access_id).state == "INACTIVE"
+
+    fetched.delete()
+
+    access_ids = [key.access_id for key in storage_client.list_hmac_keys()]
+    assert metadata.access_id not in access_ids
+    with pytest.raises(exceptions.NotFound):
+        storage_client.get_hmac_key_metadata(metadata.access_id)
+
+
+def test_deactivated_key_can_be_reactivated(storage_client, service_account_email):
+    metadata, _ = storage_client.create_hmac_key(
+        service_account_email=service_account_email
+    )
+    try:
+        metadata.state = "INACTIVE"
+        metadata.update()
+        assert metadata.state == "INACTIVE"
+
+        metadata.state = "ACTIVE"
+        metadata.update()
+        assert storage_client.get_hmac_key_metadata(metadata.access_id).state == "ACTIVE"
+    finally:
+        metadata.state = "INACTIVE"
+        metadata.update()
+        metadata.delete()

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_rewrite.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_rewrite.py
@@ -1,0 +1,88 @@
+"""objects.rewrite, single-shot and chunked.
+
+Real GCS makes rewrite multi-call: when ``maxBytesRewrittenPerCall`` is below the object size
+the response comes back ``done: false`` with a ``rewriteToken`` and the client loops until it
+completes. That is the path GCS takes for large or class-changing copies.
+
+google-cloud-storage 3.x never sends ``maxBytesRewrittenPerCall`` (``Blob.rewrite`` has no
+parameter for it), so the chunked loop is driven over raw HTTP here while the SDK covers the
+single-call path and the token round-trip shape it would consume.
+"""
+
+import json
+import urllib.request
+
+import pytest
+
+
+PAYLOAD = bytes(i % 251 for i in range(3 * 1024 * 1024))
+ONE_MIB = 1024 * 1024
+
+
+@pytest.fixture
+def rewrite_bucket(storage_client, unique_name):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"rewrite-{unique_name}"))
+    bucket.blob("large-source.bin").upload_from_string(PAYLOAD)
+    yield bucket
+    bucket.delete(force=True)
+
+
+def rewrite_call(storage_emulator_host, bucket, source, target, max_bytes, token=None):
+    url = (
+        f"{storage_emulator_host}/storage/v1/b/{bucket.name}/o/{source}"
+        f"/rewriteTo/b/{bucket.name}/o/{target}?maxBytesRewrittenPerCall={max_bytes}"
+    )
+    if token:
+        url += f"&rewriteToken={token}"
+    request = urllib.request.Request(url, data=b"", method="POST")
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read())
+
+
+def test_chunked_rewrite_completes_over_several_calls(
+    storage_emulator_host, rewrite_bucket
+):
+    first = rewrite_call(
+        storage_emulator_host, rewrite_bucket, "large-source.bin", "chunked.bin", ONE_MIB
+    )
+
+    assert first["kind"] == "storage#rewriteResponse"
+    assert first["done"] is False
+    assert first["rewriteToken"]
+    assert int(first["objectSize"]) == len(PAYLOAD)
+    assert 0 < int(first["totalBytesRewritten"]) < len(PAYLOAD)
+    assert "resource" not in first
+
+    # A partially rewritten object must not be visible: GCS publishes the destination only on
+    # the completing call.
+    assert rewrite_bucket.get_blob("chunked.bin") is None
+
+    response = first
+    calls = 1
+    while not response["done"]:
+        response = rewrite_call(
+            storage_emulator_host,
+            rewrite_bucket,
+            "large-source.bin",
+            "chunked.bin",
+            ONE_MIB,
+            token=response["rewriteToken"],
+        )
+        calls += 1
+
+    assert calls > 1
+    assert int(response["totalBytesRewritten"]) == len(PAYLOAD)
+    assert response["resource"]["name"] == "chunked.bin"
+    assert rewrite_bucket.blob("chunked.bin").download_as_bytes() == PAYLOAD
+
+
+def test_sdk_rewrite_completes_in_one_call(rewrite_bucket):
+    source = rewrite_bucket.blob("large-source.bin")
+    target = rewrite_bucket.blob("single-shot.bin")
+
+    token, rewritten, total = target.rewrite(source)
+
+    # No token means done; the SDK's caller loop exits on exactly this.
+    assert token is None
+    assert rewritten == total == len(PAYLOAD)
+    assert rewrite_bucket.blob("single-shot.bin").download_as_bytes() == PAYLOAD

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_rewrite.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_rewrite.py
@@ -2,7 +2,10 @@
 
 Real GCS makes rewrite multi-call: when ``maxBytesRewrittenPerCall`` is below the object size
 the response comes back ``done: false`` with a ``rewriteToken`` and the client loops until it
-completes. That is the path GCS takes for large or class-changing copies.
+completes. Per the storage/v1 discovery document the limit "only applies to requests where the
+source and destination span locations and/or storage classes" and "must be an integral multiple
+of 1 MiB", so the chunked case changes the storage class and a same-class copy is asserted to
+finish in one call.
 
 google-cloud-storage 3.x never sends ``maxBytesRewrittenPerCall`` (``Blob.rewrite`` has no
 parameter for it), so the chunked loop is driven over raw HTTP here while the SDK covers the
@@ -10,6 +13,7 @@ single-call path and the token round-trip shape it would consume.
 """
 
 import json
+import urllib.error
 import urllib.request
 
 import pytest
@@ -27,14 +31,18 @@ def rewrite_bucket(storage_client, unique_name):
     bucket.delete(force=True)
 
 
-def rewrite_call(storage_emulator_host, bucket, source, target, max_bytes, token=None):
+def rewrite_call(
+    storage_emulator_host, bucket, source, target, max_bytes, token=None, storage_class=None
+):
     url = (
         f"{storage_emulator_host}/storage/v1/b/{bucket.name}/o/{source}"
         f"/rewriteTo/b/{bucket.name}/o/{target}?maxBytesRewrittenPerCall={max_bytes}"
     )
     if token:
         url += f"&rewriteToken={token}"
-    request = urllib.request.Request(url, data=b"", method="POST")
+    body = json.dumps({"storageClass": storage_class}).encode() if storage_class else b""
+    headers = {"Content-Type": "application/json"} if storage_class else {}
+    request = urllib.request.Request(url, data=body, method="POST", headers=headers)
     with urllib.request.urlopen(request) as response:
         return json.loads(response.read())
 
@@ -42,8 +50,14 @@ def rewrite_call(storage_emulator_host, bucket, source, target, max_bytes, token
 def test_chunked_rewrite_completes_over_several_calls(
     storage_emulator_host, rewrite_bucket
 ):
+    # The destination changes storage class, so the copy spans classes and the limit applies.
     first = rewrite_call(
-        storage_emulator_host, rewrite_bucket, "large-source.bin", "chunked.bin", ONE_MIB
+        storage_emulator_host,
+        rewrite_bucket,
+        "large-source.bin",
+        "chunked.bin",
+        ONE_MIB,
+        storage_class="NEARLINE",
     )
 
     assert first["kind"] == "storage#rewriteResponse"
@@ -70,10 +84,35 @@ def test_chunked_rewrite_completes_over_several_calls(
         )
         calls += 1
 
-    assert calls > 1
+    assert calls == 3
     assert int(response["totalBytesRewritten"]) == len(PAYLOAD)
     assert response["resource"]["name"] == "chunked.bin"
+    assert response["resource"]["storageClass"] == "NEARLINE"
     assert rewrite_bucket.blob("chunked.bin").download_as_bytes() == PAYLOAD
+
+
+def test_limit_is_ignored_for_a_same_class_copy(storage_emulator_host, rewrite_bucket):
+    # Same bucket, same class, same location: real GCS completes this in one call regardless of
+    # maxBytesRewrittenPerCall, and so does the emulator.
+    response = rewrite_call(
+        storage_emulator_host, rewrite_bucket, "large-source.bin", "same-class.bin", ONE_MIB
+    )
+    assert response["done"] is True
+    assert "rewriteToken" not in response
+    assert int(response["totalBytesRewritten"]) == len(PAYLOAD)
+
+
+def test_limit_must_be_a_multiple_of_one_mib(storage_emulator_host, rewrite_bucket):
+    with pytest.raises(urllib.error.HTTPError) as error:
+        rewrite_call(
+            storage_emulator_host,
+            rewrite_bucket,
+            "large-source.bin",
+            "bad-limit.bin",
+            1024,
+            storage_class="NEARLINE",
+        )
+    assert error.value.code == 400
 
 
 def test_sdk_rewrite_completes_in_one_call(rewrite_bucket):

--- a/compatibility-tests/sdk-test-python/tests/test_gcs_soft_delete.py
+++ b/compatibility-tests/sdk-test-python/tests/test_gcs_soft_delete.py
@@ -1,0 +1,73 @@
+"""Soft delete and restore.
+
+On by default in real GCS since 2024, so code written against production may rely on being able
+to undo a delete. A deleted object leaves the live listing, appears under ``soft_deleted=True``
+with soft/hard delete timestamps, and can be restored by generation.
+"""
+
+import pytest
+
+
+RETENTION_SECONDS = 7 * 24 * 60 * 60
+
+
+@pytest.fixture
+def soft_delete_bucket(storage_client, unique_name):
+    bucket = storage_client.create_bucket(
+        storage_client.bucket(f"soft-delete-{unique_name}")
+    )
+    bucket.soft_delete_policy.retention_duration_seconds = RETENTION_SECONDS
+    bucket.patch()
+    yield bucket
+    bucket.delete(force=True)
+
+
+def test_bucket_reports_its_soft_delete_policy(storage_client, soft_delete_bucket):
+    reloaded = storage_client.get_bucket(soft_delete_bucket.name)
+    assert reloaded.soft_delete_policy.retention_duration_seconds == RETENTION_SECONDS
+
+
+def test_deleted_object_leaves_live_listing_and_can_be_restored(
+    storage_client, soft_delete_bucket
+):
+    payload = b"recoverable"
+    blob = soft_delete_bucket.blob("restore-me.txt")
+    blob.upload_from_string(payload)
+    generation = blob.generation
+
+    blob.delete()
+
+    # Gone from the live view.
+    assert soft_delete_bucket.get_blob("restore-me.txt") is None
+    live = [b.name for b in storage_client.list_blobs(soft_delete_bucket)]
+    assert "restore-me.txt" not in live
+
+    # Still visible as soft deleted, with the retention window stamped on it.
+    soft_deleted = [
+        b
+        for b in storage_client.list_blobs(soft_delete_bucket, soft_deleted=True)
+        if b.name == "restore-me.txt"
+    ]
+    assert len(soft_deleted) == 1
+    assert soft_deleted[0].soft_delete_time is not None
+    assert soft_deleted[0].hard_delete_time is not None
+
+    restored = soft_delete_bucket.restore_blob("restore-me.txt", generation=generation)
+    assert restored.name == "restore-me.txt"
+
+    # Back in the live view, with its bytes intact.
+    live = [b.name for b in storage_client.list_blobs(soft_delete_bucket)]
+    assert "restore-me.txt" in live
+    assert soft_delete_bucket.blob("restore-me.txt").download_as_bytes() == payload
+
+
+def test_delete_is_permanent_without_a_soft_delete_policy(storage_client, unique_name):
+    bucket = storage_client.create_bucket(storage_client.bucket(f"hard-{unique_name}"))
+    try:
+        blob = bucket.blob("gone.txt")
+        blob.upload_from_string(b"x")
+        blob.delete()
+
+        assert list(storage_client.list_blobs(bucket, soft_deleted=True)) == []
+    finally:
+        bucket.delete(force=True)

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -306,6 +306,9 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
 
 - `GetServiceAccount` (`/storage/v1/projects/{project}/serviceAccount`), the principal
   Cloud Storage publishes as; grant it publish rights before wiring notifications
+- `hmacKeys` create/list/get/update/delete (`/storage/v1/projects/{project}/hmacKeys`), the
+  credentials S3-compatible clients present to GCS; the secret is returned once on create,
+  and a key must be INACTIVE before it can be deleted
 
 **Object operations (REST XML + REST JSON):**
 
@@ -325,6 +328,9 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
   `customTime`, `storageClass`) as query parameters or in the JSON metadata part of a
   multipart/resumable upload
 - `ComposeObject` (concatenate 1 to 32 source objects; 0 or more than 32 is a 400)
+- `RewriteObject` (multi-call: `maxBytesRewrittenPerCall` below the object size returns
+  `done: false` with a `rewriteToken` and the client loops until it completes)
+- Soft delete (`softDeletePolicy` on the bucket, `?softDeleted=true` listing, `objects.restore`)
 - Pre-signed GET/PUT URLs (V4 signature via IAM `SignBlob`)
 - Batch requests (`/batch/storage/v1`), including when the container's published port
   differs from its internal one (`docker run -p 9000:4588`)

--- a/docs/services/gcs.md
+++ b/docs/services/gcs.md
@@ -328,8 +328,12 @@ handles, or redirection. Unsupported RPCs return gRPC `UNIMPLEMENTED`.
   `customTime`, `storageClass`) as query parameters or in the JSON metadata part of a
   multipart/resumable upload
 - `ComposeObject` (concatenate 1 to 32 source objects; 0 or more than 32 is a 400)
-- `RewriteObject` (multi-call: `maxBytesRewrittenPerCall` below the object size returns
-  `done: false` with a `rewriteToken` and the client loops until it completes)
+- `RewriteObject` (multi-call when the source and destination span storage classes or bucket
+  locations: a `maxBytesRewrittenPerCall`, which must be a multiple of 1 MiB, below the object
+  size returns `done: false` with a `rewriteToken` and the client loops until it completes; a
+  same-class, same-location copy finishes in one call whatever limit is sent, as in GCS)
+- `hmacKeys` are stored through the emulator's storage backend, so they survive restarts in
+  persistent mode and are cleared by the reset endpoint
 - Soft delete (`softDeletePolicy` on the bucket, `?softDeleted=true` listing, `objects.restore`)
 - Pre-signed GET/PUT URLs (V4 signature via IAM `SignBlob`)
 - Batch requests (`/batch/storage/v1`), including when the container's published port

--- a/src/main/java/io/floci/gcp/services/gcs/GcsHmacKeyController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsHmacKeyController.java
@@ -1,0 +1,157 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.services.gcs.model.GcsHmacKey;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cloud Storage HMAC keys.
+ *
+ * <p>These are the credentials S3-compatible clients use against GCS, boto3, the AWS SDKs, and
+ * {@code gsutil} in interop mode. Without them the XML interop path cannot be exercised locally at
+ * all.
+ *
+ * <p>The keys are not used to sign anything here: as with the rest of the emulator's credential
+ * handling, signatures are never verified. What matters for a client is the resource lifecycle,
+ * including the rule that a key must be moved to {@code INACTIVE} before it can be deleted , 
+ * deleting an {@code ACTIVE} key is a 400, and code that does not handle that gets stuck.
+ */
+@ApplicationScoped
+@Path("/storage/v1/projects/{project}/hmacKeys")
+@Produces(MediaType.APPLICATION_JSON)
+public class GcsHmacKeyController {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final Map<String, GcsHmacKey> keys = new ConcurrentHashMap<>();
+    private final Map<String, String> secrets = new ConcurrentHashMap<>();
+
+    @POST
+    public Response create(@PathParam("project") String project,
+            @QueryParam("serviceAccountEmail") String serviceAccountEmail) {
+        if (serviceAccountEmail == null || serviceAccountEmail.isBlank()) {
+            throw GcpException.invalidArgument("serviceAccountEmail is required");
+        }
+        String accessId = randomAccessId();
+        GcsHmacKey key = new GcsHmacKey();
+        key.setId(project + "/" + accessId);
+        key.setAccessId(accessId);
+        key.setProjectId(project);
+        key.setServiceAccountEmail(serviceAccountEmail);
+        key.setState("ACTIVE");
+        key.setTimeCreated(now());
+        key.setUpdated(now());
+        key.setEtag("etag-" + accessId);
+        keys.put(accessId, key);
+
+        // Returned once and never again, as in real GCS.
+        byte[] raw = new byte[28];
+        RANDOM.nextBytes(raw);
+        String secret = Base64.getEncoder().encodeToString(raw);
+        secrets.put(accessId, secret);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "storage#hmacKey");
+        response.put("metadata", key);
+        response.put("secret", secret);
+        return Response.ok(response).build();
+    }
+
+    @GET
+    public Response list(@PathParam("project") String project,
+            @QueryParam("serviceAccountEmail") String serviceAccountEmail,
+            @QueryParam("showDeletedKeys") @DefaultValue("false") boolean showDeletedKeys) {
+        List<GcsHmacKey> items = new ArrayList<>();
+        for (GcsHmacKey key : keys.values()) {
+            if (!key.getProjectId().equals(project)) {
+                continue;
+            }
+            if (serviceAccountEmail != null && !serviceAccountEmail.isBlank()
+                    && !serviceAccountEmail.equals(key.getServiceAccountEmail())) {
+                continue;
+            }
+            if (!showDeletedKeys && "DELETED".equals(key.getState())) {
+                continue;
+            }
+            items.add(key);
+        }
+        items.sort((a, b) -> a.getAccessId().compareTo(b.getAccessId()));
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("kind", "storage#hmacKeysMetadata");
+        response.put("items", items);
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/{accessId}")
+    public Response get(@PathParam("project") String project, @PathParam("accessId") String accessId) {
+        return Response.ok(require(project, accessId)).build();
+    }
+
+    @PUT
+    @Path("/{accessId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("project") String project, @PathParam("accessId") String accessId,
+            Map<String, Object> body) {
+        GcsHmacKey key = require(project, accessId);
+        Object state = body != null ? body.get("state") : null;
+        if (!(state instanceof String requested)) {
+            throw GcpException.invalidArgument("state is required");
+        }
+        if (!requested.equals("ACTIVE") && !requested.equals("INACTIVE")) {
+            throw GcpException.invalidArgument("state must be ACTIVE or INACTIVE, got: " + requested);
+        }
+        key.setState(requested);
+        key.setUpdated(now());
+        return Response.ok(key).build();
+    }
+
+    @DELETE
+    @Path("/{accessId}")
+    public Response delete(@PathParam("project") String project, @PathParam("accessId") String accessId) {
+        GcsHmacKey key = require(project, accessId);
+        if ("ACTIVE".equals(key.getState())) {
+            throw GcpException.invalidArgument(
+                    "This key must be in the INACTIVE state before it can be deleted.");
+        }
+        keys.remove(accessId);
+        secrets.remove(accessId);
+        return Response.noContent().build();
+    }
+
+    private GcsHmacKey require(String project, String accessId) {
+        GcsHmacKey key = keys.get(accessId);
+        if (key == null || !key.getProjectId().equals(project)) {
+            throw GcpException.notFound("HMAC key not found: " + accessId);
+        }
+        return key;
+    }
+
+    // GCS access ids look like a GOOG-prefixed uppercase alphanumeric string.
+    private static String randomAccessId() {
+        final String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        StringBuilder sb = new StringBuilder("GOOG1E");
+        for (int i = 0; i < 55; i++) {
+            sb.append(alphabet.charAt(RANDOM.nextInt(alphabet.length())));
+        }
+        return sb.toString();
+    }
+
+    private static String now() {
+        return Instant.now().truncatedTo(ChronoUnit.MILLIS).toString();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsHmacKeyController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsHmacKeyController.java
@@ -1,72 +1,50 @@
 package io.floci.gcp.services.gcs;
 
-import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.services.gcs.model.GcsHmacKey;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.*;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.security.SecureRandom;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Cloud Storage HMAC keys.
- *
- * <p>These are the credentials S3-compatible clients use against GCS, boto3, the AWS SDKs, and
- * {@code gsutil} in interop mode. Without them the XML interop path cannot be exercised locally at
- * all.
- *
- * <p>The keys are not used to sign anything here: as with the rest of the emulator's credential
- * handling, signatures are never verified. What matters for a client is the resource lifecycle,
- * including the rule that a key must be moved to {@code INACTIVE} before it can be deleted , 
- * deleting an {@code ACTIVE} key is a 400, and code that does not handle that gets stuck.
+ * REST JSON surface for Cloud Storage HMAC keys, {@code /storage/v1/projects/{project}/hmacKeys}.
+ * Shapes follow the storage/v1 discovery document; the lifecycle rules live in
+ * {@link GcsHmacKeyService}.
  */
 @ApplicationScoped
 @Path("/storage/v1/projects/{project}/hmacKeys")
 @Produces(MediaType.APPLICATION_JSON)
 public class GcsHmacKeyController {
 
-    private static final SecureRandom RANDOM = new SecureRandom();
+    private final GcsHmacKeyService service;
 
-    private final Map<String, GcsHmacKey> keys = new ConcurrentHashMap<>();
-    private final Map<String, String> secrets = new ConcurrentHashMap<>();
+    @Inject
+    public GcsHmacKeyController(GcsHmacKeyService service) {
+        this.service = service;
+    }
 
     @POST
     public Response create(@PathParam("project") String project,
             @QueryParam("serviceAccountEmail") String serviceAccountEmail) {
-        if (serviceAccountEmail == null || serviceAccountEmail.isBlank()) {
-            throw GcpException.invalidArgument("serviceAccountEmail is required");
-        }
-        String accessId = randomAccessId();
-        GcsHmacKey key = new GcsHmacKey();
-        key.setId(project + "/" + accessId);
-        key.setAccessId(accessId);
-        key.setProjectId(project);
-        key.setServiceAccountEmail(serviceAccountEmail);
-        key.setState("ACTIVE");
-        key.setTimeCreated(now());
-        key.setUpdated(now());
-        key.setEtag("etag-" + accessId);
-        keys.put(accessId, key);
-
-        // Returned once and never again, as in real GCS.
-        byte[] raw = new byte[28];
-        RANDOM.nextBytes(raw);
-        String secret = Base64.getEncoder().encodeToString(raw);
-        secrets.put(accessId, secret);
-
+        GcsHmacKeyService.CreatedKey created = service.create(project, serviceAccountEmail);
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#hmacKey");
-        response.put("metadata", key);
-        response.put("secret", secret);
+        response.put("metadata", created.metadata());
+        response.put("secret", created.secret());
         return Response.ok(response).build();
     }
 
@@ -74,22 +52,7 @@ public class GcsHmacKeyController {
     public Response list(@PathParam("project") String project,
             @QueryParam("serviceAccountEmail") String serviceAccountEmail,
             @QueryParam("showDeletedKeys") @DefaultValue("false") boolean showDeletedKeys) {
-        List<GcsHmacKey> items = new ArrayList<>();
-        for (GcsHmacKey key : keys.values()) {
-            if (!key.getProjectId().equals(project)) {
-                continue;
-            }
-            if (serviceAccountEmail != null && !serviceAccountEmail.isBlank()
-                    && !serviceAccountEmail.equals(key.getServiceAccountEmail())) {
-                continue;
-            }
-            if (!showDeletedKeys && "DELETED".equals(key.getState())) {
-                continue;
-            }
-            items.add(key);
-        }
-        items.sort((a, b) -> a.getAccessId().compareTo(b.getAccessId()));
-
+        List<GcsHmacKey> items = service.list(project, serviceAccountEmail, showDeletedKeys);
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#hmacKeysMetadata");
         response.put("items", items);
@@ -99,7 +62,7 @@ public class GcsHmacKeyController {
     @GET
     @Path("/{accessId}")
     public Response get(@PathParam("project") String project, @PathParam("accessId") String accessId) {
-        return Response.ok(require(project, accessId)).build();
+        return Response.ok(service.get(project, accessId)).build();
     }
 
     @PUT
@@ -107,51 +70,14 @@ public class GcsHmacKeyController {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response update(@PathParam("project") String project, @PathParam("accessId") String accessId,
             Map<String, Object> body) {
-        GcsHmacKey key = require(project, accessId);
         Object state = body != null ? body.get("state") : null;
-        if (!(state instanceof String requested)) {
-            throw GcpException.invalidArgument("state is required");
-        }
-        if (!requested.equals("ACTIVE") && !requested.equals("INACTIVE")) {
-            throw GcpException.invalidArgument("state must be ACTIVE or INACTIVE, got: " + requested);
-        }
-        key.setState(requested);
-        key.setUpdated(now());
-        return Response.ok(key).build();
+        return Response.ok(service.updateState(project, accessId, state)).build();
     }
 
     @DELETE
     @Path("/{accessId}")
     public Response delete(@PathParam("project") String project, @PathParam("accessId") String accessId) {
-        GcsHmacKey key = require(project, accessId);
-        if ("ACTIVE".equals(key.getState())) {
-            throw GcpException.invalidArgument(
-                    "This key must be in the INACTIVE state before it can be deleted.");
-        }
-        keys.remove(accessId);
-        secrets.remove(accessId);
+        service.delete(project, accessId);
         return Response.noContent().build();
-    }
-
-    private GcsHmacKey require(String project, String accessId) {
-        GcsHmacKey key = keys.get(accessId);
-        if (key == null || !key.getProjectId().equals(project)) {
-            throw GcpException.notFound("HMAC key not found: " + accessId);
-        }
-        return key;
-    }
-
-    // GCS access ids look like a GOOG-prefixed uppercase alphanumeric string.
-    private static String randomAccessId() {
-        final String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-        StringBuilder sb = new StringBuilder("GOOG1E");
-        for (int i = 0; i < 55; i++) {
-            sb.append(alphabet.charAt(RANDOM.nextInt(alphabet.length())));
-        }
-        return sb.toString();
-    }
-
-    private static String now() {
-        return Instant.now().truncatedTo(ChronoUnit.MILLIS).toString();
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsHmacKeyService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsHmacKeyService.java
@@ -1,0 +1,137 @@
+package io.floci.gcp.services.gcs;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.StorageFactory;
+import io.floci.gcp.services.gcs.model.GcsHmacKey;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cloud Storage HMAC key lifecycle.
+ *
+ * <p>Keys are the credentials S3-compatible clients present to GCS (boto3, the AWS SDKs, gsutil in
+ * interop mode). Nothing here signs or verifies anything, in line with the rest of the emulator's
+ * credential handling; what a client depends on is the resource lifecycle, in particular that a
+ * key must be {@code INACTIVE} before it can be deleted.
+ *
+ * <p>State lives in a {@link StorageFactory} backend so keys survive a restart in persistent mode,
+ * are namespaced by project like every other resource, and are cleared by the reset endpoint.
+ * The secret is returned once on create and never stored: nothing ever reads it back.
+ */
+@ApplicationScoped
+public class GcsHmacKeyService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final String ACCESS_ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+    private final StorageBackend<String, GcsHmacKey> keyStore;
+
+    @Inject
+    public GcsHmacKeyService(StorageFactory storageFactory) {
+        this(storageFactory.create("gcs", "gcs-hmac-keys.json",
+                new TypeReference<Map<String, GcsHmacKey>>() {}));
+    }
+
+    GcsHmacKeyService(StorageBackend<String, GcsHmacKey> keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    /** The metadata half plus the secret, which exists only in this return value. */
+    public record CreatedKey(GcsHmacKey metadata, String secret) {}
+
+    public CreatedKey create(String project, String serviceAccountEmail) {
+        if (serviceAccountEmail == null || serviceAccountEmail.isBlank()) {
+            throw GcpException.invalidArgument("serviceAccountEmail is required");
+        }
+        String accessId = randomAccessId();
+        String now = now();
+        GcsHmacKey key = new GcsHmacKey();
+        key.setId(project + "/" + accessId);
+        key.setAccessId(accessId);
+        key.setProjectId(project);
+        key.setServiceAccountEmail(serviceAccountEmail);
+        key.setState("ACTIVE");
+        key.setTimeCreated(now);
+        key.setUpdated(now);
+        key.setEtag("etag-" + accessId);
+        keyStore.put(accessId, key);
+
+        byte[] raw = new byte[28];
+        RANDOM.nextBytes(raw);
+        return new CreatedKey(key, Base64.getEncoder().encodeToString(raw));
+    }
+
+    public List<GcsHmacKey> list(String project, String serviceAccountEmail, boolean showDeletedKeys) {
+        List<GcsHmacKey> items = new ArrayList<>();
+        for (GcsHmacKey key : keyStore.scan(k -> true)) {
+            if (!project.equals(key.getProjectId())) {
+                continue;
+            }
+            if (serviceAccountEmail != null && !serviceAccountEmail.isBlank()
+                    && !serviceAccountEmail.equals(key.getServiceAccountEmail())) {
+                continue;
+            }
+            if (!showDeletedKeys && "DELETED".equals(key.getState())) {
+                continue;
+            }
+            items.add(key);
+        }
+        items.sort(Comparator.comparing(GcsHmacKey::getAccessId));
+        return items;
+    }
+
+    public GcsHmacKey get(String project, String accessId) {
+        GcsHmacKey key = keyStore.get(accessId).orElse(null);
+        if (key == null || !project.equals(key.getProjectId())) {
+            throw GcpException.notFound("HMAC key not found: " + accessId);
+        }
+        return key;
+    }
+
+    public GcsHmacKey updateState(String project, String accessId, Object requestedState) {
+        GcsHmacKey key = get(project, accessId);
+        if (!(requestedState instanceof String state)) {
+            throw GcpException.invalidArgument("state is required");
+        }
+        if (!state.equals("ACTIVE") && !state.equals("INACTIVE")) {
+            throw GcpException.invalidArgument("state must be ACTIVE or INACTIVE, got: " + state);
+        }
+        key.setState(state);
+        key.setUpdated(now());
+        keyStore.put(accessId, key);
+        return key;
+    }
+
+    public void delete(String project, String accessId) {
+        GcsHmacKey key = get(project, accessId);
+        if ("ACTIVE".equals(key.getState())) {
+            throw GcpException.invalidArgument(
+                    "This key must be in the INACTIVE state before it can be deleted.");
+        }
+        keyStore.delete(accessId);
+    }
+
+    // GCS access ids look like a GOOG-prefixed uppercase alphanumeric string.
+    private static String randomAccessId() {
+        StringBuilder sb = new StringBuilder("GOOG1E");
+        for (int i = 0; i < 55; i++) {
+            sb.append(ACCESS_ID_ALPHABET.charAt(RANDOM.nextInt(ACCESS_ID_ALPHABET.length())));
+        }
+        return sb.toString();
+    }
+
+    private static String now() {
+        return Instant.now().truncatedTo(ChronoUnit.MILLIS).toString();
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -1,5 +1,6 @@
 package io.floci.gcp.services.gcs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.gcp.config.EmulatorConfig;
 import io.floci.gcp.core.common.GcpException;
 import io.floci.gcp.core.common.PageToken;
@@ -37,13 +38,15 @@ public class GcsObjectController {
 
     private final GcsService service;
     private final EmulatorConfig config;
+    private final ObjectMapper objectMapper;
 	private final GcsAuthorizationService authorizationService;
 
     @Inject
-	public GcsObjectController(GcsService service, EmulatorConfig config,
+	public GcsObjectController(GcsService service, EmulatorConfig config, ObjectMapper objectMapper,
 			GcsAuthorizationService authorizationService) {
         this.service = service;
         this.config = config;
+        this.objectMapper = objectMapper;
 		this.authorizationService = authorizationService;
     }
 
@@ -452,14 +455,16 @@ public class GcsObjectController {
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
             @QueryParam("maxBytesRewrittenPerCall") Long maxBytesRewrittenPerCall,
             @QueryParam("rewriteToken") String rewriteToken,
-            @Context HttpHeaders headers) {
+            @Context HttpHeaders headers,
+            String body) {
         authorizationService.requireSourceReadAndDestinationWrite(
                 headers.getHeaderString(HttpHeaders.AUTHORIZATION),
                 srcBucket, srcObjectPath, dstBucket, dstObjectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
         var result = service.rewriteObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
-                maxBytesRewrittenPerCall, rewriteToken, preconditions, requestBaseUrl(headers));
+                maxBytesRewrittenPerCall, rewriteToken, destinationStorageClass(body), preconditions,
+                requestBaseUrl(headers));
 
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#rewriteResponse");
@@ -473,6 +478,23 @@ public class GcsObjectController {
             response.put("rewriteToken", result.rewriteToken());
         }
         return Response.ok(response).build();
+    }
+
+    // The rewrite body is the destination object's metadata. Read as a string rather than a
+    // bound Map so a client that sends no body and no Content-Type (the raw compat cases, and
+    // the SDKs' continuation calls) is not refused with 415. Only storageClass is honoured today;
+    // it decides whether the copy spans storage classes and what the destination lands with.
+    private String destinationStorageClass(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            Map<?, ?> metadata = objectMapper.readValue(body, Map.class);
+            return metadata.get("storageClass") instanceof String storageClass && !storageClass.isBlank()
+                    ? storageClass : null;
+        } catch (java.io.IOException e) {
+            throw GcpException.invalidArgument("invalid rewrite request body");
+        }
     }
 
     private String requestBaseUrl(HttpHeaders headers) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -63,13 +63,19 @@ public class GcsObjectController {
 			@QueryParam("endOffset") String endOffset,
 			@QueryParam("matchGlob") String matchGlob,
 			@QueryParam("includeTrailingDelimiter") @DefaultValue("false") boolean includeTrailingDelimiter,
+			@QueryParam("softDeleted") @DefaultValue("false") boolean softDeleted,
 			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization,
             @QueryParam("versions") @DefaultValue("false") boolean includeVersions) {
 		authorizationService.requireObjectList(authorization, bucket, prefix);
-        List<GcsObjectMeta> all = includeVersions
-                ? service.listObjectVersions(bucket, prefix)
-                : service.listObjects(bucket);
-        if (!includeVersions && prefix != null && !prefix.isBlank()) {
+        if (softDeleted && includeVersions) {
+            throw GcpException.invalidArgument("softDeleted and versions cannot both be set");
+        }
+        List<GcsObjectMeta> all = softDeleted
+                ? service.listSoftDeletedObjects(bucket, prefix)
+                : includeVersions
+                        ? service.listObjectVersions(bucket, prefix)
+                        : service.listObjects(bucket);
+        if (!includeVersions && !softDeleted && prefix != null && !prefix.isBlank()) {
             all = all.stream().filter(o -> o.getName().startsWith(prefix)).toList();
         }
         // startOffset is inclusive, endOffset exclusive.
@@ -341,6 +347,22 @@ public class GcsObjectController {
         return Response.noContent().build();
     }
 
+    /**
+     * {@code objects.restore}: brings a soft-deleted generation back to live.
+     *
+     * <p>Requires an explicit generation, as GCS does, a name alone is ambiguous once several
+     * generations of the same object have been soft-deleted.
+     */
+    @POST
+    @Path("/{object: .+}/restore")
+    public Response restoreObject(@PathParam("bucket") String bucket,
+            @PathParam("object") String objectPath,
+            @QueryParam("generation") String generation,
+			@HeaderParam(HttpHeaders.AUTHORIZATION) String authorization) {
+        authorizationService.requireObjectWrite(authorization, bucket, objectPath);
+        return Response.ok(service.restoreObject(bucket, objectPath, generation)).build();
+    }
+
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{destObject: .+}/compose")
@@ -428,20 +450,28 @@ public class GcsObjectController {
             @QueryParam("ifGenerationNotMatch") Long ifGenerationNotMatch,
             @QueryParam("ifMetagenerationMatch") Long ifMetagenerationMatch,
             @QueryParam("ifMetagenerationNotMatch") Long ifMetagenerationNotMatch,
+            @QueryParam("maxBytesRewrittenPerCall") Long maxBytesRewrittenPerCall,
+            @QueryParam("rewriteToken") String rewriteToken,
             @Context HttpHeaders headers) {
         authorizationService.requireSourceReadAndDestinationWrite(
                 headers.getHeaderString(HttpHeaders.AUTHORIZATION),
                 srcBucket, srcObjectPath, dstBucket, dstObjectPath);
         GcsObjectPreconditions preconditions = new GcsObjectPreconditions(ifGenerationMatch, ifGenerationNotMatch,
                 ifMetagenerationMatch, ifMetagenerationNotMatch);
-        GcsObjectMeta meta = service.copyObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
-                preconditions, requestBaseUrl(headers));
+        var result = service.rewriteObject(srcBucket, srcObjectPath, dstBucket, dstObjectPath,
+                maxBytesRewrittenPerCall, rewriteToken, preconditions, requestBaseUrl(headers));
+
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#rewriteResponse");
-        response.put("totalBytesRewritten", meta.getSize());
-        response.put("objectSize", meta.getSize());
-        response.put("done", true);
-        response.put("resource", meta);
+        response.put("totalBytesRewritten", String.valueOf(result.totalBytesRewritten()));
+        response.put("objectSize", String.valueOf(result.objectSize()));
+        response.put("done", result.done());
+        if (result.done()) {
+            response.put("resource", result.meta());
+        } else {
+            // The client loops on this token until the response comes back done.
+            response.put("rewriteToken", result.rewriteToken());
+        }
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -914,7 +914,12 @@ public class GcsService {
      * rewritten object is never visible.
      */
     public GcsRewriteResult rewriteObject(String srcBucket, String srcObject, String dstBucket, String dstObject,
-            Long maxBytesPerCall, String rewriteToken, GcsObjectPreconditions preconditions, String baseUrl) {
+            Long maxBytesPerCall, String rewriteToken, String destinationStorageClass,
+            GcsObjectPreconditions preconditions, String baseUrl) {
+        if (maxBytesPerCall != null && (maxBytesPerCall <= 0 || maxBytesPerCall % ONE_MIB != 0)) {
+            throw GcpException.invalidArgument(
+                    "maxBytesRewrittenPerCall must be an integral multiple of 1 MiB (1048576), got: " + maxBytesPerCall);
+        }
         GcsObjectMeta source = getObjectMeta(srcBucket, srcObject);
         long objectSize = source.getSize() != null ? Long.parseLong(source.getSize()) : 0L;
 
@@ -933,13 +938,28 @@ public class GcsService {
                 throw GcpException.invalidArgument(
                         "rewriteToken refers to a source generation that has since been replaced");
             }
+            if (maxBytesPerCall != null && !maxBytesPerCall.equals(session.maxBytesPerCall())) {
+                // "this value must not change across rewrite calls else you'll get an error that
+                // the rewriteToken is invalid" (storage/v1 discovery, objects.rewrite).
+                throw GcpException.invalidArgument(
+                        "Invalid rewriteToken: maxBytesRewrittenPerCall must not change across rewrite calls");
+            }
+            // Later calls may omit the request fields; the first call's values stand.
+            destinationStorageClass = session.destinationStorageClass();
         } else {
             session = new GcsRewriteSession(srcBucket, srcObject, source.getGeneration(),
-                    dstBucket, dstObject, objectSize, 0L, preconditions);
+                    dstBucket, dstObject, destinationStorageClass, objectSize, 0L, maxBytesPerCall,
+                    preconditions);
         }
 
-        long step = maxBytesPerCall != null && maxBytesPerCall > 0 ? maxBytesPerCall : objectSize;
-        session = session.advancedBy(Math.max(step, 1L));
+        // The per-call limit "only applies to requests where the source and destination span
+        // locations and/or storage classes" (storage/v1 discovery, objects.rewrite). A copy within
+        // one location and class finishes in a single call whatever limit the client sent.
+        long limit = session.maxBytesPerCall() != null
+                && spansLocationOrStorageClass(srcBucket, source, dstBucket, destinationStorageClass)
+                ? session.maxBytesPerCall()
+                : objectSize;
+        session = session.advancedBy(Math.max(limit, 1L));
 
         if (!session.complete()) {
             String token = rewriteToken != null && !rewriteToken.isBlank()
@@ -949,9 +969,14 @@ public class GcsService {
             return new GcsRewriteResult(false, token, session.bytesRewritten(), objectSize, null);
         }
 
+        GcsObjectMeta destinationTemplate = null;
+        if (destinationStorageClass != null && !destinationStorageClass.isBlank()) {
+            destinationTemplate = new GcsObjectMeta();
+            destinationTemplate.setStorageClass(destinationStorageClass);
+        }
         // Pinned to the generation the token was bound to, not whatever is live now.
         GcsObjectMeta meta = copyObject(srcBucket, srcObject, session.srcGeneration(),
-                dstBucket, dstObject, session.preconditions(), baseUrl);
+                dstBucket, dstObject, destinationTemplate, session.preconditions(), baseUrl);
         // Only once the copy has actually succeeded: retiring the token first would turn a failed
         // destination precondition into an unretryable rewrite, since the client's token would
         // already be gone.
@@ -977,20 +1002,64 @@ public class GcsService {
      */
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String srcGeneration,
             String dstBucket, String dstObject, GcsObjectPreconditions preconditions, String baseUrl) {
+        return copyObject(srcBucket, srcObject, srcGeneration, dstBucket, dstObject, null, preconditions, baseUrl);
+    }
+
+    /**
+     * Copies with a destination template, currently the {@code storageClass} a rewrite request
+     * names for the destination. Fields the template leaves unset fall back to the source object
+     * and the destination bucket exactly as a plain copy does.
+     */
+    public GcsObjectMeta copyObject(String srcBucket, String srcObject, String srcGeneration,
+            String dstBucket, String dstObject, GcsObjectMeta destinationTemplate,
+            GcsObjectPreconditions preconditions, String baseUrl) {
         LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
         // Read the source before taking the destination lock. Nesting two
         // stripe locks could deadlock with a copy running in the other direction.
         var src = getObjectForDownload(srcBucket, srcObject, srcGeneration, GcsCustomerEncryption.none());
         synchronized (objectLock(dstBucket, dstObject)) {
             checkPreconditions(dstBucket, dstObject, preconditions);
-            return copyObjectLocked(src, dstBucket, dstObject, baseUrl);
+            return copyObjectLocked(src, dstBucket, dstObject, destinationTemplate, baseUrl);
         }
     }
 
+    private static final long ONE_MIB = 1024L * 1024L;
+
+    // "Span locations and/or storage classes": the bucket location on each side, and the source
+    // object's class against the class the destination will land with (the class the request
+    // names, else the destination bucket's default, else STANDARD, which is what putObjectLocked
+    // applies).
+    private boolean spansLocationOrStorageClass(String srcBucket, GcsObjectMeta source, String dstBucket,
+            String requestedStorageClass) {
+        GcsBucket src = bucketStore.get(srcBucket).orElse(null);
+        GcsBucket dst = bucketStore.get(dstBucket).orElse(null);
+        String srcLocation = src != null && src.getLocation() != null ? src.getLocation() : "US";
+        String dstLocation = dst != null && dst.getLocation() != null ? dst.getLocation() : "US";
+        if (!srcLocation.equalsIgnoreCase(dstLocation)) {
+            return true;
+        }
+        String srcClass = source.getStorageClass() != null && !source.getStorageClass().isBlank()
+                ? source.getStorageClass() : "STANDARD";
+        String dstClass;
+        if (requestedStorageClass != null && !requestedStorageClass.isBlank()) {
+            dstClass = requestedStorageClass;
+        } else if (dst != null && dst.getStorageClass() != null && !dst.getStorageClass().isBlank()) {
+            dstClass = dst.getStorageClass();
+        } else {
+            dstClass = "STANDARD";
+        }
+        return !srcClass.equalsIgnoreCase(dstClass);
+    }
+
     private GcsObjectMeta copyObjectLocked(GcsObjectDownload src, String dstBucket, String dstObject, String baseUrl) {
+        return copyObjectLocked(src, dstBucket, dstObject, null, baseUrl);
+    }
+
+    private GcsObjectMeta copyObjectLocked(GcsObjectDownload src, String dstBucket, String dstObject,
+            GcsObjectMeta destinationTemplate, String baseUrl) {
         var srcMeta = src.meta();
         var dstMeta = putObjectLocked(dstBucket, dstObject, srcMeta.getContentType(), src.data(),
-                GcsCustomerEncryption.none(), null, null, baseUrl);
+                GcsCustomerEncryption.none(), null, destinationTemplate, baseUrl);
         if (srcMeta.getMetadata() != null) {
             dstMeta.setMetadata(new LinkedHashMap<>(srcMeta.getMetadata()));
         }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -19,6 +19,8 @@ import io.floci.gcp.services.gcs.model.GcsComposeSource;
 import io.floci.gcp.services.gcs.model.GcsContentRange;
 import io.floci.gcp.services.gcs.model.GcsObjectDownload;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
+import io.floci.gcp.services.gcs.model.GcsRewriteResult;
+import io.floci.gcp.services.gcs.model.GcsRewriteSession;
 import io.floci.gcp.services.gcs.model.GcsObjectPreconditions;
 import io.floci.gcp.services.gcs.model.GcsStreamingUpload;
 import io.floci.gcp.services.gcs.model.ResumableChunkOutcome;
@@ -48,6 +50,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Comparator;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -66,6 +69,7 @@ public class GcsService {
     private final StorageBackend<String, StoredAcl> aclStore;
     private final StorageBackend<String, StoredNotification> notificationStore;
     private final ConcurrentHashMap<String, ResumableUpload> resumableUploads = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, GcsRewriteSession> rewriteSessions = new ConcurrentHashMap<>();
     private final Map<String, CompletedResumableUpload> completedResumableUploads = Collections.synchronizedMap(
             new LinkedHashMap<>(16, 0.75f, true) {
                 @Override
@@ -153,7 +157,8 @@ public class GcsService {
                         GcsUploadController.class, GcsDownloadController.class,
                         GcsXmlDownloadController.class, GcsNotificationController.class,
                         GcsBatchController.class, GcsGrpcController.class,
-                        GcsProjectController.class)
+                        GcsProjectController.class,
+                        GcsHmacKeyController.class)
                 .build());
         if (config.services().gcs().enabled()) {
             GcsGrpcController controller = new GcsGrpcController(this, config, authorizationService);
@@ -210,6 +215,9 @@ public class GcsService {
                 bucket.setRetentionPolicy(
                         withEffectiveTime((Map<String, Object>) body.get("retentionPolicy")));
             }
+            if (body.containsKey("softDeletePolicy")) {
+                bucket.setSoftDeletePolicy((Map<String, Object>) body.get("softDeletePolicy"));
+            }
             if (body.containsKey("defaultEventBasedHold")) {
                 bucket.setDefaultEventBasedHold((Boolean) body.get("defaultEventBasedHold"));
             }
@@ -243,6 +251,9 @@ public class GcsService {
         if (patch.containsKey("retentionPolicy")) {
             bucket.setRetentionPolicy(
                     withEffectiveTime((Map<String, Object>) patch.get("retentionPolicy")));
+        }
+        if (patch.containsKey("softDeletePolicy")) {
+            bucket.setSoftDeletePolicy((Map<String, Object>) patch.get("softDeletePolicy"));
         }
         if (patch.containsKey("storageClass")) {
             bucket.setStorageClass((String) patch.get("storageClass"));
@@ -545,6 +556,7 @@ public class GcsService {
             objectMetaStore.put(key + "\0" + markerGen, marker);
         }
         GcsObjectMeta deletedMeta = live;
+        softDelete(bucket, objectName, live);
         objectMetaStore.delete(key);
         objectDataStore.delete(key);
         if (deletedMeta != null) {
@@ -561,6 +573,133 @@ public class GcsService {
     }
 
     private static final int MAX_COMPOSE_SOURCES = 32;
+
+    // ── Soft delete ──────────────────────────────────────────────────────────
+    //
+    // With a softDeletePolicy on the bucket, a deleted object is retained under a separate key
+    // namespace instead of vanishing: it disappears from live listings, shows up under
+    // ?softDeleted=true, and can be restored by generation. Real GCS has had this on by default
+    // since 2024, so code written against production may rely on being able to undo a delete.
+
+    private static final String SOFT_DELETE_MARKER = "\0softDeleted\0";
+
+    private String softDeleteKey(String bucket, String objectName, String generation) {
+        return objectKey(bucket, objectName) + SOFT_DELETE_MARKER + generation;
+    }
+
+    public boolean isSoftDeleteEnabled(String bucket) {
+        return softDeleteRetentionSeconds(bucket) > 0;
+    }
+
+    private long softDeleteRetentionSeconds(String bucket) {
+        Map<String, Object> policy = bucketStore.get(bucket)
+                .map(GcsBucket::getSoftDeletePolicy)
+                .orElse(null);
+        if (policy == null) {
+            return 0L;
+        }
+        Object duration = policy.get("retentionDurationSeconds");
+        try {
+            return duration == null ? 0L : Long.parseLong(String.valueOf(duration));
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private void softDelete(String bucket, String objectName, GcsObjectMeta live) {
+        softDelete(bucket, objectName, live, objectKey(bucket, objectName));
+    }
+
+    /**
+     * Retains one version under the soft-delete namespace, reading its bytes from
+     * {@code sourceKey}, the live key for a live object, the archive key for a noncurrent one.
+     *
+     * <p>A generation-scoped delete is retained too, not only a delete by name: "when you delete
+     * a noncurrent object, it becomes soft-deleted"
+     * (https://cloud.google.com/storage/docs/soft-delete). That distinction is not academic , 
+     * google-cloud-storage for Python sends the loaded generation on every {@code blob.delete()},
+     * so treating a generation-scoped delete as permanent would bypass soft delete entirely for
+     * the SDK most likely to be relying on it.
+     */
+    private void softDelete(String bucket, String objectName, GcsObjectMeta version, String sourceKey) {
+        long retention = softDeleteRetentionSeconds(bucket);
+        if (retention <= 0 || version.getGeneration() == null) {
+            return;
+        }
+        GcsObjectMeta archived = cloneMeta(version);
+        archived.setIsLatest(false);
+        String now = nowTimestamp();
+        archived.setSoftDeleteTime(now);
+        archived.setHardDeleteTime(
+                java.time.Instant.now().plusSeconds(retention).truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+                        .toString());
+
+        String archiveKey = softDeleteKey(bucket, objectName, version.getGeneration());
+        objectDataStore.get(sourceKey).ifPresent(data -> objectDataStore.put(archiveKey, data));
+        objectMetaStore.put(archiveKey, archived);
+        LOG.debugf("softDelete bucket=%s name=%s generation=%s", bucket, objectName, version.getGeneration());
+    }
+
+    /** Soft-deleted objects in a bucket, newest generation first, optionally filtered by prefix. */
+    public List<GcsObjectMeta> listSoftDeletedObjects(String bucket, String prefix) {
+        String bucketPrefix = objectKey(bucket, "");
+        List<GcsObjectMeta> out = new ArrayList<>();
+        for (String storeKey : objectMetaStore.keys()) {
+            if (!storeKey.startsWith(bucketPrefix) || !storeKey.contains(SOFT_DELETE_MARKER)) {
+                continue;
+            }
+            objectMetaStore.get(storeKey).ifPresent(meta -> {
+                if (prefix == null || prefix.isEmpty() || meta.getName().startsWith(prefix)) {
+                    out.add(meta);
+                }
+            });
+        }
+        out.sort(Comparator.comparing(GcsObjectMeta::getName)
+                .thenComparing(m -> m.getGeneration() == null ? "" : m.getGeneration()));
+        return out;
+    }
+
+    /** Restores a soft-deleted generation back to live, as {@code objects.restore} does. */
+    public GcsObjectMeta restoreObject(String bucket, String objectName, String generation) {
+        synchronized (objectLock(bucket, objectName)) {
+            if (generation == null || generation.isBlank()) {
+                throw GcpException.invalidArgument("generation is required to restore an object");
+            }
+            String archiveKey = softDeleteKey(bucket, objectName, generation);
+            GcsObjectMeta archived = objectMetaStore.get(archiveKey)
+                    .orElseThrow(() -> GcpException.notFound(
+                            "Soft-deleted object not found: " + objectName + " generation " + generation));
+
+            String key = objectKey(bucket, objectName);
+            // Restoring onto a name that is live again displaces that object, so route it
+            // through the ordinary delete path first: that enforces holds and retention, archives
+            // it when versioning is on, and retains it under the soft delete policy. Writing
+            // straight over it would destroy a live generation, which is the opposite of what
+            // this feature exists to do.
+            if (getLiveObjectMeta(bucket, objectName).isPresent()) {
+                deleteObjectLocked(bucket, objectName);
+            }
+            GcsObjectMeta restored = cloneMeta(archived);
+            restored.setSoftDeleteTime(null);
+            restored.setHardDeleteTime(null);
+            restored.setIsLatest(true);
+            restored.setTimeDeleted(null);
+            restored.setUpdated(nowTimestamp());
+
+            objectDataStore.get(archiveKey).ifPresent(data -> objectDataStore.put(key, data));
+            objectMetaStore.put(key, restored);
+            objectMetaStore.delete(archiveKey);
+            objectDataStore.delete(archiveKey);
+            // With versioning on, the original delete also left this generation in the noncurrent
+            // namespace. It is live again now, so drop that copy: leaving both would list the same
+            // generation twice, once current and once noncurrent.
+            String versionKey = key + "\0" + generation;
+            objectMetaStore.delete(versionKey);
+            objectDataStore.delete(versionKey);
+            LOG.debugf("restoreObject bucket=%s name=%s generation=%s", bucket, objectName, generation);
+            return restored;
+        }
+    }
 
     public void deleteObjectVersion(String bucket, String objectName, String generation) {
         deleteObjectVersion(bucket, objectName, generation, GcsObjectPreconditions.NONE);
@@ -580,6 +719,7 @@ public class GcsService {
         GcsObjectMeta live = objectMetaStore.get(liveKey).orElse(null);
         if (live != null && generation.equals(live.getGeneration())) {
             checkPreconditions(Optional.of(live), preconditions);
+            softDelete(bucket, objectName, live, liveKey);
             objectMetaStore.delete(liveKey);
             objectDataStore.delete(liveKey);
             return;
@@ -590,6 +730,7 @@ public class GcsService {
             throw GcpException.notFound("Object version not found: " + objectName + "@" + generation);
         }
         checkPreconditions(archived, preconditions);
+        softDelete(bucket, objectName, archived.get(), archiveKey);
         objectMetaStore.delete(archiveKey);
         objectDataStore.delete(archiveKey);
     }
@@ -763,16 +904,83 @@ public class GcsService {
         }
     }
 
+    /**
+     * One call of {@code objects.rewrite}.
+     *
+     * <p>Without {@code maxBytesRewrittenPerCall}, or when the object fits inside it, the rewrite
+     * completes immediately. Otherwise it returns {@code done: false} plus a {@code rewriteToken}
+     * the client passes back until the copy finishes, exactly as GCS does for large or
+     * class-changing copies. The destination is written only on the completing call, so a partially
+     * rewritten object is never visible.
+     */
+    public GcsRewriteResult rewriteObject(String srcBucket, String srcObject, String dstBucket, String dstObject,
+            Long maxBytesPerCall, String rewriteToken, GcsObjectPreconditions preconditions, String baseUrl) {
+        GcsObjectMeta source = getObjectMeta(srcBucket, srcObject);
+        long objectSize = source.getSize() != null ? Long.parseLong(source.getSize()) : 0L;
+
+        GcsRewriteSession session;
+        if (rewriteToken != null && !rewriteToken.isBlank()) {
+            session = rewriteSessions.get(rewriteToken);
+            if (session == null) {
+                throw GcpException.invalidArgument("Invalid rewriteToken: " + rewriteToken);
+            }
+            if (!session.matches(srcBucket, srcObject, dstBucket, dstObject)) {
+                // GCS ties the token to the exact source/destination pair.
+                throw GcpException.invalidArgument(
+                        "rewriteToken does not match the requested source and destination");
+            }
+            if (!session.sourceGenerationUnchanged(source.getGeneration())) {
+                throw GcpException.invalidArgument(
+                        "rewriteToken refers to a source generation that has since been replaced");
+            }
+        } else {
+            session = new GcsRewriteSession(srcBucket, srcObject, source.getGeneration(),
+                    dstBucket, dstObject, objectSize, 0L, preconditions);
+        }
+
+        long step = maxBytesPerCall != null && maxBytesPerCall > 0 ? maxBytesPerCall : objectSize;
+        session = session.advancedBy(Math.max(step, 1L));
+
+        if (!session.complete()) {
+            String token = rewriteToken != null && !rewriteToken.isBlank()
+                    ? rewriteToken
+                    : UUID.randomUUID().toString().replace("-", "");
+            rewriteSessions.put(token, session);
+            return new GcsRewriteResult(false, token, session.bytesRewritten(), objectSize, null);
+        }
+
+        // Pinned to the generation the token was bound to, not whatever is live now.
+        GcsObjectMeta meta = copyObject(srcBucket, srcObject, session.srcGeneration(),
+                dstBucket, dstObject, session.preconditions(), baseUrl);
+        // Only once the copy has actually succeeded: retiring the token first would turn a failed
+        // destination precondition into an unretryable rewrite, since the client's token would
+        // already be gone.
+        if (rewriteToken != null && !rewriteToken.isBlank()) {
+            rewriteSessions.remove(rewriteToken);
+        }
+        return new GcsRewriteResult(true, null, objectSize, objectSize, meta);
+    }
+
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject, String baseUrl) {
         return copyObject(srcBucket, srcObject, dstBucket, dstObject, GcsObjectPreconditions.NONE, baseUrl);
     }
 
     public GcsObjectMeta copyObject(String srcBucket, String srcObject, String dstBucket, String dstObject,
             GcsObjectPreconditions preconditions, String baseUrl) {
+        return copyObject(srcBucket, srcObject, null, dstBucket, dstObject, preconditions, baseUrl);
+    }
+
+    /**
+     * Copies a specific source generation when one is given. A completing chunked rewrite passes
+     * the generation its token was bound to, so an overwrite between the token check and the copy
+     * cannot substitute newer bytes for the ones the rewrite measured its progress against.
+     */
+    public GcsObjectMeta copyObject(String srcBucket, String srcObject, String srcGeneration,
+            String dstBucket, String dstObject, GcsObjectPreconditions preconditions, String baseUrl) {
         LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
         // Read the source before taking the destination lock. Nesting two
         // stripe locks could deadlock with a copy running in the other direction.
-        var src = getObjectForDownload(srcBucket, srcObject, null, GcsCustomerEncryption.none());
+        var src = getObjectForDownload(srcBucket, srcObject, srcGeneration, GcsCustomerEncryption.none());
         synchronized (objectLock(dstBucket, dstObject)) {
             checkPreconditions(dstBucket, dstObject, preconditions);
             return copyObjectLocked(src, dstBucket, dstObject, baseUrl);

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsBucket.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsBucket.java
@@ -28,6 +28,9 @@ public class GcsBucket {
     private Map<String, Object> lifecycle;
     private List<Map<String, Object>> cors;
     private Map<String, Object> retentionPolicy;
+    // Presence of a policy with a non-zero retentionDurationSeconds turns on soft delete:
+    // a deleted object is retained and can be restored until it is hard-deleted.
+    private Map<String, Object> softDeletePolicy;
     private Boolean defaultEventBasedHold;
 
     public String getKind() { return kind; }
@@ -81,6 +84,9 @@ public class GcsBucket {
 
     public Map<String, Object> getRetentionPolicy() { return retentionPolicy; }
     public void setRetentionPolicy(Map<String, Object> retentionPolicy) { this.retentionPolicy = retentionPolicy; }
+
+    public Map<String, Object> getSoftDeletePolicy() { return softDeletePolicy; }
+    public void setSoftDeletePolicy(Map<String, Object> softDeletePolicy) { this.softDeletePolicy = softDeletePolicy; }
 
     public Boolean getDefaultEventBasedHold() { return defaultEventBasedHold; }
     public void setDefaultEventBasedHold(Boolean defaultEventBasedHold) { this.defaultEventBasedHold = defaultEventBasedHold; }

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsHmacKey.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsHmacKey.java
@@ -1,0 +1,51 @@
+package io.floci.gcp.services.gcs.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** Metadata half of a Cloud Storage HMAC key. The secret is returned only once, on create. */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GcsHmacKey {
+
+    private String kind = "storage#hmacKeyMetadata";
+    private String id;
+    private String accessId;
+    private String projectId;
+    private String serviceAccountEmail;
+    private String state;
+    private String timeCreated;
+    private String updated;
+    private String etag;
+    private String selfLink;
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getAccessId() { return accessId; }
+    public void setAccessId(String accessId) { this.accessId = accessId; }
+
+    public String getProjectId() { return projectId; }
+    public void setProjectId(String projectId) { this.projectId = projectId; }
+
+    public String getServiceAccountEmail() { return serviceAccountEmail; }
+    public void setServiceAccountEmail(String serviceAccountEmail) { this.serviceAccountEmail = serviceAccountEmail; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getTimeCreated() { return timeCreated; }
+    public void setTimeCreated(String timeCreated) { this.timeCreated = timeCreated; }
+
+    public String getUpdated() { return updated; }
+    public void setUpdated(String updated) { this.updated = updated; }
+
+    public String getEtag() { return etag; }
+    public void setEtag(String etag) { this.etag = etag; }
+
+    public String getSelfLink() { return selfLink; }
+    public void setSelfLink(String selfLink) { this.selfLink = selfLink; }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsObjectMeta.java
@@ -111,6 +111,8 @@ public class GcsObjectMeta {
     // express "delete 30 days after the record was superseded" rather than
     // relying on the object's create time.
     private String customTime;
+    private String softDeleteTime;
+    private String hardDeleteTime;
 
     public String getTimeDeleted() { return timeDeleted; }
     public void setTimeDeleted(String timeDeleted) { this.timeDeleted = timeDeleted; }
@@ -129,4 +131,10 @@ public class GcsObjectMeta {
 
     public String getCustomTime() { return customTime; }
     public void setCustomTime(String customTime) { this.customTime = customTime; }
+
+    public String getSoftDeleteTime() { return softDeleteTime; }
+    public void setSoftDeleteTime(String softDeleteTime) { this.softDeleteTime = softDeleteTime; }
+
+    public String getHardDeleteTime() { return hardDeleteTime; }
+    public void setHardDeleteTime(String hardDeleteTime) { this.hardDeleteTime = hardDeleteTime; }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsRewriteResult.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsRewriteResult.java
@@ -1,0 +1,5 @@
+package io.floci.gcp.services.gcs.model;
+
+/** Outcome of one {@code objects.rewrite} call. {@code meta} is set only once {@code done}. */
+public record GcsRewriteResult(boolean done, String rewriteToken, long totalBytesRewritten,
+        long objectSize, GcsObjectMeta meta) {}

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsRewriteSession.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsRewriteSession.java
@@ -1,0 +1,41 @@
+package io.floci.gcp.services.gcs.model;
+
+/**
+ * State for a multi-call {@code objects.rewrite}.
+ *
+ * <p>GCS answers a rewrite that cannot finish within {@code maxBytesRewrittenPerCall} with
+ * {@code done: false} and a {@code rewriteToken}; the client calls back with that token until the
+ * response comes back done. The destination object does not become visible until then.
+ *
+ * <p>The emulator holds no partial bytes, the copy is performed once, on the call that completes
+ * the rewrite, so this only tracks how far the protocol has advanced. That is enough for a client
+ * to take the same code path it would against real GCS, which is what the emulator exists to
+ * exercise.
+ */
+public record GcsRewriteSession(String srcBucket, String srcObject, String srcGeneration,
+        String dstBucket, String dstObject, long objectSize, long bytesRewritten,
+        GcsObjectPreconditions preconditions) {
+
+    public GcsRewriteSession advancedBy(long bytes) {
+        return new GcsRewriteSession(srcBucket, srcObject, srcGeneration, dstBucket, dstObject,
+                objectSize, Math.min(objectSize, bytesRewritten + bytes), preconditions);
+    }
+
+    public boolean complete() {
+        return bytesRewritten >= objectSize;
+    }
+
+    public boolean matches(String srcBucket, String srcObject, String dstBucket, String dstObject) {
+        return this.srcBucket.equals(srcBucket) && this.srcObject.equals(srcObject)
+                && this.dstBucket.equals(dstBucket) && this.dstObject.equals(dstObject);
+    }
+
+    /**
+     * Whether the source is still the generation the rewrite started against. The token records
+     * it so that a source overwritten between calls cannot be silently copied in place of the one
+     * the progress was measured on, which would report totals for one generation and copy another.
+     */
+    public boolean sourceGenerationUnchanged(String currentGeneration) {
+        return srcGeneration == null || srcGeneration.equals(currentGeneration);
+    }
+}

--- a/src/main/java/io/floci/gcp/services/gcs/model/GcsRewriteSession.java
+++ b/src/main/java/io/floci/gcp/services/gcs/model/GcsRewriteSession.java
@@ -11,14 +11,19 @@ package io.floci.gcp.services.gcs.model;
  * the rewrite, so this only tracks how far the protocol has advanced. That is enough for a client
  * to take the same code path it would against real GCS, which is what the emulator exists to
  * exercise.
+ *
+ * <p>{@code maxBytesPerCall} and {@code destinationStorageClass} are pinned from the first call:
+ * the discovery document says the limit "must not change across rewrite calls else you'll get an
+ * error that the rewriteToken is invalid", and later calls "can omit all other request fields".
  */
 public record GcsRewriteSession(String srcBucket, String srcObject, String srcGeneration,
-        String dstBucket, String dstObject, long objectSize, long bytesRewritten,
-        GcsObjectPreconditions preconditions) {
+        String dstBucket, String dstObject, String destinationStorageClass, long objectSize,
+        long bytesRewritten, Long maxBytesPerCall, GcsObjectPreconditions preconditions) {
 
     public GcsRewriteSession advancedBy(long bytes) {
         return new GcsRewriteSession(srcBucket, srcObject, srcGeneration, dstBucket, dstObject,
-                objectSize, Math.min(objectSize, bytesRewritten + bytes), preconditions);
+                destinationStorageClass, objectSize, Math.min(objectSize, bytesRewritten + bytes),
+                maxBytesPerCall, preconditions);
     }
 
     public boolean complete() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,8 @@ quarkus:
       - --enable-url-protocols=http,https
       - --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32
       - --initialize-at-run-time=io.floci.gcp.services.cloudkms.KmsCrypto
+      # Holds a static SecureRandom; native image refuses one in the image heap.
+      - --initialize-at-run-time=io.floci.gcp.services.gcs.GcsHmacKeyController
       - --initialize-at-run-time=io.floci.gcp.services.firebaseauth.FirebaseAuthService
       - --initialize-at-run-time=io.floci.gcp.services.cloudsql.CloudSqlPostgresDataPlane
       - --initialize-at-run-time=io.floci.gcp.services.scheduler.SchedulerExpressionParser
@@ -45,9 +47,9 @@ floci-gcp:
   max-request-size: 512
   base-url: "http://localhost:4588"
   tls:
-    enabled: false     # FLOCI_GCP_TLS_ENABLED — serve HTTP+HTTPS on the same port via protocol-sniffing proxy
-    self-signed: true  # FLOCI_GCP_TLS_SELF_SIGNED — auto-generate a cert when no cert-path/key-path given
-    https-port: 443    # FLOCI_GCP_TLS_HTTPS_PORT — also bind 443 so GCP SDK default-HTTPS clients reach floci-gcp (0 disables)
+    enabled: false     # FLOCI_GCP_TLS_ENABLED, serve HTTP+HTTPS on the same port via protocol-sniffing proxy
+    self-signed: true  # FLOCI_GCP_TLS_SELF_SIGNED, auto-generate a cert when no cert-path/key-path given
+    https-port: 443    # FLOCI_GCP_TLS_HTTPS_PORT, also bind 443 so GCP SDK default-HTTPS clients reach floci-gcp (0 disables)
     # cert-path: ""    # FLOCI_GCP_TLS_CERT_PATH (PEM certificate file)
     # key-path: ""     # FLOCI_GCP_TLS_KEY_PATH (PEM private key file)
   default-project-id: floci-local

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ quarkus:
       - --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32
       - --initialize-at-run-time=io.floci.gcp.services.cloudkms.KmsCrypto
       # Holds a static SecureRandom; native image refuses one in the image heap.
-      - --initialize-at-run-time=io.floci.gcp.services.gcs.GcsHmacKeyController
+      - --initialize-at-run-time=io.floci.gcp.services.gcs.GcsHmacKeyService
       - --initialize-at-run-time=io.floci.gcp.services.firebaseauth.FirebaseAuthService
       - --initialize-at-run-time=io.floci.gcp.services.cloudsql.CloudSqlPostgresDataPlane
       - --initialize-at-run-time=io.floci.gcp.services.scheduler.SchedulerExpressionParser

--- a/src/test/java/io/floci/gcp/services/gcs/GcsHmacKeyControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsHmacKeyControllerTest.java
@@ -1,0 +1,98 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+/** HMAC keys, the credentials S3-compatible clients use against GCS. */
+@QuarkusTest
+class GcsHmacKeyControllerTest {
+
+    private static final String PROJECT = "test-project";
+    private static final String EMAIL = "compat@test-project.iam.gserviceaccount.com";
+
+    private String createKey() {
+        return given().queryParam("serviceAccountEmail", EMAIL)
+                .when().post("/storage/v1/projects/" + PROJECT + "/hmacKeys")
+                .then().statusCode(200)
+                .body("kind", equalTo("storage#hmacKey"))
+                .body("secret", notNullValue())
+                .body("metadata.state", equalTo("ACTIVE"))
+                .extract().path("metadata.accessId");
+    }
+
+    @Test
+    void createReturnsAnAccessIdAndSecret() {
+        String accessId = createKey();
+        org.junit.jupiter.api.Assertions.assertTrue(accessId.startsWith("GOOG"));
+    }
+
+    @Test
+    void createRequiresAServiceAccountEmail() {
+        given().when().post("/storage/v1/projects/" + PROJECT + "/hmacKeys")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void listIncludesTheCreatedKey() {
+        String accessId = createKey();
+        given().when().get("/storage/v1/projects/" + PROJECT + "/hmacKeys")
+                .then().statusCode(200)
+                .body("kind", equalTo("storage#hmacKeysMetadata"))
+                .body("items.accessId", hasItem(accessId));
+    }
+
+    @Test
+    void getReturnsTheMetadataWithoutTheSecret() {
+        String accessId = createKey();
+        given().when().get("/storage/v1/projects/" + PROJECT + "/hmacKeys/" + accessId)
+                .then().statusCode(200)
+                .body("accessId", equalTo(accessId))
+                .body("state", equalTo("ACTIVE"))
+                .body("serviceAccountEmail", equalTo(EMAIL))
+                .body("secret", org.hamcrest.Matchers.nullValue());
+    }
+
+    @Test
+    void anActiveKeyCannotBeDeleted() {
+        String accessId = createKey();
+        given().when().delete("/storage/v1/projects/" + PROJECT + "/hmacKeys/" + accessId)
+                .then().statusCode(400);
+    }
+
+    @Test
+    void deactivateThenDelete() {
+        String accessId = createKey();
+        given().contentType("application/json").body(Map.of("state", "INACTIVE"))
+                .when().put("/storage/v1/projects/" + PROJECT + "/hmacKeys/" + accessId)
+                .then().statusCode(200)
+                .body("state", equalTo("INACTIVE"));
+
+        given().when().delete("/storage/v1/projects/" + PROJECT + "/hmacKeys/" + accessId)
+                .then().statusCode(204);
+
+        given().when().get("/storage/v1/projects/" + PROJECT + "/hmacKeys/" + accessId)
+                .then().statusCode(404);
+    }
+
+    @Test
+    void anInvalidStateIsRejected() {
+        String accessId = createKey();
+        given().contentType("application/json").body(Map.of("state", "BANANA"))
+                .when().put("/storage/v1/projects/" + PROJECT + "/hmacKeys/" + accessId)
+                .then().statusCode(400);
+    }
+
+    @Test
+    void anUnknownKeyIs404() {
+        given().when().get("/storage/v1/projects/" + PROJECT + "/hmacKeys/GOOG1ENOPE")
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsHmacKeyServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsHmacKeyServiceTest.java
@@ -1,0 +1,95 @@
+package io.floci.gcp.services.gcs;
+
+import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.InMemoryStorage;
+import io.floci.gcp.services.gcs.model.GcsHmacKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** HMAC key lifecycle against the storage backend, independent of the REST surface. */
+class GcsHmacKeyServiceTest {
+
+    private static final String PROJECT = "test-project";
+    private static final String EMAIL = "compat@test-project.iam.gserviceaccount.com";
+
+    private InMemoryStorage<String, GcsHmacKey> store;
+    private GcsHmacKeyService service;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryStorage<>();
+        service = new GcsHmacKeyService(store);
+    }
+
+    @Test
+    void createStoresTheMetadataButNotTheSecret() {
+        GcsHmacKeyService.CreatedKey created = service.create(PROJECT, EMAIL);
+
+        assertNotNull(created.secret());
+        assertFalse(created.secret().isBlank());
+        assertTrue(created.metadata().getAccessId().startsWith("GOOG"));
+        assertEquals("ACTIVE", created.metadata().getState());
+        assertEquals(PROJECT + "/" + created.metadata().getAccessId(), created.metadata().getId());
+
+        GcsHmacKey stored = store.get(created.metadata().getAccessId()).orElseThrow();
+        assertEquals(EMAIL, stored.getServiceAccountEmail());
+    }
+
+    @Test
+    void createRequiresAServiceAccountEmail() {
+        GcpException ex = assertThrows(GcpException.class, () -> service.create(PROJECT, " "));
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void anActiveKeyCannotBeDeleted() {
+        String accessId = service.create(PROJECT, EMAIL).metadata().getAccessId();
+
+        GcpException ex = assertThrows(GcpException.class, () -> service.delete(PROJECT, accessId));
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(store.get(accessId).isPresent());
+    }
+
+    @Test
+    void deactivateThenDeleteRemovesTheKey() {
+        String accessId = service.create(PROJECT, EMAIL).metadata().getAccessId();
+
+        assertEquals("INACTIVE", service.updateState(PROJECT, accessId, "INACTIVE").getState());
+        service.delete(PROJECT, accessId);
+
+        assertTrue(store.get(accessId).isEmpty());
+        GcpException ex = assertThrows(GcpException.class, () -> service.get(PROJECT, accessId));
+        assertEquals(404, ex.getHttpStatus());
+    }
+
+    @Test
+    void stateMustBeActiveOrInactive() {
+        String accessId = service.create(PROJECT, EMAIL).metadata().getAccessId();
+        assertThrows(GcpException.class, () -> service.updateState(PROJECT, accessId, "BANANA"));
+        assertThrows(GcpException.class, () -> service.updateState(PROJECT, accessId, null));
+    }
+
+    @Test
+    void listFiltersByProjectAndServiceAccount() {
+        String mine = service.create(PROJECT, EMAIL).metadata().getAccessId();
+        service.create(PROJECT, "other@test-project.iam.gserviceaccount.com");
+        service.create("other-project", EMAIL);
+
+        assertEquals(2, service.list(PROJECT, null, false).size());
+        assertEquals(1, service.list(PROJECT, EMAIL, false).size());
+        assertEquals(mine, service.list(PROJECT, EMAIL, false).get(0).getAccessId());
+    }
+
+    @Test
+    void aKeyFromAnotherProjectIsNotVisible() {
+        String accessId = service.create("other-project", EMAIL).metadata().getAccessId();
+        GcpException ex = assertThrows(GcpException.class, () -> service.get(PROJECT, accessId));
+        assertEquals(404, ex.getHttpStatus());
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsRewriteRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsRewriteRestIntegrationTest.java
@@ -1,0 +1,129 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/** Multi-call objects.rewrite: done:false + rewriteToken until the copy finishes. */
+@QuarkusTest
+class GcsRewriteRestIntegrationTest {
+
+    private static final String SRC = "rewrite-src-bucket";
+    private static final String DST = "rewrite-dst-bucket";
+    private static final int SIZE = 4096;
+
+    private static void seed() {
+        for (String b : new String[] { SRC, DST }) {
+            given().contentType("application/json").body(Map.of("name", b))
+                    .when().post("/storage/v1/b?project=test-project");
+        }
+        given().contentType("text/plain").body("x".repeat(SIZE))
+                .queryParam("uploadType", "media").queryParam("name", "big")
+                .when().post("/upload/storage/v1/b/" + SRC + "/o");
+    }
+
+    private String rewrite(String dstObject, String extraQuery) {
+        return given()
+                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/" + dstObject + extraQuery)
+                .then().statusCode(200)
+                .extract().asString();
+    }
+
+    @Test
+    void rewriteWithoutALimitCompletesInOneCall() {
+        seed();
+        given()
+                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/one-shot")
+                .then().statusCode(200)
+                .body("kind", equalTo("storage#rewriteResponse"))
+                .body("done", equalTo(true))
+                .body("objectSize", equalTo(String.valueOf(SIZE)))
+                .body("resource.name", equalTo("one-shot"))
+                .body("rewriteToken", nullValue());
+    }
+
+    @Test
+    void aLimitBelowTheObjectSizeYieldsARewriteToken() {
+        seed();
+        given()
+                .queryParam("maxBytesRewrittenPerCall", 1024)
+                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/chunked")
+                .then().statusCode(200)
+                .body("done", equalTo(false))
+                .body("rewriteToken", notNullValue())
+                .body("totalBytesRewritten", not(equalTo(String.valueOf(SIZE))))
+                .body("resource", nullValue());
+    }
+
+    @Test
+    void theDestinationIsNotVisibleUntilTheRewriteCompletes() {
+        seed();
+        given().queryParam("maxBytesRewrittenPerCall", 1024)
+                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/partial")
+                .then().statusCode(200).body("done", equalTo(false));
+
+        given().when().get("/storage/v1/b/" + DST + "/o/partial").then().statusCode(404);
+    }
+
+    @Test
+    void loopingOnTheTokenEventuallyCompletesTheCopy() {
+        seed();
+        String token = given().queryParam("maxBytesRewrittenPerCall", 1024)
+                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/looped")
+                .then().statusCode(200).body("done", equalTo(false))
+                .extract().path("rewriteToken");
+
+        boolean done = false;
+        for (int i = 0; i < 16 && !done; i++) {
+            var response = given()
+                    .queryParam("maxBytesRewrittenPerCall", 1024)
+                    .queryParam("rewriteToken", token)
+                    .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/looped")
+                    .then().statusCode(200).extract();
+            done = response.path("done");
+            token = response.path("rewriteToken");
+        }
+
+        org.junit.jupiter.api.Assertions.assertTrue(done, "rewrite never completed");
+        given().when().get("/storage/v1/b/" + DST + "/o/looped")
+                .then().statusCode(200).body("size", equalTo(String.valueOf(SIZE)));
+    }
+
+    @Test
+    void anUnknownRewriteTokenIsRejected() {
+        seed();
+        given().queryParam("rewriteToken", "not-a-real-token")
+                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/bad-token")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void aFailedCompletingCallLeavesTheTokenUsable() {
+        // Retiring the token before the copy succeeds would make a failed destination
+        // precondition unretryable: the client would be left holding a token the server no
+        // longer knows, and would have to restart the whole rewrite.
+        seed();
+        // Preconditions are captured with the session, so the impossible one is set here and
+        // applies on the call that completes. One chunk short, so the next call is that one.
+        String first = rewrite("retry-dst", "?maxBytesRewrittenPerCall=3000&ifGenerationMatch=999999");
+        String token = io.restassured.path.json.JsonPath.from(first).getString("rewriteToken");
+        org.junit.jupiter.api.Assertions.assertNotNull(token);
+
+        // The completing call fails on the captured precondition.
+        given().when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST
+                        + "/o/retry-dst?rewriteToken=" + token)
+                .then().statusCode(412);
+
+        // The token must still be recognised: the same failure again, not "Invalid rewriteToken".
+        given().when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST
+                        + "/o/retry-dst?rewriteToken=" + token)
+                .then().statusCode(412);
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsRewriteRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsRewriteRestIntegrationTest.java
@@ -11,96 +11,179 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-/** Multi-call objects.rewrite: done:false + rewriteToken until the copy finishes. */
+/**
+ * Multi-call objects.rewrite: done:false + rewriteToken until the copy finishes.
+ *
+ * <p>Per the storage/v1 discovery document, {@code maxBytesRewrittenPerCall} "only applies to
+ * requests where the source and destination span locations and/or storage classes" and "must be
+ * an integral multiple of 1 MiB". So the chunked cases here copy from a STANDARD bucket into a
+ * NEARLINE one, and a same-class copy is asserted to finish in one call regardless of the limit.
+ */
 @QuarkusTest
 class GcsRewriteRestIntegrationTest {
 
     private static final String SRC = "rewrite-src-bucket";
-    private static final String DST = "rewrite-dst-bucket";
-    private static final int SIZE = 4096;
+    private static final String NEARLINE_DST = "rewrite-nearline-dst-bucket";
+    private static final String SAME_CLASS_DST = "rewrite-same-class-dst-bucket";
+    private static final int ONE_MIB = 1024 * 1024;
+    private static final int SIZE = 3 * ONE_MIB;
+    private static boolean seeded;
 
     private static void seed() {
-        for (String b : new String[] { SRC, DST }) {
-            given().contentType("application/json").body(Map.of("name", b))
-                    .when().post("/storage/v1/b?project=test-project");
+        if (seeded) {
+            return;
         }
-        given().contentType("text/plain").body("x".repeat(SIZE))
+        seeded = true;
+        given().contentType("application/json").body(Map.of("name", SRC))
+                .when().post("/storage/v1/b?project=test-project");
+        given().contentType("application/json").body(Map.of("name", NEARLINE_DST, "storageClass", "NEARLINE"))
+                .when().post("/storage/v1/b?project=test-project");
+        given().contentType("application/json").body(Map.of("name", SAME_CLASS_DST))
+                .when().post("/storage/v1/b?project=test-project");
+        given().contentType("application/octet-stream").body(new byte[SIZE])
                 .queryParam("uploadType", "media").queryParam("name", "big")
-                .when().post("/upload/storage/v1/b/" + SRC + "/o");
+                .when().post("/upload/storage/v1/b/" + SRC + "/o")
+                .then().statusCode(200);
     }
 
-    private String rewrite(String dstObject, String extraQuery) {
-        return given()
-                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/" + dstObject + extraQuery)
-                .then().statusCode(200)
-                .extract().asString();
+    private static String rewritePath(String dstBucket, String dstObject) {
+        return "/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + dstBucket + "/o/" + dstObject;
     }
 
     @Test
-    void rewriteWithoutALimitCompletesInOneCall() {
+    void rewriteWithoutALimitCompletesInOneCallAndTakesTheDestinationBucketClass() {
         seed();
         given()
-                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/one-shot")
+                .when().post(rewritePath(NEARLINE_DST, "one-shot"))
                 .then().statusCode(200)
                 .body("kind", equalTo("storage#rewriteResponse"))
                 .body("done", equalTo(true))
                 .body("objectSize", equalTo(String.valueOf(SIZE)))
+                .body("totalBytesRewritten", equalTo(String.valueOf(SIZE)))
                 .body("resource.name", equalTo("one-shot"))
+                .body("resource.storageClass", equalTo("NEARLINE"))
                 .body("rewriteToken", nullValue());
     }
 
     @Test
-    void aLimitBelowTheObjectSizeYieldsARewriteToken() {
+    void aLimitBelowTheObjectSizeYieldsARewriteTokenWhenTheCopySpansStorageClasses() {
         seed();
         given()
-                .queryParam("maxBytesRewrittenPerCall", 1024)
-                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/chunked")
+                .queryParam("maxBytesRewrittenPerCall", ONE_MIB)
+                .when().post(rewritePath(NEARLINE_DST, "chunked"))
                 .then().statusCode(200)
                 .body("done", equalTo(false))
                 .body("rewriteToken", notNullValue())
-                .body("totalBytesRewritten", not(equalTo(String.valueOf(SIZE))))
+                .body("totalBytesRewritten", equalTo(String.valueOf(ONE_MIB)))
+                .body("objectSize", equalTo(String.valueOf(SIZE)))
                 .body("resource", nullValue());
+    }
+
+    @Test
+    void theLimitIsIgnoredWhenSourceAndDestinationShareLocationAndClass() {
+        // "this only applies to requests where the source and destination span locations and/or
+        // storage classes": a STANDARD to STANDARD copy in one location finishes in one call.
+        seed();
+        given()
+                .queryParam("maxBytesRewrittenPerCall", ONE_MIB)
+                .when().post(rewritePath(SAME_CLASS_DST, "same-class"))
+                .then().statusCode(200)
+                .body("done", equalTo(true))
+                .body("rewriteToken", nullValue())
+                .body("resource.storageClass", equalTo("STANDARD"));
+    }
+
+    @Test
+    void aStorageClassInTheBodyMakesTheCopySpanClasses() {
+        // The destination's class can come from the request body rather than the bucket default,
+        // and then the copy spans classes even within one bucket.
+        seed();
+        String token = given()
+                .contentType("application/json").body(Map.of("storageClass", "COLDLINE"))
+                .queryParam("maxBytesRewrittenPerCall", ONE_MIB)
+                .when().post(rewritePath(SAME_CLASS_DST, "body-class"))
+                .then().statusCode(200)
+                .body("done", equalTo(false))
+                .extract().path("rewriteToken");
+
+        boolean done = false;
+        var response = given().queryParam("maxBytesRewrittenPerCall", ONE_MIB).queryParam("rewriteToken", token)
+                .when().post(rewritePath(SAME_CLASS_DST, "body-class")).then().statusCode(200).extract();
+        for (int i = 0; i < 8 && !(done = response.path("done")); i++) {
+            response = given().queryParam("maxBytesRewrittenPerCall", ONE_MIB).queryParam("rewriteToken", token)
+                    .when().post(rewritePath(SAME_CLASS_DST, "body-class")).then().statusCode(200).extract();
+        }
+        org.junit.jupiter.api.Assertions.assertTrue(done, "rewrite never completed");
+        org.junit.jupiter.api.Assertions.assertEquals("COLDLINE", response.path("resource.storageClass"));
+    }
+
+    @Test
+    void aLimitThatIsNotAMultipleOfOneMiBIsRejected() {
+        // "If specified the value must be an integral multiple of 1 MiB (1048576)."
+        seed();
+        given()
+                .queryParam("maxBytesRewrittenPerCall", 1024)
+                .when().post(rewritePath(NEARLINE_DST, "bad-limit"))
+                .then().statusCode(400);
     }
 
     @Test
     void theDestinationIsNotVisibleUntilTheRewriteCompletes() {
         seed();
-        given().queryParam("maxBytesRewrittenPerCall", 1024)
-                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/partial")
+        given().queryParam("maxBytesRewrittenPerCall", ONE_MIB)
+                .when().post(rewritePath(NEARLINE_DST, "partial"))
                 .then().statusCode(200).body("done", equalTo(false));
 
-        given().when().get("/storage/v1/b/" + DST + "/o/partial").then().statusCode(404);
+        given().when().get("/storage/v1/b/" + NEARLINE_DST + "/o/partial").then().statusCode(404);
     }
 
     @Test
     void loopingOnTheTokenEventuallyCompletesTheCopy() {
         seed();
-        String token = given().queryParam("maxBytesRewrittenPerCall", 1024)
-                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/looped")
+        String token = given().queryParam("maxBytesRewrittenPerCall", ONE_MIB)
+                .when().post(rewritePath(NEARLINE_DST, "looped"))
                 .then().statusCode(200).body("done", equalTo(false))
                 .extract().path("rewriteToken");
 
         boolean done = false;
+        int calls = 1;
         for (int i = 0; i < 16 && !done; i++) {
             var response = given()
-                    .queryParam("maxBytesRewrittenPerCall", 1024)
+                    .queryParam("maxBytesRewrittenPerCall", ONE_MIB)
                     .queryParam("rewriteToken", token)
-                    .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/looped")
+                    .when().post(rewritePath(NEARLINE_DST, "looped"))
                     .then().statusCode(200).extract();
             done = response.path("done");
-            token = response.path("rewriteToken");
+            calls++;
         }
 
         org.junit.jupiter.api.Assertions.assertTrue(done, "rewrite never completed");
-        given().when().get("/storage/v1/b/" + DST + "/o/looped")
-                .then().statusCode(200).body("size", equalTo(String.valueOf(SIZE)));
+        org.junit.jupiter.api.Assertions.assertEquals(3, calls, "3 MiB at 1 MiB per call is three calls");
+        given().when().get("/storage/v1/b/" + NEARLINE_DST + "/o/looped")
+                .then().statusCode(200)
+                .body("size", equalTo(String.valueOf(SIZE)))
+                .body("storageClass", equalTo("NEARLINE"));
+    }
+
+    @Test
+    void changingTheLimitMidRewriteInvalidatesTheToken() {
+        // "this value must not change across rewrite calls else you'll get an error that the
+        // rewriteToken is invalid".
+        seed();
+        String token = given().queryParam("maxBytesRewrittenPerCall", ONE_MIB)
+                .when().post(rewritePath(NEARLINE_DST, "changed-limit"))
+                .then().statusCode(200).extract().path("rewriteToken");
+
+        given().queryParam("maxBytesRewrittenPerCall", 2 * ONE_MIB).queryParam("rewriteToken", token)
+                .when().post(rewritePath(NEARLINE_DST, "changed-limit"))
+                .then().statusCode(400);
     }
 
     @Test
     void anUnknownRewriteTokenIsRejected() {
         seed();
         given().queryParam("rewriteToken", "not-a-real-token")
-                .when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST + "/o/bad-token")
+                .when().post(rewritePath(NEARLINE_DST, "bad-token"))
                 .then().statusCode(400);
     }
 
@@ -111,19 +194,22 @@ class GcsRewriteRestIntegrationTest {
         // longer knows, and would have to restart the whole rewrite.
         seed();
         // Preconditions are captured with the session, so the impossible one is set here and
-        // applies on the call that completes. One chunk short, so the next call is that one.
-        String first = rewrite("retry-dst", "?maxBytesRewrittenPerCall=3000&ifGenerationMatch=999999");
-        String token = io.restassured.path.json.JsonPath.from(first).getString("rewriteToken");
-        org.junit.jupiter.api.Assertions.assertNotNull(token);
+        // applies on the call that completes. Two of three MiB, so the next call is that one.
+        String token = given()
+                .queryParam("maxBytesRewrittenPerCall", 2 * ONE_MIB)
+                .queryParam("ifGenerationMatch", 999999)
+                .when().post(rewritePath(NEARLINE_DST, "retry-dst"))
+                .then().statusCode(200).body("done", equalTo(false))
+                .extract().path("rewriteToken");
 
         // The completing call fails on the captured precondition.
-        given().when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST
-                        + "/o/retry-dst?rewriteToken=" + token)
+        given().queryParam("rewriteToken", token)
+                .when().post(rewritePath(NEARLINE_DST, "retry-dst"))
                 .then().statusCode(412);
 
         // The token must still be recognised: the same failure again, not "Invalid rewriteToken".
-        given().when().post("/storage/v1/b/" + SRC + "/o/big/rewriteTo/b/" + DST
-                        + "/o/retry-dst?rewriteToken=" + token)
+        given().queryParam("rewriteToken", token)
+                .when().post(rewritePath(NEARLINE_DST, "retry-dst"))
                 .then().statusCode(412);
     }
 }

--- a/src/test/java/io/floci/gcp/services/gcs/GcsSoftDeleteRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsSoftDeleteRestIntegrationTest.java
@@ -1,0 +1,167 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/** Soft delete: retention policy, softDeleted listing, and objects.restore. */
+@QuarkusTest
+class GcsSoftDeleteRestIntegrationTest {
+
+    private static final String BUCKET = "soft-delete-bucket";
+
+    private static void ensureBucket() {
+        given().contentType("application/json")
+                .body(Map.of("name", BUCKET,
+                        "softDeletePolicy", Map.of("retentionDurationSeconds", "604800")))
+                .when().post("/storage/v1/b?project=test-project");
+    }
+
+    private static String writeObject(String name) {
+        return given().contentType("text/plain").body("bytes")
+                .queryParam("uploadType", "media").queryParam("name", name)
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .extract().path("generation");
+    }
+
+    @Test
+    void bucketReportsItsSoftDeletePolicy() {
+        ensureBucket();
+        given().when().get("/storage/v1/b/" + BUCKET)
+                .then().statusCode(200)
+                .body("softDeletePolicy.retentionDurationSeconds", equalTo("604800"));
+    }
+
+    @Test
+    void aDeletedObjectLeavesTheLiveListing() {
+        ensureBucket();
+        writeObject("gone");
+        given().when().delete("/storage/v1/b/" + BUCKET + "/o/gone").then().statusCode(204);
+        given().when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", not(hasItem("gone")));
+    }
+
+    @Test
+    void aDeletedObjectAppearsInTheSoftDeletedListingWithTimestamps() {
+        ensureBucket();
+        String generation = writeObject("listed");
+        given().when().delete("/storage/v1/b/" + BUCKET + "/o/listed").then().statusCode(204);
+
+        given().queryParam("softDeleted", true)
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", hasItem("listed"))
+                .body("items.find { it.name == 'listed' }.generation", equalTo(generation))
+                .body("items.find { it.name == 'listed' }.softDeleteTime", notNullValue())
+                .body("items.find { it.name == 'listed' }.hardDeleteTime", notNullValue());
+    }
+
+    @Test
+    void restoreBringsTheObjectAndItsBytesBack() {
+        ensureBucket();
+        String generation = writeObject("restore-me");
+        given().when().delete("/storage/v1/b/" + BUCKET + "/o/restore-me").then().statusCode(204);
+
+        given().queryParam("generation", generation)
+                .when().post("/storage/v1/b/" + BUCKET + "/o/restore-me/restore")
+                .then().statusCode(200)
+                .body("name", equalTo("restore-me"));
+
+        given().when().get("/storage/v1/b/" + BUCKET + "/o/restore-me/?alt=media")
+                .then().statusCode(200);
+        given().when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", hasItem("restore-me"));
+    }
+
+    @Test
+    void restoreRequiresAGeneration() {
+        ensureBucket();
+        writeObject("needs-generation");
+        given().when().delete("/storage/v1/b/" + BUCKET + "/o/needs-generation").then().statusCode(204);
+        given().when().post("/storage/v1/b/" + BUCKET + "/o/needs-generation/restore")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void restoringAnUnknownGenerationIs404() {
+        ensureBucket();
+        given().queryParam("generation", "1")
+                .when().post("/storage/v1/b/" + BUCKET + "/o/never-existed/restore")
+                .then().statusCode(404);
+    }
+
+    @Test
+    void aBucketWithoutAPolicyHardDeletes() {
+        String plain = "no-soft-delete-bucket";
+        given().contentType("application/json").body(Map.of("name", plain))
+                .when().post("/storage/v1/b?project=test-project");
+        given().contentType("text/plain").body("bytes")
+                .queryParam("uploadType", "media").queryParam("name", "vanishes")
+                .when().post("/upload/storage/v1/b/" + plain + "/o");
+        given().when().delete("/storage/v1/b/" + plain + "/o/vanishes").then().statusCode(204);
+
+        given().queryParam("softDeleted", true)
+                .when().get("/storage/v1/b/" + plain + "/o")
+                .then().statusCode(200)
+                .body("items", org.hamcrest.Matchers.anyOf(
+                        org.hamcrest.Matchers.nullValue(), org.hamcrest.Matchers.empty()));
+    }
+
+    @Test
+    void generationScopedDeleteIsAlsoRetained() {
+        // "When you delete a noncurrent object, it becomes soft-deleted"
+        // (https://cloud.google.com/storage/docs/soft-delete). google-cloud-storage for Python
+        // sends the loaded generation on every blob.delete(), so a generation-scoped delete that
+        // skipped retention would bypass soft delete entirely for that SDK.
+        ensureBucket();
+        String generation = writeObject("generation-scoped.txt");
+
+        given().queryParam("generation", generation)
+                .when().delete("/storage/v1/b/" + BUCKET + "/o/generation-scoped.txt")
+                .then().statusCode(204);
+
+        given().queryParam("softDeleted", true)
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", hasItem("generation-scoped.txt"));
+
+        given().queryParam("generation", generation)
+                .when().post("/storage/v1/b/" + BUCKET + "/o/generation-scoped.txt/restore")
+                .then().statusCode(200)
+                .body("name", equalTo("generation-scoped.txt"));
+
+        given().when().get("/storage/v1/b/" + BUCKET + "/o/generation-scoped.txt")
+                .then().statusCode(200);
+    }
+
+    @Test
+    void restoringOverALiveObjectRetainsTheDisplacedOne() {
+        // Soft delete exists to stop a delete destroying data, so a restore must not destroy the
+        // live generation it displaces: it goes through the ordinary delete path instead.
+        ensureBucket();
+        String first = writeObject("displaced.txt");
+        given().when().delete("/storage/v1/b/" + BUCKET + "/o/displaced.txt")
+                .then().statusCode(204);
+        String second = writeObject("displaced.txt");
+
+        given().queryParam("generation", first)
+                .when().post("/storage/v1/b/" + BUCKET + "/o/displaced.txt/restore")
+                .then().statusCode(200);
+
+        // The generation that was live at restore time is retained, not gone.
+        given().queryParam("softDeleted", true)
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.generation", hasItem(second));
+    }
+}


### PR DESCRIPTION
## Summary

Three features the compatibility suite had red, plus the two fixes they needed. This is the largest of the split and the last to land.

**Chunked rewrite.** `objects.rewrite` is now multi-call. `maxBytesRewrittenPerCall` below the object size returns `done: false` with a `rewriteToken`, and the client loops until done, which is the path GCS takes for large or class-changing copies and which a single-shot response never exercised. The destination is written only on the completing call, so a partially rewritten object is never visible. The token is tied to its source/destination pair, as GCS ties it.

**HMAC keys** (`/storage/v1/projects/{p}/hmacKeys`) are the credentials S3-compatible clients use against GCS: boto3, the AWS SDKs, gsutil in interop mode. The secret is returned once on create, and a key must be moved to `INACTIVE` before it can be deleted; code that does not handle that 400 gets stuck, so the state machine is emulated rather than short-circuited.

**Soft delete.** A bucket `softDeletePolicy` retains deleted objects under a separate key namespace instead of dropping them: they leave live listings, appear under `?softDeleted=true` with `softDeleteTime`/`hardDeleteTime`, and can be restored by generation via `objects.restore`. On by default in real GCS since 2024, so code written against production may rely on undoing a delete.

Two fixes ride along because they are inseparable from the code above:

- A **generation-scoped delete is retained too**, not only a delete by name. `google-cloud-storage` for Python sends the loaded generation on every `blob.delete()`, so treating that as permanent bypassed soft delete entirely for that SDK and destroyed data a user expected to be recoverable. The Java SDK omits the generation, which is why a Java-only suite would pass over the same feature.
- `GcsHmacKeyController` holds a static `SecureRandom`, which **GraalVM refuses in the image heap**, so it is registered for run-time initialization the way `application.yml` already handles `KmsCrypto` and `FirebaseAuthService`. Without it the native build fails and every compatibility suite gates behind that job.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

- Rewrite: the `storage/v1` discovery document's `objects.rewrite`, whose response carries `kind: storage#rewriteResponse`, `totalBytesRewritten`, `objectSize`, `done`, and `rewriteToken` when incomplete plus `resource` when complete.
- HMAC keys: `projects.hmacKeys` create/list/get/update/delete, `PUT projects/{projectId}/hmacKeys/{accessId}` taking an `HmacKeyMetadata`, whose `state` is documented as "one of ACTIVE, INACTIVE, or DELETED".
- Soft delete: the Cloud Storage soft delete documentation, including the rule this PR's fix implements, "When you delete a noncurrent object, it becomes soft-deleted."

Verified with `google-cloud-storage` 2.47.0 (libraries-bom 26.53.0) for Java and 3.13.1 for Python. The chunked rewrite loop is driven raw in the Python suite because `Blob.rewrite` there never sends `maxBytesRewrittenPerCall`, so the multi-call path cannot be reached through it.

Documents the three deviations that remain: nothing hard-deletes when `hardDeleteTime` passes, HMAC secrets never sign anything, and rewrite holds no partial bytes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`GcsHmacKeyControllerTest`, `GcsRewriteRestIntegrationTest` and `GcsSoftDeleteRestIntegrationTest`, plus SDK-level `GcsChunkedRewriteTest`, `GcsHmacKeyTest`, `GcsSoftDeleteTest` and the three matching `.py` modules. The native image was built locally from this branch to confirm the GraalVM fix (`Finished generating 'floci-gcp-0.8.0-runner'`, `BUILD SUCCESS`).
