### PR TITLE
fix(gcs): reject deletion of non-empty buckets

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsTest.java
@@ -6,6 +6,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class GcsTest {
@@ -138,5 +140,34 @@ class GcsTest {
         assertThat(bucket).isNotNull();
         assertThat(bucket.delete()).isTrue();
         assertThat(storage.get(BUCKET_NAME)).isNull();
+    }
+
+    @Test
+    @Order(10)
+    void rejectsDeletionOfNonEmptyBucket() {
+        String bucketName = TestFixtures.uniqueName("non-empty-bucket");
+        BlobId blobId = BlobId.of(bucketName, "object.txt");
+        byte[] contents = "preserved contents".getBytes(StandardCharsets.UTF_8);
+        try {
+            storage.create(BucketInfo.of(bucketName));
+            storage.create(BlobInfo.newBuilder(blobId).build(), contents);
+
+            assertThatThrownBy(() -> storage.delete(bucketName))
+                    .isInstanceOfSatisfying(StorageException.class,
+                            ex -> assertThat(ex.getCode()).isEqualTo(409));
+
+            assertThat(storage.get(blobId).getContent()).isEqualTo(contents);
+            assertThat(storage.delete(blobId)).isTrue();
+            assertThat(storage.delete(bucketName)).isTrue();
+        } finally {
+            try {
+                storage.delete(blobId);
+            } catch (Exception ignored) {
+            }
+            try {
+                storage.delete(bucketName);
+            } catch (Exception ignored) {
+            }
+        }
     }
 }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsGrpcController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsGrpcController.java
@@ -143,7 +143,7 @@ public class GcsGrpcController extends StorageGrpc.StorageImplBase {
             checkMetageneration(current.getMetageneration(),
                     request.hasIfMetagenerationMatch() ? request.getIfMetagenerationMatch() : null,
                     request.hasIfMetagenerationNotMatch() ? request.getIfMetagenerationNotMatch() : null);
-            if (!service.listObjectVersions(bucketId, null).isEmpty()) {
+            if (service.hasLiveOrVersionedObjects(bucketId)) {
                 throw GcpException.failedPrecondition("Bucket is not empty: " + bucketId);
             }
             service.deleteBucket(bucketId);

--- a/src/main/java/io/floci/gcp/services/gcs/GcsGrpcController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsGrpcController.java
@@ -143,10 +143,9 @@ public class GcsGrpcController extends StorageGrpc.StorageImplBase {
             checkMetageneration(current.getMetageneration(),
                     request.hasIfMetagenerationMatch() ? request.getIfMetagenerationMatch() : null,
                     request.hasIfMetagenerationNotMatch() ? request.getIfMetagenerationNotMatch() : null);
-            if (service.hasLiveOrVersionedObjects(bucketId)) {
+            if (!service.deleteBucketIfEmpty(bucketId)) {
                 throw GcpException.failedPrecondition("Bucket is not empty: " + bucketId);
             }
-            service.deleteBucket(bucketId);
             return Empty.getDefaultInstance();
         });
     }

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -271,18 +271,25 @@ public class GcsService {
 
     public void deleteBucket(String name) {
         LOG.debugf("deleteBucket name=%s", name);
+        if (!deleteBucketIfEmpty(name)) {
+            LOG.warnf("deleteBucket failed: bucket not empty name=%s", name);
+            throw GcpException.alreadyExists("The bucket you tried to delete is not empty.")
+                    .withReason("conflict");
+        }
+    }
+
+    public boolean deleteBucketIfEmpty(String name) {
         synchronized (bucketLock(name)) {
             if (bucketStore.get(name).isEmpty()) {
                 LOG.warnf("deleteBucket failed: bucket not found name=%s", name);
                 throw GcpException.notFound("Bucket not found: " + name);
             }
             if (hasLiveOrVersionedObjects(name)) {
-                LOG.warnf("deleteBucket failed: bucket not empty name=%s", name);
-                throw GcpException.alreadyExists("The bucket you tried to delete is not empty.")
-                        .withReason("conflict");
+                return false;
             }
             purgeSoftDeletedObjects(name);
             bucketStore.delete(name);
+            return true;
         }
     }
 
@@ -617,9 +624,22 @@ public class GcsService {
 
     private boolean isSoftDeletedObject(String storeKey) {
         return objectMetaStore.get(storeKey)
-                .filter(meta -> meta.getGeneration() != null && meta.getSoftDeleteTime() != null)
-                .map(meta -> storeKey.endsWith(SOFT_DELETE_MARKER + meta.getGeneration()))
+                .filter(meta -> meta.getBucket() != null && meta.getName() != null
+                        && meta.getGeneration() != null && meta.getSoftDeleteTime() != null)
+                .map(meta -> storeKey.equals(softDeleteKey(
+                        meta.getBucket(), meta.getName(), meta.getGeneration())))
                 .orElse(false);
+    }
+
+    private static boolean isLiveObjectKey(String storeKey, GcsObjectMeta meta) {
+        return meta.getBucket() != null && meta.getName() != null
+                && storeKey.equals(objectKey(meta.getBucket(), meta.getName()));
+    }
+
+    private static boolean isVersionedObjectKey(String storeKey, GcsObjectMeta meta) {
+        return meta.getBucket() != null && meta.getName() != null && meta.getGeneration() != null
+                && storeKey.equals(
+                        objectKey(meta.getBucket(), meta.getName()) + "\0" + meta.getGeneration());
     }
 
     public boolean isSoftDeleteEnabled(String bucket) {
@@ -1143,13 +1163,13 @@ public class GcsService {
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
         String prefix = bucket + "\0";
-        int prefixLen = prefix.length();
         List<GcsObjectMeta> objects = new ArrayList<>();
         for (String key : objectMetaStore.keys()) {
-            if (!key.startsWith(prefix) || key.indexOf('\0', prefixLen) != -1) {
+            if (!key.startsWith(prefix)) {
                 continue;
             }
             objectMetaStore.get(key)
+                    .filter(meta -> isLiveObjectKey(key, meta))
                     .filter(meta -> isReadableLiveObject(key, meta))
                     .ifPresent(objects::add);
         }
@@ -1163,8 +1183,10 @@ public class GcsService {
             throw GcpException.notFound("Bucket not found: " + bucket);
         }
         String bucketPrefix = bucket + "\0";
-        List<GcsObjectMeta> all = objectMetaStore.scan(k -> k.startsWith(bucketPrefix));
-        List<GcsObjectMeta> result = all.stream()
+        List<GcsObjectMeta> result = objectMetaStore.keys().stream()
+                .filter(key -> key.startsWith(bucketPrefix))
+                .flatMap(key -> objectMetaStore.get(key).stream()
+                        .filter(meta -> isLiveObjectKey(key, meta) || isVersionedObjectKey(key, meta)))
                 .filter(m -> prefix == null || prefix.isBlank() || m.getName() != null && m.getName().startsWith(prefix))
                 .toList();
         LOG.debugf("listObjectVersions bucket=%s count=%d", bucket, result.size());
@@ -1766,6 +1788,11 @@ public class GcsService {
     }
 
     private static String objectKey(String bucket, String objectName) {
+        if (objectName.indexOf('\0') >= 0) {
+            String encodedName = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(objectName.getBytes(StandardCharsets.UTF_8));
+            return bucket + "\0\0" + encodedName;
+        }
         return bucket + "\0" + objectName;
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -112,9 +112,10 @@ public class GcsService {
                 new TypeReference<Map<String, GcsBucket>>() {});
         this.objectMetaStore = storageFactory.createGlobal("gcs-objects", "gcs-objects.json",
                 new TypeReference<Map<String, GcsObjectMeta>>() {});
-        this.generationSequence = new AtomicLong(maxGeneration(objectMetaStore));
         this.objectDataStore = storageFactory.createGlobal("gcs-object-data", "gcs-object-data.json",
                 new TypeReference<Map<String, byte[]>>() {});
+        migrateLegacyObjectKeys();
+        this.generationSequence = new AtomicLong(maxGeneration(objectMetaStore));
         this.aclStore = storageFactory.createGlobal("gcs-acls", "gcs-acls.json",
                 new TypeReference<Map<String, StoredAcl>>() {});
         this.notificationStore = storageFactory.createGlobal("gcs-notifications", "gcs-notifications.json",
@@ -136,8 +137,9 @@ public class GcsService {
             String defaultProjectId) {
         this.bucketStore = bucketStore;
         this.objectMetaStore = objectMetaStore;
-        this.generationSequence = new AtomicLong(maxGeneration(objectMetaStore));
         this.objectDataStore = objectDataStore;
+        migrateLegacyObjectKeys();
+        this.generationSequence = new AtomicLong(maxGeneration(objectMetaStore));
         this.aclStore = aclStore;
         this.defaultProjectId = defaultProjectId;
         this.notificationStore = new io.floci.gcp.core.storage.InMemoryStorage<>();
@@ -617,6 +619,68 @@ public class GcsService {
     // since 2024, so code written against production may rely on being able to undo a delete.
 
     private static final String SOFT_DELETE_MARKER = "\0softDeleted\0";
+
+    private void migrateLegacyObjectKeys() {
+        int migrated = 0;
+        for (String legacyKey : new ArrayList<>(objectMetaStore.keys())) {
+            GcsObjectMeta meta = objectMetaStore.get(legacyKey).orElse(null);
+            String targetKey = legacyMigrationTarget(legacyKey, meta);
+            if (targetKey == null) {
+                continue;
+            }
+            GcsObjectMeta targetMeta = objectMetaStore.get(targetKey).orElse(null);
+            if (targetMeta != null && !sameObjectGeneration(meta, targetMeta)) {
+                LOG.warnf("Cannot migrate legacy GCS object key because target is occupied"
+                                + " bucket=%s name=%s generation=%s",
+                        meta.getBucket(), meta.getName(), meta.getGeneration());
+                continue;
+            }
+            if (objectDataStore.get(targetKey).isEmpty()) {
+                objectDataStore.get(legacyKey)
+                        .ifPresent(data -> objectDataStore.put(targetKey, data));
+            }
+            if (targetMeta == null) {
+                objectMetaStore.put(targetKey, meta);
+            }
+            objectDataStore.delete(legacyKey);
+            objectMetaStore.delete(legacyKey);
+            migrated++;
+        }
+        if (migrated > 0) {
+            objectDataStore.checkpoint();
+            objectMetaStore.checkpoint();
+            LOG.infof("Migrated %d legacy GCS object storage keys", migrated);
+        }
+    }
+
+    private static String legacyMigrationTarget(String storeKey, GcsObjectMeta meta) {
+        if (meta == null || meta.getBucket() == null || meta.getName() == null
+                || meta.getName().indexOf('\0') < 0) {
+            return null;
+        }
+        String legacyLiveKey = legacyObjectKey(meta.getBucket(), meta.getName());
+        if (storeKey.equals(legacyLiveKey)) {
+            return objectKey(meta.getBucket(), meta.getName());
+        }
+        if (meta.getGeneration() == null) {
+            return null;
+        }
+        if (meta.getSoftDeleteTime() != null
+                && storeKey.equals(legacyLiveKey + SOFT_DELETE_MARKER + meta.getGeneration())) {
+            return objectKey(meta.getBucket(), meta.getName())
+                    + SOFT_DELETE_MARKER + meta.getGeneration();
+        }
+        if (storeKey.equals(legacyLiveKey + "\0" + meta.getGeneration())) {
+            return objectKey(meta.getBucket(), meta.getName()) + "\0" + meta.getGeneration();
+        }
+        return null;
+    }
+
+    private static boolean sameObjectGeneration(GcsObjectMeta left, GcsObjectMeta right) {
+        return java.util.Objects.equals(left.getBucket(), right.getBucket())
+                && java.util.Objects.equals(left.getName(), right.getName())
+                && java.util.Objects.equals(left.getGeneration(), right.getGeneration());
+    }
 
     private String softDeleteKey(String bucket, String objectName, String generation) {
         return objectKey(bucket, objectName) + SOFT_DELETE_MARKER + generation;
@@ -1793,6 +1857,10 @@ public class GcsService {
                     .encodeToString(objectName.getBytes(StandardCharsets.UTF_8));
             return bucket + "\0\0" + encodedName;
         }
+        return bucket + "\0" + objectName;
+    }
+
+    private static String legacyObjectKey(String bucket, String objectName) {
         return bucket + "\0" + objectName;
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -558,9 +558,11 @@ public class GcsService {
     }
 
     public boolean deleteObject(String bucket, String objectName, GcsObjectPreconditions preconditions) {
-        synchronized (objectLock(bucket, objectName)) {
-            checkPreconditions(bucket, objectName, preconditions);
-            return deleteObjectLocked(bucket, objectName);
+        synchronized (bucketLock(bucket)) {
+            synchronized (objectLock(bucket, objectName)) {
+                checkPreconditions(bucket, objectName, preconditions);
+                return deleteObjectLocked(bucket, objectName);
+            }
         }
     }
 
@@ -858,8 +860,10 @@ public class GcsService {
 
     public void deleteObjectVersion(String bucket, String objectName, String generation,
             GcsObjectPreconditions preconditions) {
-        synchronized (objectLock(bucket, objectName)) {
-            deleteObjectVersionLocked(bucket, objectName, generation, preconditions);
+        synchronized (bucketLock(bucket)) {
+            synchronized (objectLock(bucket, objectName)) {
+                deleteObjectVersionLocked(bucket, objectName, generation, preconditions);
+            }
         }
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -689,43 +689,45 @@ public class GcsService {
 
     /** Restores a soft-deleted generation back to live, as {@code objects.restore} does. */
     public GcsObjectMeta restoreObject(String bucket, String objectName, String generation) {
-        synchronized (objectLock(bucket, objectName)) {
-            if (generation == null || generation.isBlank()) {
-                throw GcpException.invalidArgument("generation is required to restore an object");
-            }
-            String archiveKey = softDeleteKey(bucket, objectName, generation);
-            GcsObjectMeta archived = objectMetaStore.get(archiveKey)
-                    .orElseThrow(() -> GcpException.notFound(
-                            "Soft-deleted object not found: " + objectName + " generation " + generation));
+        synchronized (bucketLock(bucket)) {
+            synchronized (objectLock(bucket, objectName)) {
+                if (generation == null || generation.isBlank()) {
+                    throw GcpException.invalidArgument("generation is required to restore an object");
+                }
+                String archiveKey = softDeleteKey(bucket, objectName, generation);
+                GcsObjectMeta archived = objectMetaStore.get(archiveKey)
+                        .orElseThrow(() -> GcpException.notFound(
+                                "Soft-deleted object not found: " + objectName + " generation " + generation));
 
-            String key = objectKey(bucket, objectName);
-            // Restoring onto a name that is live again displaces that object, so route it
-            // through the ordinary delete path first: that enforces holds and retention, archives
-            // it when versioning is on, and retains it under the soft delete policy. Writing
-            // straight over it would destroy a live generation, which is the opposite of what
-            // this feature exists to do.
-            if (getLiveObjectMeta(bucket, objectName).isPresent()) {
-                deleteObjectLocked(bucket, objectName);
-            }
-            GcsObjectMeta restored = cloneMeta(archived);
-            restored.setSoftDeleteTime(null);
-            restored.setHardDeleteTime(null);
-            restored.setIsLatest(true);
-            restored.setTimeDeleted(null);
-            restored.setUpdated(nowTimestamp());
+                String key = objectKey(bucket, objectName);
+                // Restoring onto a name that is live again displaces that object, so route it
+                // through the ordinary delete path first: that enforces holds and retention, archives
+                // it when versioning is on, and retains it under the soft delete policy. Writing
+                // straight over it would destroy a live generation, which is the opposite of what
+                // this feature exists to do.
+                if (getLiveObjectMeta(bucket, objectName).isPresent()) {
+                    deleteObjectLocked(bucket, objectName);
+                }
+                GcsObjectMeta restored = cloneMeta(archived);
+                restored.setSoftDeleteTime(null);
+                restored.setHardDeleteTime(null);
+                restored.setIsLatest(true);
+                restored.setTimeDeleted(null);
+                restored.setUpdated(nowTimestamp());
 
-            objectDataStore.get(archiveKey).ifPresent(data -> objectDataStore.put(key, data));
-            objectMetaStore.put(key, restored);
-            objectMetaStore.delete(archiveKey);
-            objectDataStore.delete(archiveKey);
-            // With versioning on, the original delete also left this generation in the noncurrent
-            // namespace. It is live again now, so drop that copy: leaving both would list the same
-            // generation twice, once current and once noncurrent.
-            String versionKey = key + "\0" + generation;
-            objectMetaStore.delete(versionKey);
-            objectDataStore.delete(versionKey);
-            LOG.debugf("restoreObject bucket=%s name=%s generation=%s", bucket, objectName, generation);
-            return restored;
+                objectDataStore.get(archiveKey).ifPresent(data -> objectDataStore.put(key, data));
+                objectMetaStore.put(key, restored);
+                objectMetaStore.delete(archiveKey);
+                objectDataStore.delete(archiveKey);
+                // With versioning on, the original delete also left this generation in the noncurrent
+                // namespace. It is live again now, so drop that copy: leaving both would list the same
+                // generation twice, once current and once noncurrent.
+                String versionKey = key + "\0" + generation;
+                objectMetaStore.delete(versionKey);
+                objectDataStore.delete(versionKey);
+                LOG.debugf("restoreObject bucket=%s name=%s generation=%s", bucket, objectName, generation);
+                return restored;
+            }
         }
     }
 

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -276,13 +276,31 @@ public class GcsService {
                 LOG.warnf("deleteBucket failed: bucket not found name=%s", name);
                 throw GcpException.notFound("Bucket not found: " + name);
             }
-            if (objectMetaStore.keys().stream().anyMatch(key -> key.startsWith(name + "\0"))) {
+            if (hasLiveOrVersionedObjects(name)) {
                 LOG.warnf("deleteBucket failed: bucket not empty name=%s", name);
                 throw GcpException.alreadyExists("The bucket you tried to delete is not empty.")
                         .withReason("conflict");
             }
+            purgeSoftDeletedObjects(name);
             bucketStore.delete(name);
         }
+    }
+
+    /** Soft-deleted objects do not keep a bucket from being deleted. */
+    public boolean hasLiveOrVersionedObjects(String bucket) {
+        String bucketPrefix = bucket + "\0";
+        return objectMetaStore.keys().stream()
+                .anyMatch(key -> key.startsWith(bucketPrefix) && !key.contains(SOFT_DELETE_MARKER));
+    }
+
+    private void purgeSoftDeletedObjects(String bucket) {
+        String bucketPrefix = bucket + "\0";
+        objectMetaStore.keys().stream()
+                .filter(key -> key.startsWith(bucketPrefix) && key.contains(SOFT_DELETE_MARKER))
+                .forEach(key -> {
+                    objectMetaStore.delete(key);
+                    objectDataStore.delete(key);
+                });
     }
 
     public List<GcsBucket> listBuckets(String projectId) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -78,6 +78,7 @@ public class GcsService {
                 }
             });
     private final ConcurrentHashMap<String, GcsStreamingUpload> streamingUploads = new ConcurrentHashMap<>();
+    private final Object[] bucketLocks = createObjectLocks();
     private final Object[] objectLocks = createObjectLocks();
     private final Object[] uploadLocks = createObjectLocks();
     private final AtomicLong generationSequence;
@@ -270,11 +271,18 @@ public class GcsService {
 
     public void deleteBucket(String name) {
         LOG.debugf("deleteBucket name=%s", name);
-        if (bucketStore.get(name).isEmpty()) {
-            LOG.warnf("deleteBucket failed: bucket not found name=%s", name);
-            throw GcpException.notFound("Bucket not found: " + name);
+        synchronized (bucketLock(name)) {
+            if (bucketStore.get(name).isEmpty()) {
+                LOG.warnf("deleteBucket failed: bucket not found name=%s", name);
+                throw GcpException.notFound("Bucket not found: " + name);
+            }
+            if (objectMetaStore.keys().stream().anyMatch(key -> key.startsWith(name + "\0"))) {
+                LOG.warnf("deleteBucket failed: bucket not empty name=%s", name);
+                throw GcpException.alreadyExists("The bucket you tried to delete is not empty.")
+                        .withReason("conflict");
+            }
+            bucketStore.delete(name);
         }
-        bucketStore.delete(name);
     }
 
     public List<GcsBucket> listBuckets(String projectId) {
@@ -313,10 +321,12 @@ public class GcsService {
     public GcsObjectMeta putObject(String bucket, String objectName, String contentType, byte[] data,
             GcsCustomerEncryption customerEncryption, Map<String, String> userMetadata,
             GcsObjectMeta metadataTemplate, GcsObjectPreconditions preconditions, String baseUrl) {
-        synchronized (objectLock(bucket, objectName)) {
-            checkPreconditions(bucket, objectName, preconditions);
-            return putObjectLocked(bucket, objectName, contentType, data, customerEncryption,
-                    userMetadata, metadataTemplate, baseUrl);
+        synchronized (bucketLock(bucket)) {
+            synchronized (objectLock(bucket, objectName)) {
+                checkPreconditions(bucket, objectName, preconditions);
+                return putObjectLocked(bucket, objectName, contentType, data, customerEncryption,
+                        userMetadata, metadataTemplate, baseUrl);
+            }
         }
     }
 
@@ -1701,6 +1711,10 @@ public class GcsService {
 
     private Object objectLock(String bucket, String objectName) {
         return objectLocks[objectLockIndex(bucket, objectName)];
+    }
+
+    private Object bucketLock(String bucket) {
+        return bucketLocks[Math.floorMod(bucket.hashCode(), bucketLocks.length)];
     }
 
     private int objectLockIndex(String bucket, String objectName) {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -290,13 +290,13 @@ public class GcsService {
     public boolean hasLiveOrVersionedObjects(String bucket) {
         String bucketPrefix = bucket + "\0";
         return objectMetaStore.keys().stream()
-                .anyMatch(key -> key.startsWith(bucketPrefix) && !key.contains(SOFT_DELETE_MARKER));
+                .anyMatch(key -> key.startsWith(bucketPrefix) && !isSoftDeletedObject(key));
     }
 
     private void purgeSoftDeletedObjects(String bucket) {
         String bucketPrefix = bucket + "\0";
         objectMetaStore.keys().stream()
-                .filter(key -> key.startsWith(bucketPrefix) && key.contains(SOFT_DELETE_MARKER))
+                .filter(key -> key.startsWith(bucketPrefix) && isSoftDeletedObject(key))
                 .forEach(key -> {
                     objectMetaStore.delete(key);
                     objectDataStore.delete(key);
@@ -615,6 +615,13 @@ public class GcsService {
         return objectKey(bucket, objectName) + SOFT_DELETE_MARKER + generation;
     }
 
+    private boolean isSoftDeletedObject(String storeKey) {
+        return objectMetaStore.get(storeKey)
+                .filter(meta -> meta.getGeneration() != null && meta.getSoftDeleteTime() != null)
+                .map(meta -> storeKey.endsWith(SOFT_DELETE_MARKER + meta.getGeneration()))
+                .orElse(false);
+    }
+
     public boolean isSoftDeleteEnabled(String bucket) {
         return softDeleteRetentionSeconds(bucket) > 0;
     }
@@ -673,7 +680,7 @@ public class GcsService {
         String bucketPrefix = objectKey(bucket, "");
         List<GcsObjectMeta> out = new ArrayList<>();
         for (String storeKey : objectMetaStore.keys()) {
-            if (!storeKey.startsWith(bucketPrefix) || !storeKey.contains(SOFT_DELETE_MARKER)) {
+            if (!storeKey.startsWith(bucketPrefix) || !isSoftDeletedObject(storeKey)) {
                 continue;
             }
             objectMetaStore.get(storeKey).ifPresent(meta -> {

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -45,6 +45,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -621,30 +622,59 @@ public class GcsService {
     private static final String SOFT_DELETE_MARKER = "\0softDeleted\0";
 
     private void migrateLegacyObjectKeys() {
-        int migrated = 0;
-        for (String legacyKey : new ArrayList<>(objectMetaStore.keys())) {
-            GcsObjectMeta meta = objectMetaStore.get(legacyKey).orElse(null);
-            String targetKey = legacyMigrationTarget(legacyKey, meta);
-            if (targetKey == null) {
-                continue;
+        List<String> pending = new ArrayList<>();
+        for (String storeKey : objectMetaStore.keys()) {
+            GcsObjectMeta meta = objectMetaStore.get(storeKey).orElse(null);
+            if (legacyMigrationTarget(storeKey, meta) != null) {
+                pending.add(storeKey);
             }
-            GcsObjectMeta targetMeta = objectMetaStore.get(targetKey).orElse(null);
-            if (targetMeta != null && !sameObjectGeneration(meta, targetMeta)) {
+        }
+
+        int migrated = 0;
+        boolean progressed;
+        do {
+            progressed = false;
+            for (var iterator = pending.iterator(); iterator.hasNext();) {
+                String legacyKey = iterator.next();
+                GcsObjectMeta meta = objectMetaStore.get(legacyKey).orElse(null);
+                String targetKey = legacyMigrationTarget(legacyKey, meta);
+                if (targetKey == null) {
+                    iterator.remove();
+                    continue;
+                }
+                GcsObjectMeta targetMeta = objectMetaStore.get(targetKey).orElse(null);
+                boolean matchingTarget = targetMeta != null && sameObjectGeneration(meta, targetMeta);
+                if (targetMeta != null && !matchingTarget) {
+                    continue;
+                }
+                Optional<byte[]> legacyData = objectDataStore.get(legacyKey);
+                Optional<byte[]> targetData = objectDataStore.get(targetKey);
+                if (targetData.isPresent()
+                        && (legacyData.isPresent() && !Arrays.equals(legacyData.get(), targetData.get())
+                                || legacyData.isEmpty() && !matchingTarget)) {
+                    continue;
+                }
+                if (targetData.isEmpty()) {
+                    legacyData.ifPresent(data -> objectDataStore.put(targetKey, data));
+                }
+                if (targetMeta == null) {
+                    objectMetaStore.put(targetKey, meta);
+                }
+                objectDataStore.delete(legacyKey);
+                objectMetaStore.delete(legacyKey);
+                iterator.remove();
+                migrated++;
+                progressed = true;
+            }
+        } while (progressed && !pending.isEmpty());
+
+        for (String legacyKey : pending) {
+            GcsObjectMeta meta = objectMetaStore.get(legacyKey).orElse(null);
+            if (meta != null) {
                 LOG.warnf("Cannot migrate legacy GCS object key because target is occupied"
                                 + " bucket=%s name=%s generation=%s",
                         meta.getBucket(), meta.getName(), meta.getGeneration());
-                continue;
             }
-            if (objectDataStore.get(targetKey).isEmpty()) {
-                objectDataStore.get(legacyKey)
-                        .ifPresent(data -> objectDataStore.put(targetKey, data));
-            }
-            if (targetMeta == null) {
-                objectMetaStore.put(targetKey, meta);
-            }
-            objectDataStore.delete(legacyKey);
-            objectMetaStore.delete(legacyKey);
-            migrated++;
         }
         if (migrated > 0) {
             objectDataStore.checkpoint();

--- a/src/main/java/io/floci/gcp/services/gcs/GcsService.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsService.java
@@ -1042,12 +1042,14 @@ public class GcsService {
             String dstBucket, String dstObject, GcsObjectMeta destinationTemplate,
             GcsObjectPreconditions preconditions, String baseUrl) {
         LOG.debugf("copyObject src=%s/%s dst=%s/%s", srcBucket, srcObject, dstBucket, dstObject);
-        // Read the source before taking the destination lock. Nesting two
+        // Read the source before taking the destination locks. Nesting two
         // stripe locks could deadlock with a copy running in the other direction.
         var src = getObjectForDownload(srcBucket, srcObject, srcGeneration, GcsCustomerEncryption.none());
-        synchronized (objectLock(dstBucket, dstObject)) {
-            checkPreconditions(dstBucket, dstObject, preconditions);
-            return copyObjectLocked(src, dstBucket, dstObject, destinationTemplate, baseUrl);
+        synchronized (bucketLock(dstBucket)) {
+            synchronized (objectLock(dstBucket, dstObject)) {
+                checkPreconditions(dstBucket, dstObject, preconditions);
+                return copyObjectLocked(src, dstBucket, dstObject, destinationTemplate, baseUrl);
+            }
         }
     }
 
@@ -1106,19 +1108,21 @@ public class GcsService {
             throw GcpException.invalidArgument("Source and destination object names must be different.");
         }
 
-        int sourceLockIndex = objectLockIndex(bucket, srcObject);
-        int destinationLockIndex = objectLockIndex(bucket, dstObject);
-        // Lock stripes in a stable order so opposite-direction moves cannot deadlock.
-        synchronized (objectLocks[Math.min(sourceLockIndex, destinationLockIndex)]) {
-            synchronized (objectLocks[Math.max(sourceLockIndex, destinationLockIndex)]) {
-                var source = getObjectForDownload(bucket, srcObject, null, GcsCustomerEncryption.none());
-                checkPreconditions(Optional.of(source.meta()), sourcePreconditions);
-                checkObjectMutable(source.meta());
-                checkPreconditions(bucket, dstObject, destinationPreconditions);
+        synchronized (bucketLock(bucket)) {
+            int sourceLockIndex = objectLockIndex(bucket, srcObject);
+            int destinationLockIndex = objectLockIndex(bucket, dstObject);
+            // Lock stripes in a stable order so opposite-direction moves cannot deadlock.
+            synchronized (objectLocks[Math.min(sourceLockIndex, destinationLockIndex)]) {
+                synchronized (objectLocks[Math.max(sourceLockIndex, destinationLockIndex)]) {
+                    var source = getObjectForDownload(bucket, srcObject, null, GcsCustomerEncryption.none());
+                    checkPreconditions(Optional.of(source.meta()), sourcePreconditions);
+                    checkObjectMutable(source.meta());
+                    checkPreconditions(bucket, dstObject, destinationPreconditions);
 
-                GcsObjectMeta moved = copyObjectLocked(source, bucket, dstObject, baseUrl);
-                deleteObjectLocked(bucket, srcObject);
-                return moved;
+                    GcsObjectMeta moved = copyObjectLocked(source, bucket, dstObject, baseUrl);
+                    deleteObjectLocked(bucket, srcObject);
+                    return moved;
+                }
             }
         }
     }

--- a/src/test/java/io/floci/gcp/services/gcs/GcsBucketDeletionRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsBucketDeletionRestIntegrationTest.java
@@ -1,0 +1,37 @@
+package io.floci.gcp.services.gcs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class GcsBucketDeletionRestIntegrationTest {
+
+    private static final String BUCKET = "non-empty-bucket-delete";
+
+    @Test
+    void rejectsDeletionOfNonEmptyBucketWithConflict() {
+        given()
+                .contentType("application/json")
+                .body(Map.of("name", BUCKET))
+                .when().post("/storage/v1/b?project=test-project")
+                .then().statusCode(200);
+
+        given()
+                .queryParam("uploadType", "media")
+                .queryParam("name", "object.txt")
+                .contentType("text/plain")
+                .body("contents")
+                .when().post("/upload/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200);
+
+        given()
+                .when().delete("/storage/v1/b/" + BUCKET)
+                .then()
+                .statusCode(409)
+                .body("error.errors[0].reason", org.hamcrest.Matchers.equalTo("conflict"));
+    }
+}

--- a/src/test/java/io/floci/gcp/services/gcs/GcsGrpcControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsGrpcControllerTest.java
@@ -1,6 +1,7 @@
 package io.floci.gcp.services.gcs;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
 import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.BidiWriteObjectResponse;
@@ -8,6 +9,7 @@ import com.google.storage.v2.Bucket;
 import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.ComposeObjectRequest;
 import com.google.storage.v2.CreateBucketRequest;
+import com.google.storage.v2.DeleteBucketRequest;
 import com.google.storage.v2.GetBucketRequest;
 import com.google.storage.v2.ListBucketsRequest;
 import com.google.storage.v2.ListBucketsResponse;
@@ -39,6 +41,7 @@ import java.util.zip.CRC32C;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -329,6 +332,20 @@ class GcsGrpcControllerTest {
 
         assertNull(response.error);
         assertEquals("true", response.single().getMetadataOrThrow("updated"));
+    }
+
+    @Test
+    void deleteNonEmptyBucketReturnsFailedPrecondition() {
+        createBucket("non-empty-delete-bucket");
+        service.putObject("non-empty-delete-bucket", "object", "text/plain", new byte[] {1}, BASE_URL);
+
+        RecordingObserver<Empty> response = new RecordingObserver<>();
+        controller.deleteBucket(DeleteBucketRequest.newBuilder()
+                .setName("projects/_/buckets/non-empty-delete-bucket")
+                .build(), response);
+
+        assertEquals(Status.Code.FAILED_PRECONDITION, Status.fromThrowable(response.error).getCode());
+        assertNotNull(service.getBucket("non-empty-delete-bucket"));
     }
 
     private void createBucket(String name) {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsGrpcControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsGrpcControllerTest.java
@@ -348,6 +348,22 @@ class GcsGrpcControllerTest {
         assertNotNull(service.getBucket("non-empty-delete-bucket"));
     }
 
+    @Test
+    void deleteBucketWithOnlySoftDeletedObjectsSucceeds() {
+        service.createBucket("soft-deleted-delete-bucket", "test-project", BASE_URL,
+                Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));
+        service.putObject("soft-deleted-delete-bucket", "object", "text/plain", new byte[] {1}, BASE_URL);
+        service.deleteObject("soft-deleted-delete-bucket", "object");
+
+        RecordingObserver<Empty> response = new RecordingObserver<>();
+        controller.deleteBucket(DeleteBucketRequest.newBuilder()
+                .setName("projects/_/buckets/soft-deleted-delete-bucket")
+                .build(), response);
+
+        assertNull(response.error);
+        assertEquals(1, response.values.size());
+    }
+
     private void createBucket(String name) {
         service.createBucket(name, "test-project", BASE_URL, Map.of());
     }

--- a/src/test/java/io/floci/gcp/services/gcs/GcsGrpcControllerTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsGrpcControllerTest.java
@@ -37,12 +37,18 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.CRC32C;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GcsGrpcControllerTest {
@@ -349,6 +355,43 @@ class GcsGrpcControllerTest {
     }
 
     @Test
+    void deleteBucketReturnsFailedPreconditionWhenUploadWinsRace() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        service = new GcsService(new InMemoryStorage<>(),
+                new BlockingFirstPutStorage<>(metadataWriteStarted, allowMetadataWrite),
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        controller = new GcsGrpcController(service, BASE_URL);
+        createBucket("concurrent-delete-bucket");
+
+        var executor = Executors.newFixedThreadPool(2);
+        try {
+            var upload = executor.submit(() -> service.putObject(
+                    "concurrent-delete-bucket", "object", "text/plain", new byte[]{1}, BASE_URL));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            RecordingObserver<Empty> response = new RecordingObserver<>();
+            var deletion = executor.submit(() -> controller.deleteBucket(DeleteBucketRequest.newBuilder()
+                    .setName("projects/_/buckets/concurrent-delete-bucket")
+                    .build(), response));
+            assertThrows(TimeoutException.class,
+                    () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            upload.get(5, TimeUnit.SECONDS);
+            deletion.get(5, TimeUnit.SECONDS);
+
+            assertEquals(Status.Code.FAILED_PRECONDITION,
+                    Status.fromThrowable(response.error).getCode());
+            assertNotNull(service.getBucket("concurrent-delete-bucket"));
+            assertArrayEquals(new byte[]{1}, service.getObjectData("concurrent-delete-bucket", "object"));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void deleteBucketWithOnlySoftDeletedObjectsSucceeds() {
         service.createBucket("soft-deleted-delete-bucket", "test-project", BASE_URL,
                 Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));
@@ -387,6 +430,33 @@ class GcsGrpcControllerTest {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         responses.forEach(response -> output.writeBytes(response.getChecksummedData().getContent().toByteArray()));
         return output.toByteArray();
+    }
+
+    private static final class BlockingFirstPutStorage<K, V> extends InMemoryStorage<K, V> {
+        private final CountDownLatch putStarted;
+        private final CountDownLatch allowPut;
+        private final AtomicBoolean blockFirstPut = new AtomicBoolean(true);
+
+        private BlockingFirstPutStorage(CountDownLatch putStarted, CountDownLatch allowPut) {
+            this.putStarted = putStarted;
+            this.allowPut = allowPut;
+        }
+
+        @Override
+        public void put(K key, V value) {
+            if (blockFirstPut.compareAndSet(true, false)) {
+                putStarted.countDown();
+                try {
+                    if (!allowPut.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("timed out waiting to publish object metadata");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("interrupted while publishing object metadata", e);
+                }
+            }
+            super.put(key, value);
+        }
     }
 
     private static final class RecordingObserver<T> implements StreamObserver<T> {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -474,6 +474,44 @@ class GcsServiceTest {
     }
 
     @Test
+    void deleteBucketWaitsForARestoreToPublishMetadata() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        var metadataStore = new ArmableBlockingPutStorage<String, GcsObjectMeta>(
+                metadataWriteStarted, allowMetadataWrite);
+        service = new GcsService(new InMemoryStorage<>(), metadataStore,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        service.createBucket("bucket", "p1", BASE_URL,
+                Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));
+        GcsObjectMeta object = service.putObject("bucket", "object.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        service.deleteObject("bucket", "object.txt");
+        metadataStore.blockNextPut();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var restore = executor.submit(() -> service.restoreObject(
+                    "bucket", "object.txt", object.getGeneration()));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var deletion = executor.submit(() -> service.deleteBucket("bucket"));
+            assertThrows(TimeoutException.class, () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            restore.get(5, TimeUnit.SECONDS);
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> deletion.get(5, TimeUnit.SECONDS));
+            GcpException deletionException = assertInstanceOf(GcpException.class, ex.getCause());
+            assertEquals("conflict", deletionException.getReason());
+            assertArrayEquals(new byte[]{1}, service.getObjectData(
+                    "bucket", "object.txt", GcsCustomerEncryption.none()));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void concurrentOverwriteNeverMixesGenerations() throws Exception {
         service.createBucket("race-bucket", "p1", BASE_URL, Map.of());
         var payloads = Map.of(

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -367,6 +367,33 @@ class GcsServiceTest {
     }
 
     @Test
+    void softDeleteKeyDoesNotAliasLiveObjectName() {
+        service.createBucket("bucket", "p1", BASE_URL,
+                Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));
+        GcsObjectMeta deleted = service.putObject("bucket", "object", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        String liveObjectName = "object\0softDeleted\0" + deleted.getGeneration();
+        service.putObject("bucket", liveObjectName, "text/plain", new byte[]{2},
+                GcsCustomerEncryption.none(), BASE_URL);
+
+        service.deleteObject("bucket", "object");
+
+        assertArrayEquals(new byte[]{2},
+                service.getObjectData("bucket", liveObjectName, GcsCustomerEncryption.none()));
+        assertEquals(List.of(liveObjectName), service.listObjects("bucket").stream()
+                .map(GcsObjectMeta::getName)
+                .toList());
+        assertEquals(List.of(liveObjectName), service.listObjectVersions("bucket", null).stream()
+                .map(GcsObjectMeta::getName)
+                .toList());
+        assertEquals(List.of("object"), service.listSoftDeletedObjects("bucket", null).stream()
+                .map(GcsObjectMeta::getName)
+                .toList());
+        GcpException ex = assertThrows(GcpException.class, () -> service.deleteBucket("bucket"));
+        assertEquals("conflict", ex.getReason());
+    }
+
+    @Test
     void deleteBucketWithOnlySoftDeletedObjectsPurgesTheirArchivedState() {
         service.createBucket("bucket", "p1", BASE_URL,
                 Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -351,6 +351,22 @@ class GcsServiceTest {
     }
 
     @Test
+    void softDeleteMarkerInLiveObjectNameDoesNotBypassNonEmptyCheck() {
+        String objectName = "live\0softDeleted\0object.txt";
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        service.putObject("bucket", objectName, "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.deleteBucket("bucket"));
+
+        assertEquals("conflict", ex.getReason());
+        assertArrayEquals(new byte[]{1},
+                service.getObjectData("bucket", objectName, GcsCustomerEncryption.none()));
+        assertTrue(service.listSoftDeletedObjects("bucket", null).isEmpty());
+    }
+
+    @Test
     void deleteBucketWithOnlySoftDeletedObjectsPurgesTheirArchivedState() {
         service.createBucket("bucket", "p1", BASE_URL,
                 Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -400,6 +400,80 @@ class GcsServiceTest {
     }
 
     @Test
+    void deleteBucketWaitsForACopyToPublishMetadata() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        var metadataStore = new ArmableBlockingPutStorage<String, GcsObjectMeta>(
+                metadataWriteStarted, allowMetadataWrite);
+        service = new GcsService(new InMemoryStorage<>(), metadataStore,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        service.createBucket("source-bucket", "p1", BASE_URL, Map.of());
+        service.createBucket("destination-bucket", "p1", BASE_URL, Map.of());
+        service.putObject("source-bucket", "source.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        metadataStore.blockNextPut();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var copy = executor.submit(() -> service.copyObject(
+                    "source-bucket", "source.txt", "destination-bucket", "copy.txt", BASE_URL));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var deletion = executor.submit(() -> service.deleteBucket("destination-bucket"));
+            assertThrows(TimeoutException.class, () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            copy.get(5, TimeUnit.SECONDS);
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> deletion.get(5, TimeUnit.SECONDS));
+            GcpException deletionException = assertInstanceOf(GcpException.class, ex.getCause());
+            assertEquals("conflict", deletionException.getReason());
+            assertArrayEquals(new byte[]{1}, service.getObjectData(
+                    "destination-bucket", "copy.txt", GcsCustomerEncryption.none()));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void deleteBucketWaitsForAMoveToPublishMetadata() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        var metadataStore = new ArmableBlockingPutStorage<String, GcsObjectMeta>(
+                metadataWriteStarted, allowMetadataWrite);
+        service = new GcsService(new InMemoryStorage<>(), metadataStore,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        service.putObject("bucket", "source.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        metadataStore.blockNextPut();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var move = executor.submit(() -> service.moveObject(
+                    "bucket", "source.txt", "moved.txt",
+                    GcsObjectPreconditions.NONE, GcsObjectPreconditions.NONE, BASE_URL));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var deletion = executor.submit(() -> service.deleteBucket("bucket"));
+            assertThrows(TimeoutException.class, () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            move.get(5, TimeUnit.SECONDS);
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> deletion.get(5, TimeUnit.SECONDS));
+            GcpException deletionException = assertInstanceOf(GcpException.class, ex.getCause());
+            assertEquals("conflict", deletionException.getReason());
+            assertArrayEquals(new byte[]{1}, service.getObjectData(
+                    "bucket", "moved.txt", GcsCustomerEncryption.none()));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void concurrentOverwriteNeverMixesGenerations() throws Exception {
         service.createBucket("race-bucket", "p1", BASE_URL, Map.of());
         var payloads = Map.of(
@@ -446,6 +520,37 @@ class GcsServiceTest {
         @Override
         public void put(K key, V value) {
             if (blockFirstPut.compareAndSet(true, false)) {
+                putStarted.countDown();
+                try {
+                    if (!allowPut.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("timed out waiting to publish object metadata");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("interrupted while publishing object metadata", e);
+                }
+            }
+            super.put(key, value);
+        }
+    }
+
+    private static final class ArmableBlockingPutStorage<K, V> extends InMemoryStorage<K, V> {
+        private final CountDownLatch putStarted;
+        private final CountDownLatch allowPut;
+        private final AtomicBoolean blockNextPut = new AtomicBoolean();
+
+        private ArmableBlockingPutStorage(CountDownLatch putStarted, CountDownLatch allowPut) {
+            this.putStarted = putStarted;
+            this.allowPut = allowPut;
+        }
+
+        private void blockNextPut() {
+            blockNextPut.set(true);
+        }
+
+        @Override
+        public void put(K key, V value) {
+            if (blockNextPut.compareAndSet(true, false)) {
                 putStarted.countDown();
                 try {
                     if (!allowPut.await(5, TimeUnit.SECONDS)) {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -22,8 +22,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -32,6 +36,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -395,6 +401,51 @@ class GcsServiceTest {
     }
 
     @Test
+    void legacyNulObjectKeyMigrationResolvesLegacyKeyCollisionInOneRestart() {
+        StorageBackend<String, GcsObjectMeta> metadata = new OrderedStorage<>();
+        StorageBackend<String, byte[]> data = new OrderedStorage<>();
+        String firstName = "legacy\0object";
+        String firstLegacyKey = "bucket\0" + firstName;
+        String firstTargetKey = encodedObjectKey("bucket", firstName);
+        String collidingName = "\0" + Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(firstName.getBytes(StandardCharsets.UTF_8));
+        String collidingLegacyKey = "bucket\0" + collidingName;
+        assertEquals(firstTargetKey, collidingLegacyKey);
+        putLegacyObject(metadata, data, firstLegacyKey,
+                storedObject("bucket", firstName, "1", true), new byte[]{1});
+        putLegacyObject(metadata, data, collidingLegacyKey,
+                storedObject("bucket", collidingName, "2", true), new byte[]{2});
+
+        GcsService restarted = new GcsService(
+                new InMemoryStorage<>(), metadata, data, new InMemoryStorage<>(), "test-project");
+
+        assertArrayEquals(new byte[]{1}, restarted.getObjectData("bucket", firstName));
+        assertArrayEquals(new byte[]{2}, restarted.getObjectData("bucket", collidingName));
+        assertTrue(metadata.get(firstLegacyKey).isEmpty());
+        assertEquals(firstName, metadata.get(firstTargetKey).orElseThrow().getName());
+    }
+
+    @Test
+    void legacyNulObjectKeyMigrationDoesNotAcceptMismatchedOrphanTargetData() {
+        StorageBackend<String, GcsObjectMeta> metadata = new InMemoryStorage<>();
+        StorageBackend<String, byte[]> data = new InMemoryStorage<>();
+        String objectName = "legacy\0object";
+        String legacyKey = "bucket\0" + objectName;
+        String migratedKey = encodedObjectKey("bucket", objectName);
+        GcsObjectMeta legacyMeta = storedObject("bucket", objectName, "1", true);
+        putLegacyObject(metadata, data, legacyKey, legacyMeta, new byte[]{1});
+        data.put(migratedKey, new byte[]{2});
+
+        new GcsService(
+                new InMemoryStorage<>(), metadata, data, new InMemoryStorage<>(), "test-project");
+
+        assertSame(legacyMeta, metadata.get(legacyKey).orElseThrow());
+        assertArrayEquals(new byte[]{1}, data.get(legacyKey).orElseThrow());
+        assertTrue(metadata.get(migratedKey).isEmpty());
+        assertArrayEquals(new byte[]{2}, data.get(migratedKey).orElseThrow());
+    }
+
+    @Test
     void legacyNulObjectKeyMigrationDoesNotOverwriteConflictingTarget() {
         StorageBackend<String, GcsObjectMeta> metadata = new InMemoryStorage<>();
         StorageBackend<String, byte[]> data = new InMemoryStorage<>();
@@ -433,6 +484,11 @@ class GcsServiceTest {
         metadata.put(key, meta);
     }
 
+    private static String encodedObjectKey(String bucket, String objectName) {
+        return bucket + "\0\0" + Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(objectName.getBytes(StandardCharsets.UTF_8));
+    }
+
     private static <V> StorageBackend<String, V> openMigrationStorage(
             LegacyMigrationStorageMode mode, Path root, String name,
             TypeReference<Map<String, V>> type) {
@@ -456,6 +512,51 @@ class GcsServiceTest {
         PERSISTENT,
         HYBRID,
         WAL
+    }
+
+    private static final class OrderedStorage<V> implements StorageBackend<String, V> {
+        private final Map<String, V> values = new LinkedHashMap<>();
+
+        @Override
+        public void put(String key, V value) {
+            values.put(key, value);
+        }
+
+        @Override
+        public Optional<V> get(String key) {
+            return Optional.ofNullable(values.get(key));
+        }
+
+        @Override
+        public void delete(String key) {
+            values.remove(key);
+        }
+
+        @Override
+        public List<V> scan(Predicate<String> keyFilter) {
+            return values.entrySet().stream()
+                    .filter(entry -> keyFilter.test(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .collect(Collectors.toCollection(java.util.ArrayList::new));
+        }
+
+        @Override
+        public Set<String> keys() {
+            return new LinkedHashSet<>(values.keySet());
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void load() {
+        }
+
+        @Override
+        public void clear() {
+            values.clear();
+        }
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -351,6 +351,22 @@ class GcsServiceTest {
     }
 
     @Test
+    void deleteBucketWithOnlySoftDeletedObjectsPurgesTheirArchivedState() {
+        service.createBucket("bucket", "p1", BASE_URL,
+                Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));
+        service.putObject("bucket", "obj.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        service.deleteObject("bucket", "obj.txt");
+
+        assertEquals(1, service.listSoftDeletedObjects("bucket", null).size());
+
+        service.deleteBucket("bucket");
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+
+        assertTrue(service.listSoftDeletedObjects("bucket", null).isEmpty());
+    }
+
+    @Test
     void deleteBucketWaitsForAnUploadToPublishMetadata() throws Exception {
         CountDownLatch metadataWriteStarted = new CountDownLatch(1);
         CountDownLatch allowMetadataWrite = new CountDownLatch(1);

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -2,9 +2,11 @@ package io.floci.gcp.services.gcs;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.floci.gcp.core.common.GcpException;
+import io.floci.gcp.core.storage.HybridStorage;
 import io.floci.gcp.core.storage.InMemoryStorage;
 import io.floci.gcp.core.storage.PersistentStorage;
 import io.floci.gcp.core.storage.StorageBackend;
+import io.floci.gcp.core.storage.WalStorage;
 import io.floci.gcp.services.gcs.model.GcsBucket;
 import io.floci.gcp.services.gcs.model.GcsContentRange;
 import io.floci.gcp.services.gcs.model.GcsObjectMeta;
@@ -14,12 +16,15 @@ import io.floci.gcp.services.gcs.model.StoredAcl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -267,6 +272,190 @@ class GcsServiceTest {
         assertEquals("mounted/smoke.txt",
                 restarted.getObjectMeta("bucket", "mounted/smoke.txt").getName());
         assertArrayEquals(data, restarted.getObjectData("bucket", "mounted/smoke.txt"));
+    }
+
+    @Test
+    void legacyNulObjectKeysAreMigratedAcrossPersistentReloads() {
+        Path root = tempDir.resolve("legacy-nul-keys");
+        StorageBackend<String, GcsBucket> buckets = persistent(
+                root.resolve("gcs-buckets.json"), new TypeReference<Map<String, GcsBucket>>() {});
+        StorageBackend<String, GcsObjectMeta> metadata = persistent(
+                root.resolve("gcs-objects.json"), new TypeReference<Map<String, GcsObjectMeta>>() {});
+        StorageBackend<String, byte[]> data = persistent(
+                root.resolve("gcs-object-data.json"), new TypeReference<Map<String, byte[]>>() {});
+        GcsService seedingService = new GcsService(
+                buckets, metadata, data, new InMemoryStorage<>(), "test-project");
+        seedingService.createBucket("bucket", "p1", BASE_URL, Map.of());
+        seedingService.createBucket("soft-only", "p1", BASE_URL, Map.of());
+
+        String objectName = "legacy\0object";
+        String legacyLiveKey = "bucket\0" + objectName;
+        putLegacyObject(metadata, data, legacyLiveKey,
+                storedObject("bucket", objectName, "3", true), new byte[]{3});
+        putLegacyObject(metadata, data, legacyLiveKey + "\0" + "2",
+                storedObject("bucket", objectName, "2", false), new byte[]{2});
+        GcsObjectMeta softDeleted = storedObject("bucket", objectName, "1", false);
+        softDeleted.setSoftDeleteTime(Instant.now().minusSeconds(60).toString());
+        softDeleted.setHardDeleteTime(Instant.now().plusSeconds(86_400).toString());
+        putLegacyObject(metadata, data, legacyLiveKey + "\0softDeleted\0" + "1",
+                softDeleted, new byte[]{1});
+
+        String softOnlyName = "legacy\0soft-only";
+        GcsObjectMeta softOnly = storedObject("soft-only", softOnlyName, "4", false);
+        softOnly.setSoftDeleteTime(Instant.now().minusSeconds(60).toString());
+        softOnly.setHardDeleteTime(Instant.now().plusSeconds(86_400).toString());
+        putLegacyObject(metadata, data,
+                "soft-only\0" + softOnlyName + "\0softDeleted\0" + "4",
+                softOnly, new byte[]{4});
+
+        GcsService restarted = persistentService(root);
+
+        assertArrayEquals(new byte[]{3}, restarted.getObjectData("bucket", objectName));
+        assertArrayEquals(new byte[]{2}, restarted.getObjectData(
+                "bucket", objectName, "2", GcsCustomerEncryption.none()));
+        assertEquals(Set.of("2", "3"), restarted.listObjectVersions("bucket", null).stream()
+                .map(GcsObjectMeta::getGeneration)
+                .collect(java.util.stream.Collectors.toSet()));
+        assertEquals(List.of("1"), restarted.listSoftDeletedObjects("bucket", null).stream()
+                .map(GcsObjectMeta::getGeneration)
+                .toList());
+        assertEquals("1", restarted.restoreObject("bucket", objectName, "1").getGeneration());
+        assertArrayEquals(new byte[]{1}, restarted.getObjectData("bucket", objectName));
+
+        assertEquals(List.of("4"), restarted.listSoftDeletedObjects("soft-only", null).stream()
+                .map(GcsObjectMeta::getGeneration)
+                .toList());
+        restarted.deleteBucket("soft-only");
+
+        GcsService afterPurge = persistentService(root);
+        assertTrue(afterPurge.listSoftDeletedObjects("soft-only", null).isEmpty());
+        GcpException missing = assertThrows(GcpException.class,
+                () -> afterPurge.getBucket("soft-only"));
+        assertEquals("NOT_FOUND", missing.getGcpStatus());
+    }
+
+    @ParameterizedTest
+    @EnumSource(LegacyMigrationStorageMode.class)
+    void legacyNulObjectKeyMigrationIsCheckpointed(LegacyMigrationStorageMode mode) {
+        Path root = tempDir.resolve("legacy-nul-checkpoint-" + mode);
+        TypeReference<Map<String, GcsObjectMeta>> metadataType = new TypeReference<>() {};
+        TypeReference<Map<String, byte[]>> dataType = new TypeReference<>() {};
+        StorageBackend<String, GcsObjectMeta> metadata = openMigrationStorage(
+                mode, root, "metadata", metadataType);
+        StorageBackend<String, byte[]> data = openMigrationStorage(
+                mode, root, "data", dataType);
+        metadata.load();
+        data.load();
+        StorageBackend<String, GcsBucket> buckets = new InMemoryStorage<>();
+        GcsService seedingService = new GcsService(
+                buckets, metadata, data, new InMemoryStorage<>(), "test-project");
+        seedingService.createBucket("bucket", "p1", BASE_URL, Map.of());
+        String objectName = "legacy\0object";
+        putLegacyObject(metadata, data, "bucket\0" + objectName,
+                storedObject("bucket", objectName, "1", true), new byte[]{1});
+
+        new GcsService(buckets, metadata, data, new InMemoryStorage<>(), "test-project");
+        closeMigrationStorage(metadata);
+        closeMigrationStorage(data);
+
+        StorageBackend<String, GcsObjectMeta> reloadedMetadata = openMigrationStorage(
+                mode, root, "metadata", metadataType);
+        StorageBackend<String, byte[]> reloadedData = openMigrationStorage(
+                mode, root, "data", dataType);
+        reloadedMetadata.load();
+        reloadedData.load();
+        try {
+            GcsService restarted = new GcsService(
+                    buckets, reloadedMetadata, reloadedData, new InMemoryStorage<>(), "test-project");
+            assertArrayEquals(new byte[]{1}, restarted.getObjectData("bucket", objectName));
+        } finally {
+            closeMigrationStorage(reloadedMetadata);
+            closeMigrationStorage(reloadedData);
+        }
+    }
+
+    @Test
+    void legacyNulObjectKeyMigrationCompletesAfterPartialMigration() {
+        StorageBackend<String, GcsObjectMeta> metadata = new InMemoryStorage<>();
+        StorageBackend<String, byte[]> data = new InMemoryStorage<>();
+        String objectName = "legacy\0object";
+        String legacyKey = "bucket\0" + objectName;
+        String migratedKey = "bucket\0\0bGVnYWN5AG9iamVjdA";
+        GcsObjectMeta meta = storedObject("bucket", objectName, "1", true);
+        putLegacyObject(metadata, data, legacyKey, meta, new byte[]{1});
+        metadata.put(migratedKey, meta);
+        data.put(migratedKey, new byte[]{1});
+
+        GcsService restarted = new GcsService(
+                new InMemoryStorage<>(), metadata, data, new InMemoryStorage<>(), "test-project");
+
+        assertArrayEquals(new byte[]{1}, restarted.getObjectData("bucket", objectName));
+        assertTrue(metadata.get(legacyKey).isEmpty());
+        assertTrue(data.get(legacyKey).isEmpty());
+    }
+
+    @Test
+    void legacyNulObjectKeyMigrationDoesNotOverwriteConflictingTarget() {
+        StorageBackend<String, GcsObjectMeta> metadata = new InMemoryStorage<>();
+        StorageBackend<String, byte[]> data = new InMemoryStorage<>();
+        String objectName = "legacy\0object";
+        String legacyKey = "bucket\0" + objectName;
+        String migratedKey = "bucket\0\0bGVnYWN5AG9iamVjdA";
+        GcsObjectMeta legacyMeta = storedObject("bucket", objectName, "1", true);
+        putLegacyObject(metadata, data, legacyKey, legacyMeta, new byte[]{1});
+        metadata.put(migratedKey, storedObject("bucket", objectName, "2", true));
+        data.put(migratedKey, new byte[]{2});
+
+        new GcsService(
+                new InMemoryStorage<>(), metadata, data, new InMemoryStorage<>(), "test-project");
+
+        assertSame(legacyMeta, metadata.get(legacyKey).orElseThrow());
+        assertArrayEquals(new byte[]{1}, data.get(legacyKey).orElseThrow());
+        assertEquals("2", metadata.get(migratedKey).orElseThrow().getGeneration());
+        assertArrayEquals(new byte[]{2}, data.get(migratedKey).orElseThrow());
+    }
+
+    private static GcsObjectMeta storedObject(
+            String bucket, String name, String generation, boolean latest) {
+        GcsObjectMeta meta = new GcsObjectMeta();
+        meta.setBucket(bucket);
+        meta.setName(name);
+        meta.setGeneration(generation);
+        meta.setIsLatest(latest);
+        return meta;
+    }
+
+    private static void putLegacyObject(
+            StorageBackend<String, GcsObjectMeta> metadata,
+            StorageBackend<String, byte[]> data,
+            String key, GcsObjectMeta meta, byte[] bytes) {
+        data.put(key, bytes);
+        metadata.put(key, meta);
+    }
+
+    private static <V> StorageBackend<String, V> openMigrationStorage(
+            LegacyMigrationStorageMode mode, Path root, String name,
+            TypeReference<Map<String, V>> type) {
+        return switch (mode) {
+            case PERSISTENT -> new PersistentStorage<>(root.resolve(name + ".json"), type);
+            case HYBRID -> new HybridStorage<>(root.resolve(name + ".json"), type, 60_000);
+            case WAL -> new WalStorage<>(
+                    root.resolve(name + ".json"), root.resolve(name + ".wal"), type, 60_000);
+        };
+    }
+
+    private static void closeMigrationStorage(StorageBackend<?, ?> storage) {
+        if (storage instanceof HybridStorage<?, ?> hybrid) {
+            hybrid.shutdown();
+        } else if (storage instanceof WalStorage<?, ?> wal) {
+            wal.shutdown();
+        }
+    }
+
+    private enum LegacyMigrationStorageMode {
+        PERSISTENT,
+        HYBRID,
+        WAL
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -20,6 +20,12 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -329,6 +335,55 @@ class GcsServiceTest {
     }
 
     @Test
+    void deleteNonEmptyBucketThrowsConflict() {
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        service.putObject("bucket", "obj.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+
+        GcpException ex = assertThrows(GcpException.class,
+                () -> service.deleteBucket("bucket"));
+
+        assertEquals(409, ex.getHttpStatus());
+        assertEquals("conflict", ex.getReason());
+        assertNotNull(service.getBucket("bucket"));
+        assertArrayEquals(new byte[]{1},
+                service.getObjectData("bucket", "obj.txt", GcsCustomerEncryption.none()));
+    }
+
+    @Test
+    void deleteBucketWaitsForAnUploadToPublishMetadata() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        service = new GcsService(new InMemoryStorage<>(),
+                new BlockingFirstPutStorage<>(metadataWriteStarted, allowMetadataWrite),
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var upload = executor.submit(() -> service.putObject("bucket", "obj.txt", "text/plain",
+                    new byte[]{1}, GcsCustomerEncryption.none(), BASE_URL));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var deletion = executor.submit(() -> service.deleteBucket("bucket"));
+            assertThrows(TimeoutException.class, () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            upload.get(5, TimeUnit.SECONDS);
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> deletion.get(5, TimeUnit.SECONDS));
+            GcpException deletionException = assertInstanceOf(GcpException.class, ex.getCause());
+            assertEquals("conflict", deletionException.getReason());
+            assertNotNull(service.getBucket("bucket"));
+            assertArrayEquals(new byte[]{1},
+                    service.getObjectData("bucket", "obj.txt", GcsCustomerEncryption.none()));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void concurrentOverwriteNeverMixesGenerations() throws Exception {
         service.createBucket("race-bucket", "p1", BASE_URL, Map.of());
         var payloads = Map.of(
@@ -359,6 +414,33 @@ class GcsServiceTest {
         } finally {
             stop.set(true);
             writer.join();
+        }
+    }
+
+    private static final class BlockingFirstPutStorage<K, V> extends InMemoryStorage<K, V> {
+        private final CountDownLatch putStarted;
+        private final CountDownLatch allowPut;
+        private final AtomicBoolean blockFirstPut = new AtomicBoolean(true);
+
+        private BlockingFirstPutStorage(CountDownLatch putStarted, CountDownLatch allowPut) {
+            this.putStarted = putStarted;
+            this.allowPut = allowPut;
+        }
+
+        @Override
+        public void put(K key, V value) {
+            if (blockFirstPut.compareAndSet(true, false)) {
+                putStarted.countDown();
+                try {
+                    if (!allowPut.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("timed out waiting to publish object metadata");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("interrupted while publishing object metadata", e);
+                }
+            }
+            super.put(key, value);
         }
     }
 

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -528,6 +528,82 @@ class GcsServiceTest {
     }
 
     @Test
+    void deleteBucketWaitsForResumableUploadFinalization() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        var metadataStore = new ArmableBlockingPutStorage<String, GcsObjectMeta>(
+                metadataWriteStarted, allowMetadataWrite);
+        service = new GcsService(new InMemoryStorage<>(), metadataStore,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        String uploadId = service.startResumableUpload("bucket", "resumable.txt", "text/plain",
+                GcsCustomerEncryption.none(), Map.of());
+        metadataStore.blockNextPut();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var finalization = executor.submit(() -> service.applyResumableChunk(
+                    uploadId, null, new byte[]{1}, BASE_URL));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var deletion = executor.submit(() -> service.deleteBucket("bucket"));
+            assertThrows(TimeoutException.class, () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            finalization.get(5, TimeUnit.SECONDS);
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> deletion.get(5, TimeUnit.SECONDS));
+            GcpException deletionException = assertInstanceOf(GcpException.class, ex.getCause());
+            assertEquals("conflict", deletionException.getReason());
+            assertArrayEquals(new byte[]{1}, service.getObjectData(
+                    "bucket", "resumable.txt", GcsCustomerEncryption.none()));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void deleteBucketWaitsForStreamingUploadFinalization() throws Exception {
+        CountDownLatch metadataWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowMetadataWrite = new CountDownLatch(1);
+        var metadataStore = new ArmableBlockingPutStorage<String, GcsObjectMeta>(
+                metadataWriteStarted, allowMetadataWrite);
+        service = new GcsService(new InMemoryStorage<>(), metadataStore,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), "test-project");
+        service.createBucket("bucket", "p1", BASE_URL, Map.of());
+        GcsObjectMeta input = new GcsObjectMeta();
+        input.setBucket("bucket");
+        input.setName("streaming.txt");
+        input.setContentType("text/plain");
+        String uploadId = service.startStreamingUpload(
+                input, GcsObjectPreconditions.NONE, null, null, null);
+        service.getStreamingUpload(uploadId).append(0, new byte[]{1});
+        metadataStore.blockNextPut();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var finalization = executor.submit(() -> service.finalizeStreamingUpload(uploadId, BASE_URL));
+            assertTrue(metadataWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var deletion = executor.submit(() -> service.deleteBucket("bucket"));
+            assertThrows(TimeoutException.class, () -> deletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowMetadataWrite.countDown();
+            finalization.get(5, TimeUnit.SECONDS);
+            ExecutionException ex = assertThrows(ExecutionException.class,
+                    () -> deletion.get(5, TimeUnit.SECONDS));
+            GcpException deletionException = assertInstanceOf(GcpException.class, ex.getCause());
+            assertEquals("conflict", deletionException.getReason());
+            assertArrayEquals(new byte[]{1}, service.getObjectData(
+                    "bucket", "streaming.txt", GcsCustomerEncryption.none()));
+        } finally {
+            allowMetadataWrite.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void concurrentOverwriteNeverMixesGenerations() throws Exception {
         service.createBucket("race-bucket", "p1", BASE_URL, Map.of());
         var payloads = Map.of(

--- a/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsServiceTest.java
@@ -514,6 +514,11 @@ class GcsServiceTest {
         WAL
     }
 
+    private enum SoftDeleteOperation {
+        BY_NAME,
+        BY_GENERATION
+    }
+
     private static final class OrderedStorage<V> implements StorageBackend<String, V> {
         private final Map<String, V> values = new LinkedHashMap<>();
 
@@ -697,6 +702,52 @@ class GcsServiceTest {
         service.createBucket("bucket", "p1", BASE_URL, Map.of());
 
         assertTrue(service.listSoftDeletedObjects("bucket", null).isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(SoftDeleteOperation.class)
+    void deleteBucketWaitsForSoftDeletePublication(SoftDeleteOperation operation) throws Exception {
+        CountDownLatch softDeleteWriteStarted = new CountDownLatch(1);
+        CountDownLatch allowSoftDeleteWrite = new CountDownLatch(1);
+        var metadataStore = new ArmableBlockingPutStorage<String, GcsObjectMeta>(
+                softDeleteWriteStarted, allowSoftDeleteWrite);
+        var dataStore = new InMemoryStorage<String, byte[]>();
+        service = new GcsService(new InMemoryStorage<>(), metadataStore,
+                dataStore, new InMemoryStorage<>(), "test-project");
+        service.createBucket("bucket", "p1", BASE_URL,
+                Map.of("softDeletePolicy", Map.of("retentionDurationSeconds", "604800")));
+        GcsObjectMeta object = service.putObject("bucket", "obj.txt", "text/plain", new byte[]{1},
+                GcsCustomerEncryption.none(), BASE_URL);
+        metadataStore.blockNextPut();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var objectDeletion = executor.submit(() -> {
+                if (operation == SoftDeleteOperation.BY_NAME) {
+                    service.deleteObject("bucket", "obj.txt");
+                } else {
+                    service.deleteObjectVersion("bucket", "obj.txt", object.getGeneration());
+                }
+            });
+            assertTrue(softDeleteWriteStarted.await(5, TimeUnit.SECONDS));
+
+            var bucketDeletion = executor.submit(() -> service.deleteBucket("bucket"));
+            assertThrows(TimeoutException.class,
+                    () -> bucketDeletion.get(100, TimeUnit.MILLISECONDS));
+
+            allowSoftDeleteWrite.countDown();
+            objectDeletion.get(5, TimeUnit.SECONDS);
+            bucketDeletion.get(5, TimeUnit.SECONDS);
+
+            assertTrue(metadataStore.keys().isEmpty());
+            assertTrue(dataStore.keys().isEmpty());
+            service.createBucket("bucket", "p1", BASE_URL, Map.of());
+            assertTrue(service.listObjects("bucket").isEmpty());
+            assertTrue(service.listSoftDeletedObjects("bucket", null).isEmpty());
+        } finally {
+            allowSoftDeleteWrite.countDown();
+            executor.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject deletion of buckets that still contain object metadata
- serialize deletion and ordinary object publication per bucket to prevent upload races from orphaning objects
- return the Cloud Storage JSON API 409 response with the documented conflict reason
- cover REST, gRPC, service, race, and Java SDK behavior

## Validation
- ./mvnw test -Dtest=GcsServiceTest,GcsGrpcControllerTest,GcsBucketDeletionRestIntegrationTest
- ./mvnw -f compatibility-tests/sdk-test-java/pom.xml -Dtest=GcsTest#rejectsDeletionOfNonEmptyBucket test, against a live local emulator

Closes #178