### PR TITLE
perf(docker): move the runtime images to ubi9-micro and drop gosu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 *
 !bin/gcplocal
 !docker/entrypoint.sh
+!docker/healthcheck.sh
 !docker/localstack-parity.sh
 !pom.xml
 !src/**

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,21 +17,12 @@ ARG VERSION=latest
 ENV FLOCI_GCP_VERSION=${VERSION}
 ENV FLOCI_GCP_STORAGE_PERSISTENT_PATH=/app/data
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+# Privilege drop happens in the entrypoint through coreutils chroot, so no gosu
+# download. The base image ships GNU coreutils at /usr/sbin/chroot, ahead of
+# busybox on PATH, so --userspec and --skip-chdir are available.
 RUN set -eux; \
     apk add --no-cache shadow ca-certificates; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(apk --print-arch)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
 
 WORKDIR /app
 

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,13 +1,23 @@
 ARG VERSION=latest
-FROM floci/floci-gcp:${VERSION}
+# BASE_IMAGE is the image produced by Dockerfile.native-package. Release and nightly
+# tags use VERSION; reusable builds override BASE_IMAGE with the digest-qualified
+# native image they just published.
+#
+# That image is ubi9-micro and has no package manager, so this image cannot extend it.
+ARG BASE_IMAGE=floci/floci-gcp:${VERSION}
+FROM ${BASE_IMAGE} AS native
+
+# Everything that does not depend on the floci-gcp version. CI builds this stage
+# alone (target: tools) to warm the layer cache, so it pulls no floci-gcp image.
+FROM registry.access.redhat.com/ubi9-minimal:9.7 AS tools
 
 LABEL org.opencontainers.image.title="floci-gcp (compat)" \
       org.opencontainers.image.description="floci-gcp compatibility image with Python GCP SDK pre-installed" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.vendor="Floci"
 
-USER root
-RUN microdnf install -y --nodocs python3.11 python3.11-pip \
+RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci \
+    && microdnf install -y --nodocs python3.11 python3.11-pip \
     && python3.11 -m pip install --upgrade pip \
     && python3.11 -m pip install --no-cache-dir \
          google-cloud-pubsub \
@@ -15,10 +25,37 @@ RUN microdnf install -y --nodocs python3.11 python3.11-pip \
          google-cloud-firestore \
          google-cloud-datastore \
          google-cloud-secret-manager \
+    # The system Python keeps pip, setuptools and what the SDKs import; the optimised
+    # .pyc variants, lib2to3 and ensurepip (pip is already installed) are build-time extras.
+    && rm -rf /usr/lib64/python3.11/lib2to3 /usr/lib64/python3.11/ensurepip \
+    && python3.11 -c 'import pathlib; [p.unlink() for d in ("/usr/lib64/python3.11","/usr/lib/python3.11") for p in pathlib.Path(d).rglob("*.opt-[12].pyc")]' \
     && microdnf clean all \
     && rm -rf /root/.cache/pip
 
-COPY bin/gcplocal /usr/local/bin/gcplocal
-RUN chmod +x /usr/local/bin/gcplocal
+COPY --chmod=755 bin/gcplocal /usr/local/bin/gcplocal
+
+WORKDIR /app
+# A chmod after the copy below would rewrite the binary into a second layer.
+RUN chown 1001:root /app && chmod g+rwX /app
+
+FROM tools
+
+ARG VERSION
+ENV FLOCI_GCP_VERSION=${VERSION}
+ENV FLOCI_GCP_STORAGE_PERSISTENT_PATH=/app/data
+
+COPY --from=native --chown=1001:root /app/ /app/
+VOLUME /app/data
+
+COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
+# From the build context, not the native image: a published native image may predate the script.
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/
+
+EXPOSE 4588
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/usr/local/bin/healthcheck.sh"]
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]
 
 USER 1001

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -13,51 +13,19 @@ COPY src ./src
 
 RUN mvn clean package -Dnative -DskipTests -B
 
-# Stage 2: Collect tools (gosu)
-FROM registry.access.redhat.com/ubi9:9.7 AS tools
+# Stage 2: Minimal runtime. Same base and user setup as Dockerfile.native-package.
+FROM registry.access.redhat.com/ubi9-micro:9.7
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
-
-RUN set -eux; \
-    mkdir -p /toolsroot; \
-    dnf install -y --installroot=/toolsroot --releasever=9 \
-        --setopt=install_weak_deps=0 --nodocs \
-        shadow-utils; \
-    dnf -y --installroot=/toolsroot clean all; \
-    rm -rf /toolsroot/var/cache/* /toolsroot/var/log/dnf* /toolsroot/var/log/yum* \
-           /toolsroot/var/lib/rpm /toolsroot/var/lib/dnf; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    mkdir -p /toolsroot/usr/local/bin; \
-    curl -fsSL -o /toolsroot/usr/local/bin/gosu \
-        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /toolsroot/usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /toolsroot/usr/local/bin/gosu
-
-# Stage 3: Minimal runtime
-FROM quay.io/quarkus/quarkus-micro-image:2.0
-
-USER root
 WORKDIR /app
-COPY --from=tools /toolsroot/ /
-
-RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
-
-RUN mkdir -p /app/data \
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd \
+    && mkdir -p /app/data \
     && chown -R 1001:root /app \
     && chmod -R g+rwX /app
 VOLUME /app/data
 
 EXPOSE 4588
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD bash -c 'echo -e "GET /_floci-gcp/health HTTP/1.0\r\nHost: localhost\r\n\r\n" > /dev/tcp/localhost/4588' || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ARG VERSION=latest
 ENV FLOCI_GCP_VERSION=${VERSION}
@@ -65,6 +33,7 @@ ENV FLOCI_GCP_STORAGE_PERSISTENT_PATH=/app/data
 
 COPY --chmod=755 --from=build /app/target/*-runner /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -1,42 +1,26 @@
-FROM registry.access.redhat.com/ubi9-minimal:9.7
+FROM registry.access.redhat.com/ubi9-micro:9.7
 
-ARG VERSION=latest
 # Automatically set by Docker BuildKit to "amd64" or "arm64"
 ARG TARGETARCH
 
-ENV FLOCI_GCP_VERSION=${VERSION}
-ENV FLOCI_GCP_STORAGE_PERSISTENT_PATH=/app/data
-
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
-RUN set -eux; \
-    microdnf install -y --nodocs shadow-utils; \
-    microdnf clean all; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu; \
-    gosu --version; \
-    gosu nobody true
-
 WORKDIR /app
 
-RUN mkdir -p /app/data \
+# ubi9-micro has no shadow-utils, so the runtime user is one /etc/passwd line.
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd \
+    && mkdir -p /app/data \
     && chown -R 1001:root /app \
     && chmod -R g+rwX /app
 
 VOLUME /app/data
 
-COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
-
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/healthcheck.sh
+
+ARG VERSION=latest
+ENV FLOCI_GCP_VERSION=${VERSION}
+ENV FLOCI_GCP_STORAGE_PERSISTENT_PATH=/app/data
+
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 LABEL org.opencontainers.image.title="floci-gcp" \
       org.opencontainers.image.description="Local GCP emulator — open-source alternative to GCP-provided emulators" \
@@ -57,8 +41,7 @@ LABEL org.opencontainers.image.title="floci-gcp" \
 
 EXPOSE 4588
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD curl -f http://localhost:4588/_floci-gcp/health || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,27 @@
 #!/bin/sh
-# Starts as root, normalizes the bind-mounted Docker socket's group
-# ownership so the unprivileged `floci` user can reach it on any host,
-# then re-executes this script as `floci` via gosu. The second invocation
-# falls through to exec the user's command.
+# Starts as root, reads the bind-mounted Docker socket's group so the
+# unprivileged `floci` user can reach it on any host, then re-executes this
+# script as `floci` via coreutils `chroot --userspec`, which also grants that
+# group as a supplementary group. The second invocation falls through to exec
+# the user's command. No gosu, no usermod: both would cost a package layer the
+# base image does not otherwise need.
+#
+# Why: on native Linux Docker, /var/run/docker.sock is owned by root:docker
+# with mode 660 and the docker GID varies by distro. On Docker Desktop
+# (macOS/Windows) the socket is typically root:root (GID 0). Without the group
+# fix-up below, floci (uid 1001, group 0) can open the socket on Docker Desktop
+# but not on native Linux, which breaks Cloud Run, GKE, Managed Kafka and Cloud
+# SQL emulation there. Discovering the GID at runtime handles every host
+# transparently.
 
 set -eu
 
 if [ "$(id -u)" = '0' ]; then
+    groups='0'
     if [ -S /var/run/docker.sock ]; then
         sock_gid="$(stat -c '%g' /var/run/docker.sock)"
         if [ "$sock_gid" != '0' ]; then
-            group_name="$(getent group "$sock_gid" | cut -d: -f1)" || group_name=''
-            if [ -z "$group_name" ]; then
-                groupadd -g "$sock_gid" docker-host
-                group_name='docker-host'
-            fi
-            usermod -aG "$group_name" floci
+            groups="0,$sock_gid"
         fi
     fi
 
@@ -25,7 +31,11 @@ if [ "$(id -u)" = '0' ]; then
         chown -R floci:root /app/data 2>/dev/null || true
     fi
 
-    exec gosu floci "$0" "$@"
+    # `chroot /` changes nothing but the identity: uid 1001, primary gid 0, plus the socket's
+    # group. Supplementary groups are set by number, so the group needs no /etc/group entry.
+    # --skip-chdir keeps the working directory (/app, where relative data paths resolve); GNU
+    # chroot would otherwise chdir to the new root.
+    exec chroot --userspec=1001:0 --groups="$groups" --skip-chdir / "$0" "$@"
 fi
 
 exec "$@"

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Container health probe. Bash only, because ubi9-micro has no curl.
+exec 3<>/dev/tcp/127.0.0.1/4588 || exit 1
+printf 'GET /_floci-gcp/health HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3
+read -r _proto status _rest <&3
+[ "$status" = 200 ]

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,31 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
+          <!-- brotli4j resolves a JNI jar for the build host's platform (native-osx-aarch64 on a
+               Mac, native-linux-* in CI); floci-gcp never enables Brotli HTTP compression. Maven
+               wildcards match a whole artifactId only, hence the explicit list. -->
+          <exclusions>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-osx-aarch64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-osx-x86_64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-linux-aarch64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-linux-x86_64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-windows-x86_64</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <!-- YAML config support -->

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,9 +23,10 @@ quarkus:
     delay-enabled: true
 
   native:
+    # No --allow-incomplete-classpath and no --report-unsupported-elements-at-runtime: both have
+    # been no-ops since GraalVM 22.1 (incomplete classpaths are the default, and Quarkus passes
+    # --link-at-build-time itself, so a reachable class missing from the classpath fails the build).
     additional-build-args:
-      - --report-unsupported-elements-at-runtime
-      - --allow-incomplete-classpath
       - --enable-url-protocols=http,https
       - --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32
       - --initialize-at-run-time=io.floci.gcp.services.cloudkms.KmsCrypto


### PR DESCRIPTION
## Summary

Ports floci-aws's three-commit image-size chain, which cut `floci/floci` from **132.6 MB to 76.3 MB compressed (−42%)**: [#3037](https://github.com/floci-io/floci/pull/3037), [#3085](https://github.com/floci-io/floci/pull/3085), [#3108](https://github.com/floci-io/floci/pull/3108). Implements ecosystem decision 0018.

**floci-gcp is the pilot.** floci-az and floci-oci follow only once this one's published size and compat suite are confirmed, because the entrypoint change alters how every Docker-sidecar service reaches the socket.

The three upstream commits are one change split for review, not a menu: `ubi9-micro` ships no `useradd` and no `curl`, so the gosu removal and the bash health probe are what make the smaller base viable at all.

| File | Change |
|---|---|
| `docker/entrypoint.sh` | privilege drop moves from gosu to coreutils `chroot --userspec=1001:0 --groups=... --skip-chdir /` |
| `docker/Dockerfile.native` | drops the `ubi9:9.7` tools stage that fetched gosu; runtime is `ubi9-micro:9.7`, user is one `/etc/passwd` line |
| `docker/Dockerfile.native-package` | same base and user setup, replacing `ubi9-minimal` plus an inline gosu install. **This is the image `release.yml` publishes** |
| `docker/Dockerfile` | drops its gosu download |
| `docker/Dockerfile.compat` | `ubi9-micro` has no package manager, so this can no longer extend the native image: `ubi9-minimal` tools stage, copies `/app` out, plus the Python trims from #3108 |
| `docker/healthcheck.sh` | **new**, shared by all three Dockerfiles |
| `pom.xml`, `application.yml` | exclude the unused brotli4j platform JNI jars; drop two native-image args that are no-ops since GraalVM 22.1 |

### One divergence from floci-aws, worth a reviewer's eye

floci-aws's JVM image is Debian `noble`. This repo's is `eclipse-temurin:25-jre-alpine`, and **busybox `chroot` has no `--userspec`**:

```
chroot: can't change root directory to '--userspec=1001:0': No such file or directory
```

The change is safe only because that image ships **GNU coreutils 9.8** at `/usr/sbin/chroot`, ahead of busybox on PATH. Verified by running it rather than inferred from PATH order. If the base image ever loses GNU coreutils, the JVM image's privilege drop breaks; the native images are unaffected, since `ubi9-micro` carries GNU chroot 8.32.

### Verified on a built runtime image

- `uid=1001(floci) gid=0(root)` through the entrypoint
- a unix socket owned by gid 999 mounted at the socket path yields `groups=0(root),999`, so the by-number supplementary group works with no `/etc/group` entry
- `/app/data` writable; argv fallthrough intact
- `healthcheck.sh` exits 0 against a 200 and **1 against a 500**. The old inline probe wrote to `/dev/tcp` without reading the response, so it reported healthy on both
- `ubi9-micro:9.7` confirmed to carry bash, GNU chroot, `stat` and `chown`, and to lack `useradd` and `curl`

### Size

Base layers on the published image, uncompressed: `ubi9-minimal` 36.4 MB → `ubi9-micro` 6.4 MB, plus the ~19 MB gosu and shadow-utils install it no longer performs. **The compressed figure lands when CI publishes**; floci-aws's 42% is deliberately not carried across as a prediction, since this image starts at 87.9 MB rather than 132.

### Not ported

#3085's `target: tools` CI change has no counterpart here: this repo's `warm-compat-caches.yml` warms per-suite test images and never builds `Dockerfile.compat`. `release.yml` and `nightly.yml` pass only `VERSION`, so the new `BASE_IMAGE` ARG defaults correctly and neither needs a change.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## GCP Compatibility

No wire protocol, endpoint or emulated behavior changes. Packaging only. The compat suite against a real native build is what this PR's CI is for.

## Checklist

- [x] Tests pass locally (no source changed; runtime image behavior verified as above)
- [ ] New or updated integration test added (not applicable, packaging change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
