### PR TITLE
fix(firebaseauth): send CORS headers on the emulator endpoints and always vary on Origin

### DIFF
--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -37,9 +37,6 @@ public class FirebaseAuthCorsRouteFilter {
     }
 
     private void handle(RoutingContext ctx) {
-        // `Vary` is unconditional, even without an `Origin` to reflect: a shared cache that
-        // stored an origin-less response would otherwise hand it, stripped of
-        // `Access-Control-Allow-Origin`, to a browser request that does carry one.
         ctx.response().putHeader("Vary", "Origin");
 
         String origin = ctx.request().getHeader("Origin");

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -11,10 +11,12 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class FirebaseAuthCorsRouteFilter {
 
-    // FirebaseAuthController (sign-in/sign-up) and SecureTokenController (token refresh).
+    // FirebaseAuthController (sign-in/sign-up), SecureTokenController (token refresh) and
+    // FirebaseAuthEmulatorController, which the Emulator UI calls from the browser.
     private static final String[] PATH_PREFIXES = {
             "/identitytoolkit.googleapis.com/*",
             "/securetoken.googleapis.com/*",
+            "/emulator/v1/*",
     };
 
     // Matches expressjs/cors' defaults, which is what firebase-tools' Auth Emulator uses.

--- a/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
+++ b/src/main/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRouteFilter.java
@@ -37,6 +37,11 @@ public class FirebaseAuthCorsRouteFilter {
     }
 
     private void handle(RoutingContext ctx) {
+        // `Vary` is unconditional, even without an `Origin` to reflect: a shared cache that
+        // stored an origin-less response would otherwise hand it, stripped of
+        // `Access-Control-Allow-Origin`, to a browser request that does carry one.
+        ctx.response().putHeader("Vary", "Origin");
+
         String origin = ctx.request().getHeader("Origin");
         if (origin == null) {
             ctx.next();
@@ -45,7 +50,6 @@ public class FirebaseAuthCorsRouteFilter {
         ctx.response().putHeader("Access-Control-Allow-Origin", origin);
 
         if (!"OPTIONS".equalsIgnoreCase(ctx.request().method().name())) {
-            ctx.response().putHeader("Vary", "Origin");
             ctx.next();
             return;
         }

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 class FirebaseAuthCorsRestIntegrationTest {
 
     private static final String CLIENT = "/identitytoolkit.googleapis.com/v1/accounts";
+    private static final String EMULATOR = "/emulator/v1";
     private static final String ORIGIN = "http://127.0.0.1:59301";
 
     @Test
@@ -58,6 +59,32 @@ class FirebaseAuthCorsRestIntegrationTest {
                 .header("Access-Control-Allow-Methods", equalTo("GET,HEAD,PUT,PATCH,POST,DELETE"))
                 .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
                 .header("Vary", equalTo("Origin, Access-Control-Request-Headers"));
+    }
+
+    @Test
+    void preflightForEmulatorDeleteAllAccountsAdvertisesTheRequestedOrigin() {
+        given()
+                .header("Origin", ORIGIN)
+                .header("Access-Control-Request-Method", "DELETE")
+                .header("Access-Control-Request-Headers", "Content-Type")
+                .when().options(EMULATOR + "/projects/cors-emulator-probe/accounts")
+                .then()
+                .statusCode(204)
+                .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
+                .header("Access-Control-Allow-Methods", equalTo("GET,HEAD,PUT,PATCH,POST,DELETE"))
+                .header("Access-Control-Allow-Headers", equalTo("Content-Type"))
+                .header("Vary", equalTo("Origin, Access-Control-Request-Headers"));
+    }
+
+    @Test
+    void actualEmulatorDeleteAllAccountsResponseAdvertisesTheRequestedOrigin() {
+        given()
+                .header("Origin", ORIGIN)
+                .when().delete(EMULATOR + "/projects/cors-emulator-probe/accounts")
+                .then()
+                .statusCode(200)
+                .header("Access-Control-Allow-Origin", equalTo(ORIGIN))
+                .header("Vary", equalTo("Origin"));
     }
 
     @Test

--- a/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/firebaseauth/FirebaseAuthCorsRestIntegrationTest.java
@@ -88,7 +88,7 @@ class FirebaseAuthCorsRestIntegrationTest {
     }
 
     @Test
-    void requestWithNoOriginGetsNoCorsHeaders() {
+    void requestWithNoOriginStillVariesOnOrigin() {
         given()
                 .urlEncodingEnabled(false)
                 .contentType("application/json")
@@ -99,6 +99,7 @@ class FirebaseAuthCorsRestIntegrationTest {
                 .when().post(CLIENT + ":signUp")
                 .then()
                 .statusCode(200)
-                .header("Access-Control-Allow-Origin", nullValue());
+                .header("Access-Control-Allow-Origin", nullValue())
+                .header("Vary", equalTo("Origin"));
     }
 }


### PR DESCRIPTION
## Summary

The two follow-ups from the review on #153, both in `FirebaseAuthCorsRouteFilter`. One PR rather than two, since they land in the same 20-line file and its test — one commit each so they still read separately.

**1. `/emulator/v1` now sends CORS headers.** `FirebaseAuthEmulatorController` (`DELETE /emulator/v1/projects/{project}/accounts`) is browser-callable from the Emulator UI, but the prefix was missing from `PATH_PREFIXES`, so its preflight came back with no `Access-Control-*` headers at all. firebase-tools' Auth Emulator installs `cors({ origin: true })` with `app.use(...)` ahead of every route registration ([server.ts#L137](https://github.com/firebase/firebase-tools/blob/1e17461/src/emulator/auth/server.ts#L137)), so `/emulator/v1` is covered there for the same reason the Identity Toolkit paths are.

**2. `Vary: Origin` is now unconditional.** The filter returned early on a missing `Origin` and emitted nothing, so an origin-less response was cacheable as if it were origin-independent. A shared cache could then hand that response — with no `Access-Control-Allow-Origin` on it — to a browser request that *did* carry an `Origin`, and the browser would block it. In `expressjs/cors`, `configureOrigin` pushes `Vary: Origin` unconditionally and `applyHeaders` only drops falsy header *values*, so `Access-Control-Allow-Origin: undefined` disappears while the `Vary` describing the negotiation stays ([lib/index.js#L64-L71](https://github.com/expressjs/cors/blob/v2.8.5/lib/index.js#L64-L71), [#L232-L246](https://github.com/expressjs/cors/blob/v2.8.5/lib/index.js#L232-L246)).

Follow-up to https://github.com/floci-io/floci-gcp/pull/153#pullrequestreview-5127429652

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

Both changes were read off the `expressjs/cors@2.8.5` and `firebase-tools` sources linked above, which is the same reference #153 was built against.

Verified in a packaged build with curl:

- `OPTIONS /emulator/v1/projects/p/accounts` with an `Origin` → `204` carrying `Access-Control-Allow-Origin`, `-Allow-Methods`, `-Allow-Headers` and `Vary: Origin, Access-Control-Request-Headers`; the actual `DELETE` carries `Access-Control-Allow-Origin` and `Vary: Origin`.
- `POST /identitytoolkit.googleapis.com/v1/accounts:signUp` with **no** `Origin` → still `200`, still no `Access-Control-Allow-Origin`, now with `Vary: Origin`.

One deliberate divergence left in place, since it is outside what the review asked for: `expressjs/cors` answers an **origin-less** `OPTIONS` with its own `204`, whereas this filter still falls through to Quarkus' automatic-OPTIONS routing. A browser never sends a preflight without an `Origin`, and absorbing every `OPTIONS` on these three prefixes at `Integer.MIN_VALUE + 1` is exactly the app-wide preflight absorption #153 removed from `GcsCorsFilter`. Happy to take it in a further PR if you'd rather match byte-for-byte.

## Checklist

- [x] `./mvnw test` passes locally (969 tests, 0 failures)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)