### PR TITLE
fix(gcs): preserve prefixes when listing with matchGlob

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsListFiltersTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/gcp/test/GcsListFiltersTest.java
@@ -85,6 +85,12 @@ class GcsListFiltersTest {
     }
 
     @Test
+    void matchGlobFiltersDirectoryPrefixes() {
+        assertThat(names(Storage.BlobListOption.currentDirectory(), Storage.BlobListOption.matchGlob("*/")))
+                .containsExactlyInAnyOrder("logs/", "metrics/");
+    }
+
+    @Test
     void includeTrailingDelimiterAddsThePlaceholderObjectToItems() throws Exception {
         // Driven raw: google-cloud-storage 2.47.0 exposes no BlobListOption for this parameter,
         // so the SDK cannot send it. Without the flag "logs/" only rolls up into prefixes[] and

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectController.java
@@ -83,15 +83,22 @@ public class GcsObjectController {
         }
         // startOffset is inclusive, endOffset exclusive.
         GcsObjectGlob.GlobMatcher globMatcher = GcsObjectGlob.matcher(GcsObjectGlob.compile(matchGlob));
+        String basePrefix = prefix != null ? prefix : "";
+        if (delimiter != null && !delimiter.isEmpty()) {
+            String globPrefix = GcsObjectGlob.fixedDirectoryPrefix(matchGlob);
+            if (globPrefix.startsWith(basePrefix)) {
+                basePrefix = globPrefix;
+            }
+        }
+        String listingPrefix = basePrefix;
         all = all.stream()
                 .sorted(Comparator.comparing(GcsObjectMeta::getName))
                 .filter(o -> startOffset == null || o.getName().compareTo(startOffset) >= 0)
                 .filter(o -> endOffset == null || o.getName().compareTo(endOffset) < 0)
-                .filter(o -> globMatcher.matches(o.getName()))
+                .filter(o -> o.getName().startsWith(listingPrefix))
                 .toList();
         Set<String> prefixes = new TreeSet<>();
         if (delimiter != null && !delimiter.isEmpty()) {
-            String basePrefix = prefix != null ? prefix : "";
             List<GcsObjectMeta> rolledUp = new ArrayList<>();
             for (GcsObjectMeta meta : all) {
                 String rest = meta.getName().substring(basePrefix.length());
@@ -110,6 +117,10 @@ public class GcsObjectController {
             }
             all = rolledUp;
         }
+        all = all.stream()
+                .filter(o -> globMatcher.matches(o.getName()))
+                .toList();
+        prefixes.removeIf(prefixEntry -> !globMatcher.matches(prefixEntry));
         PageToken.Page<GcsObjectMeta> page = PageToken.paginate(all, maxResults, pageToken);
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("kind", "storage#objects");

--- a/src/main/java/io/floci/gcp/services/gcs/GcsObjectGlob.java
+++ b/src/main/java/io/floci/gcp/services/gcs/GcsObjectGlob.java
@@ -76,6 +76,13 @@ final class GcsObjectGlob {
                     }
                 }
                 case ',' -> out.append(depth > 0 ? "|" : "\\,");
+                case '\\' -> {
+                    if (i + 1 < glob.length()) {
+                        appendLiteral(out, glob.charAt(++i));
+                    } else {
+                        appendLiteral(out, c);
+                    }
+                }
                 default -> appendLiteral(out, c);
             }
         }
@@ -132,6 +139,29 @@ final class GcsObjectGlob {
     /** A glob bound to one request, carrying that request's remaining matching budget. */
     static GlobMatcher matcher(Pattern pattern) {
         return new GlobMatcher(pattern);
+    }
+
+    /** Literal path segments before the first glob token act as a prefix for delimiter roll-up. */
+    static String fixedDirectoryPrefix(String glob) {
+        if (glob == null || glob.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder fixedPrefix = new StringBuilder();
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            if (c == '\\' && i + 1 < glob.length()) {
+                fixedPrefix.append(glob.charAt(++i));
+                continue;
+            }
+            if ("*?[{".indexOf(c) >= 0) {
+                break;
+            }
+            fixedPrefix.append(c);
+        }
+
+        int delimiter = fixedPrefix.lastIndexOf("/");
+        return delimiter < 0 ? "" : fixedPrefix.substring(0, delimiter + 1);
     }
 
     static final class GlobMatcher {

--- a/src/test/java/io/floci/gcp/services/gcs/GcsListFilterRestIntegrationTest.java
+++ b/src/test/java/io/floci/gcp/services/gcs/GcsListFilterRestIntegrationTest.java
@@ -103,6 +103,55 @@ class GcsListFilterRestIntegrationTest {
     }
 
     @Test
+    void matchGlobFiltersPrefixesAfterDelimiterRollup() {
+        seed();
+        given().queryParam("delimiter", "/").queryParam("matchGlob", "*/")
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items", org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.nullValue(), empty()))
+                .body("prefixes", containsInAnyOrder("a/", "b/", "logs/"));
+    }
+
+    @Test
+    void matchGlobFixedDirectoryPrefixControlsDelimiterRollup() {
+        seed();
+        given().queryParam("delimiter", "/").queryParam("matchGlob", "a/*")
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", containsInAnyOrder("a/", "a/1.txt", "a/2.txt"))
+                .body("prefixes", org.hamcrest.Matchers.anyOf(org.hamcrest.Matchers.nullValue(), empty()));
+
+        given().queryParam("delimiter", "/").queryParam("matchGlob", "a/**")
+                .when().get("/storage/v1/b/" + BUCKET + "/o")
+                .then().statusCode(200)
+                .body("items.name", containsInAnyOrder("a/", "a/1.txt", "a/2.txt"))
+                .body("prefixes", contains("a/b/"));
+    }
+
+    @Test
+    void matchGlobBackslashEscapesTheNextCharacter() {
+        String bucket = "glob-backslash-bucket";
+        given().contentType("application/json").body(Map.of("name", bucket))
+                .when().post("/storage/v1/b?project=test-project");
+        for (String name : new String[] {"ab/file.txt", "a\\b/file.txt"}) {
+            given().contentType("text/plain").body("x")
+                    .queryParam("uploadType", "media")
+                    .queryParam("name", name)
+                    .when().post("/upload/storage/v1/b/" + bucket + "/o");
+        }
+
+        given().queryParam("delimiter", "/").queryParam("matchGlob", "a\\b/*")
+                .when().get("/storage/v1/b/" + bucket + "/o")
+                .then().statusCode(200)
+                .body("items.name", contains("ab/file.txt"));
+
+        given().queryParam("delimiter", "/").queryParam("matchGlob", "a\\\\b/*")
+                .when().get("/storage/v1/b/" + bucket + "/o")
+                .then().statusCode(200)
+                .body("items.name", contains("a\\b/file.txt"));
+    }
+
+    @Test
     void trailingDelimiterPlaceholderIsRolledUpByDefault() {
         seed();
         given().queryParam("delimiter", "/").when().get("/storage/v1/b/" + BUCKET + "/o")


### PR DESCRIPTION
## Summary

Preserves matching directory prefixes when `objects.list` combines `delimiter=/` with `matchGlob`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## GCP Compatibility

The behavior was reproduced in real GCS with objects under two prefixes:

```console
$ gcloud storage cp /dev/null gs://$BUCKET/level0/file
Copying file:///dev/null to gs://$BUCKET/level0/file
$ gcloud storage cp /dev/null gs://$BUCKET/other/file
Copying file:///dev/null to gs://$BUCKET/other/file
```

```console
$ curl --include --get \
    --header "Authorization: Bearer $(gcloud auth print-access-token)" \
    --data-urlencode 'delimiter=/' \
    --data-urlencode 'matchGlob=*/' \
    "https://storage.googleapis.com/storage/v1/b/$BUCKET/o"
HTTP/2 200
content-type: application/json; charset=UTF-8

{
  "kind": "storage#objects",
  "prefixes": [
    "level0/",
    "other/"
  ]
}
```

Floci previously returned only `{"kind":"storage#objects"}` for the same request. Real GCS was also checked for literal directory prefixes: `a/*` returns direct objects under `a/`, while `a/**` additionally returns matching nested prefixes. Backslash escaping was checked as well: `a\b/*` matches `ab/file.txt`, while `a\\b/*` matches an object named `a\b/file.txt`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
